### PR TITLE
util.get_int() broken on Linux / Python 2.7.3 #65

### DIFF
--- a/snap7/util.py
+++ b/snap7/util.py
@@ -134,11 +134,8 @@ def set_int(_bytearray, byte_index, _int):
     """
     # make sure were dealing with an int
     _int = int(_int)
-    # int needs two be two bytes.
-    byte0 = _int >> 8
-    byte1 = _int - (byte0 << 8)
-    _bytearray[byte_index] = byte0
-    _bytearray[byte_index + 1] = byte1
+    _bytes = struct.unpack('2B', struct.pack('>h', _int))
+    _bytearray[byte_index:2] = _bytes
 
 
 def get_int(_bytearray, byte_index):
@@ -147,9 +144,9 @@ def get_int(_bytearray, byte_index):
 
     int are represented in two bytes
     """
-    byte1 = _bytearray[byte_index + 1]
-    byte0 = _bytearray[byte_index]
-    return byte1 + (byte0 << 8)
+    data = _bytearray[byte_index:2]
+    value = struct.unpack('>h', struct.pack('2B', *data))[0]
+    return value
 
 
 def set_real(_bytearray, byte_index, real):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -68,6 +68,25 @@ class TestS7util(unittest.TestCase):
         row['ID'] = 259
         self.assertTrue(row['ID'] == 259)
 
+    def test_get_int_values(self):
+        test_array = bytearray(_bytearray)
+        row = util.DB_Row(test_array, test_spec, layout_offset=4)
+        for value in (
+                    -32768,
+                    -16385,
+                    -256,
+                    -128,
+                    -127,
+                    0,
+                    127,
+                    128,
+                    255,
+                    256,
+                    16384,
+                    32767):
+            row['ID'] = value
+            self.assertEqual(row['ID'], value)
+
     def test_get_bool(self):
         test_array = bytearray(_bytearray)
         row = util.DB_Row(test_array, test_spec, layout_offset=4)


### PR DESCRIPTION
rewrite get_int and set_int to use struct.pack and struct.unpack, matching
get/set_dword

Add test that fails on previous implementation