### PR TITLE
Register PA area in snap7-server

### DIFF
--- a/snap7/bin/snap7-server.py
+++ b/snap7/bin/snap7-server.py
@@ -19,8 +19,10 @@ tcpport = 1102
 def mainloop():
     server = snap7.server.Server()
     size = 100
-    data = (snap7.snap7types.wordlen_to_ctypes[snap7.snap7types.S7WLByte] * size)()
-    server.register_area(snap7.snap7types.srvAreaDB, 1, data)
+    DBdata = (snap7.snap7types.wordlen_to_ctypes[snap7.snap7types.S7WLByte] * size)()
+    PAdata = (snap7.snap7types.wordlen_to_ctypes[snap7.snap7types.S7WLByte] * size)()
+    server.register_area(snap7.snap7types.srvAreaDB, 1, DBdata)
+    server.register_area(snap7.snap7types.srvAreaPA, 1, PAdata)
 
     server.start(tcpport=tcpport)
     while True:

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -197,7 +197,6 @@ class TestClient(unittest.TestCase):
     def test_get_connected(self):
         self.client.get_connected()
 
-    @unittest.skip("TODO: item not available?")
     def test_ab_read(self):
         start = 1
         size = 1


### PR DESCRIPTION
ab_read() queries PA area on the server, ab_read() would fail because
data could not be read on the server

Adding PA area fixes test_ab_read

un-skip test_ab_read