### PR TITLE
Add __del__ to client, server and partner

### DIFF
--- a/snap7/client.py
+++ b/snap7/client.py
@@ -31,10 +31,13 @@ class Client(object):
     A snap7 client
     """
     def __init__(self):
-        self.library = load_library()
         self.pointer = False
+        self.library = load_library()
         self.create()
 
+    def __del__(self):
+        self.destroy()
+        
     def create(self):
         """
         create a SNAP7 client.

--- a/snap7/partner.py
+++ b/snap7/partner.py
@@ -30,10 +30,13 @@ class Partner(object):
     A snap7 partner.
     """
     def __init__(self, active=False):
-        self.library = load_library()
         self.pointer = None
+        self.library = load_library()
         self.create(active)
 
+    def __del__(self):
+        self.destroy()
+        
     def as_b_send(self):
         """
         Sends a data packet to the partner. This function is asynchronous, i.e.

--- a/snap7/server.py
+++ b/snap7/server.py
@@ -37,6 +37,9 @@ class Server(object):
         self.create()
         if log:
             self._set_log_callback()
+    
+    def __del__(self):
+        self.destroy()
 
     def event_text(self, event):
         """Returns a textual explanation of a given event object

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -3,6 +3,7 @@ import struct
 import unittest
 import logging
 import time
+import mock
 
 from subprocess import Popen
 from os import path, kill
@@ -324,7 +325,7 @@ class TestClient(unittest.TestCase):
         pduRequested = self.client.get_param(10)
         pduSize = self.client.get_pdu_length()
         self.assertEqual(pduSize, pduRequested)
-    
+
     def test_get_cpu_info(self):
         expected = (
             ('ModuleTypeName', 'CPU 315-2 PN/DP'),
@@ -336,7 +337,7 @@ class TestClient(unittest.TestCase):
         cpuInfo = self.client.get_cpu_info()
         for param, value in expected:
             self.assertEqual(getattr(cpuInfo, param).decode('utf-8'), value)
-        
+
 
 
 class TestClientBeforeConnect(unittest.TestCase):
@@ -360,24 +361,30 @@ class TestClientBeforeConnect(unittest.TestCase):
         for param, value in values:
             self.client.set_param(param, value)
 
-import mock
 class TestLibraryIntegration(unittest.TestCase):
+    def setUp(self):
+        # replace the function load_library with a mock
+        self.loadlib_patch = mock.patch('snap7.client.load_library')
+        self.loadlib_func = self.loadlib_patch.start()
 
-    @mock.patch('snap7.client.load_library')
-    def setUp(self, loadlib):
+        # have load_library return another mock
         self.mocklib = mock.MagicMock()
-        # loadlib returns a MagicMock instead of a snap7 library
-        loadlib.return_value = self.mocklib
+        self.loadlib_func.return_value = self.mocklib
 
+        # have the Cli_Create of the mock return None
         self.mocklib.Cli_Create.return_value = None
-        self.client = snap7.client.Client()
-        self.mocklib.Cli_Create.assert_called_once()
 
     def tearDown(self):
-        pass
+        # restore load_library
+        self.loadlib_patch.stop()
+
+    def test_create(self):
+        client = snap7.client.Client()
+        self.mocklib.Cli_Create.assert_called_once()
 
     def test_gc(self):
-        del self.client
+        client = snap7.client.Client()
+        del client
         self.mocklib.Cli_Destroy.assert_called_once()
 
 if __name__ == '__main__':

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -360,6 +360,25 @@ class TestClientBeforeConnect(unittest.TestCase):
         for param, value in values:
             self.client.set_param(param, value)
 
+import mock
+class TestLibraryIntegration(unittest.TestCase):
+
+    @mock.patch('snap7.client.load_library')
+    def setUp(self, loadlib):
+        self.mocklib = mock.MagicMock()
+        # loadlib returns a MagicMock instead of a snap7 library
+        loadlib.return_value = self.mocklib
+
+        self.mocklib.Cli_Create.return_value = None
+        self.client = snap7.client.Client()
+        self.mocklib.Cli_Create.assert_called_once()
+
+    def tearDown(self):
+        pass
+
+    def test_gc(self):
+        del self.client
+        self.mocklib.Cli_Destroy.assert_called_once()
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_partner.py
+++ b/test/test_partner.py
@@ -1,5 +1,6 @@
 import logging
 import unittest as unittest
+import mock
 import snap7.partner
 from snap7.snap7exceptions import Snap7Exception
 
@@ -110,6 +111,33 @@ class TestPartner(unittest.TestCase):
 
     def test_wait_as_b_send_completion(self):
         self.assertRaises(Snap7Exception, self.partner.wait_as_b_send_completion)
+
+
+class TestLibraryIntegration(unittest.TestCase):
+    def setUp(self):
+        # replace the function load_library with a mock
+        self.loadlib_patch = mock.patch('snap7.partner.load_library')
+        self.loadlib_func = self.loadlib_patch.start()
+
+        # have load_library return another mock
+        self.mocklib = mock.MagicMock()
+        self.loadlib_func.return_value = self.mocklib
+
+        # have the Par_Create of the mock return None
+        self.mocklib.Par_Create.return_value = None
+
+    def tearDown(self):
+        # restore load_library
+        self.loadlib_patch.stop()
+
+    def test_create(self):
+        partner = snap7.partner.Partner()
+        self.mocklib.Par_Create.assert_called_once()
+
+    def test_gc(self):
+        partner = snap7.partner.Partner()
+        del partner
+        self.mocklib.Par_Destroy.assert_called_once()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I found this behavior by a mis-use of snap7, instead of just re-connecting on error I instantiated a new client as well. 

This eventually led to the last client not being able to open a socket anymore, as the maximum number of sockets for the user was reached.

This is of course better solved by not instantiating a new client, but I think it's good to let python-gc clean up the no-longer used instances as well. 