### PR TITLE
corrected logger calls. 

### DIFF
--- a/snap7/client.py
+++ b/snap7/client.py
@@ -89,7 +89,7 @@ class Client(object):
         if not status_string:
             raise Snap7Exception("The cpu state (%s) is invalid" % state.value)
         
-        logging.debug("CPU state is %s" % status_string)
+        logger.debug("CPU state is %s" % status_string)
         return status_string
 
     def get_cpu_info(self):
@@ -215,7 +215,7 @@ class Client(object):
     def db_get(self, db_number):
         """Uploads a DB from AG.
         """
-        logging.debug("db_get db_number: %s" % db_number)
+        logger.debug("db_get db_number: %s" % db_number)
         _buffer = buffer_type()
         result = self.library.Cli_DBGet(
             self.pointer, db_number, byref(_buffer),
@@ -234,7 +234,7 @@ class Client(object):
         assert area in snap7.snap7types.areas.values()
         wordlen = snap7.snap7types.S7WLByte
         type_ = snap7.snap7types.wordlen_to_ctypes[wordlen]
-        logging.debug("reading area: %s dbnumber: %s start: %s: amount %s: "
+        logger.debug("reading area: %s dbnumber: %s start: %s: amount %s: "
                       "wordlen: %s" % (area, dbnumber, start, size, wordlen))
         data = (type_ * size)()
         result = self.library.Cli_ReadArea(self.pointer, area, dbnumber, start,
@@ -256,7 +256,7 @@ class Client(object):
         wordlen = snap7.snap7types.S7WLByte
         type_ = snap7.snap7types.wordlen_to_ctypes[wordlen]
         size = len(data)
-        logging.debug("writing area: %s dbnumber: %s start: %s: size %s: "
+        logger.debug("writing area: %s dbnumber: %s start: %s: size %s: "
                       "type: %s" % (area, dbnumber, start, size, type_))
         cdata = (type_ * len(data)).from_buffer(data)
         return self.library.Cli_WriteArea(self.pointer, area, dbnumber, start,
@@ -278,11 +278,11 @@ class Client(object):
 
         :returns: a snap7.types.BlocksList object.
         """
-        logging.debug("listing blocks")
+        logger.debug("listing blocks")
         blocksList = BlocksList()
         result = self.library.Cli_ListBlocks(self.pointer, byref(blocksList))
         check_error(result, context="client")
-        logging.debug("blocks: %s" % blocksList)
+        logger.debug("blocks: %s" % blocksList)
         return blocksList
 
     def list_blocks_of_type(self, blocktype, size):
@@ -293,7 +293,7 @@ class Client(object):
         if not blocktype:
             raise Snap7Exception("The blocktype parameter was invalid")
 
-        logging.debug("listing blocks of type: %s size: %s" %
+        logger.debug("listing blocks of type: %s size: %s" %
                       (blocktype, size))
 
         if (size == 0):
@@ -306,7 +306,7 @@ class Client(object):
             byref(data),
             byref(count))
 
-        logging.debug("number of items found: %s" % count)
+        logger.debug("number of items found: %s" % count)
 
         check_error(result, context="client")
         return data
@@ -319,7 +319,7 @@ class Client(object):
         if not blocktype:
             raise Snap7Exception("The blocktype parameter was invalid")
 
-        logging.debug("retrieving block info for block %s of type %s" %
+        logger.debug("retrieving block info for block %s of type %s" %
                       (db_number, blocktype))
 
         data = TS7BlockInfo()
@@ -388,7 +388,7 @@ class Client(object):
         wordlen = snap7.snap7types.S7WLByte
         type_ = snap7.snap7types.wordlen_to_ctypes[wordlen]
         data = (type_ * size)()
-        logging.debug("ab_read: start: %s: size %s: " % (start, size))
+        logger.debug("ab_read: start: %s: size %s: " % (start, size))
         result = self.library.Cli_ABRead(self.pointer, start, size,
                                          byref(data))
         check_error(result, context="client")
@@ -403,7 +403,7 @@ class Client(object):
         type_ = snap7.snap7types.wordlen_to_ctypes[wordlen]
         size = len(data)
         cdata = (type_ * size).from_buffer(data)
-        logging.debug("ab write: start: %s: size: %s: " % (start, size))
+        logger.debug("ab write: start: %s: size: %s: " % (start, size))
         return self.library.Cli_ABWrite(
             self.pointer, start, size, byref(cdata))
 
@@ -414,7 +414,7 @@ class Client(object):
         wordlen = snap7.snap7types.S7WLByte
         type_ = snap7.snap7types.wordlen_to_ctypes[wordlen]
         data = (type_ * size)()
-        logging.debug("ab_read: start: %s: size %s: " % (start, size))
+        logger.debug("ab_read: start: %s: size %s: " % (start, size))
         result = self.library.Cli_AsABRead(self.pointer, start, size,
                                            byref(data))
         check_error(result, context="client")
@@ -428,7 +428,7 @@ class Client(object):
         type_ = snap7.snap7types.wordlen_to_ctypes[wordlen]
         size = len(data)
         cdata = (type_ * size).from_buffer(data)
-        logging.debug("ab write: start: %s: size: %s: " % (start, size))
+        logger.debug("ab write: start: %s: size: %s: " % (start, size))
         return self.library.Cli_AsABWrite(
             self.pointer, start, size, byref(cdata))
 
@@ -467,7 +467,7 @@ class Client(object):
         """
         This is the asynchronous counterpart of Cli_DBGet.
         """
-        logging.debug("db_get db_number: %s" % db_number)
+        logger.debug("db_get db_number: %s" % db_number)
         _buffer = buffer_type()
         result = self.library.Cli_AsDBGet(self.pointer, db_number,
                                           byref(_buffer),

--- a/snap7/server.py
+++ b/snap7/server.py
@@ -152,7 +152,7 @@ class Server(object):
         start the server.
         """
         if tcpport != 102:
-            logging.info("setting server TCP port to %s" % tcpport)
+            logger.info("setting server TCP port to %s" % tcpport)
             self.set_param(snap7.snap7types.LocalPort, tcpport)
         logger.info("starting server on 0.0.0.0:%s" % tcpport)
         return self.library.Srv_Start(self.pointer)
@@ -204,14 +204,14 @@ class Server(object):
     def unlock_area(self, code, index):
         """Unlocks a previously locked shared memory area.
         """
-        logging.debug("unlocking area code %s index %s" % (code, index))
+        logger.debug("unlocking area code %s index %s" % (code, index))
         return self.library.Srv_UnlockArea(self.pointer, code, index)
 
     @error_wrap
     def lock_area(self, code, index):
         """Locks a shared memory area.
         """
-        logging.debug("locking area code %s index %s" % (code, index))
+        logger.debug("locking area code %s index %s" % (code, index))
         return self.library.Srv_UnlockArea(self.pointer, code, index)
 
     @error_wrap
@@ -220,7 +220,7 @@ class Server(object):
         start server on a specific interface.
         """
         if tcpport != 102:
-            logging.info("setting server TCP port to %s" % tcpport)
+            logger.info("setting server TCP port to %s" % tcpport)
             self.set_param(snap7.snap7types.LocalPort, tcpport)
         assert re.match(ipv4, ip), '%s is invalid ipv4' % ip
         logger.info("starting server to %s:102" % ip)

--- a/snap7/util.py
+++ b/snap7/util.py
@@ -208,8 +208,8 @@ def get_string(_bytearray, byte_index, max_size):
     size = _bytearray[byte_index + 1]
 
     if max_size < size:
-        logging.error("the string is to big for the size encountered in specification")
-        logging.error("WRONG SIZED STRING ENCOUNTERED")
+        logger.error("the string is to big for the size encountered in specification")
+        logger.error("WRONG SIZED STRING ENCOUNTERED")
         size = max_size
 
     data = map(chr, _bytearray[byte_index + 2:byte_index + 2 + size])
@@ -311,7 +311,7 @@ class DB(object):
             key = row[id_field] if id_field else i
             if key and key in self.index:
                 msg = '%s not unique!' % key
-                logging.error(msg)
+                logger.error(msg)
             self.index[key] = row
 
     def __getitem__(self, key, default=None):


### PR DESCRIPTION
some of the modules were mistakenly calling the root logger (logging.debug or logging.info) instead of using the logger object that was declared in the module.