### PR TITLE
Fixed get_int bug

### DIFF
--- a/snap7/util.py
+++ b/snap7/util.py
@@ -144,7 +144,7 @@ def get_int(_bytearray, byte_index):
 
     int are represented in two bytes
     """
-    data = _bytearray[byte_index:2]
+    data = _bytearray[byte_index:byte_index + 2]
     value = struct.unpack('>h', struct.pack('2B', *data))[0]
     return value
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -19,6 +19,7 @@ test_spec = """
 12.7	testbool8    BOOL
 13      testReal     REAL
 17      testDword    DWORD
+21      testint2     INT
 """
 
 _bytearray = bytearray([
@@ -28,6 +29,7 @@ _bytearray = bytearray([
     8*1 + 4*1 + 2*1 + 1*1,                         # test bools
     68, 78, 211, 51,                               # test real
     255, 255, 255, 255                             # test dword
+    0, 0,                                          # test int 2
     ])
 
 
@@ -60,8 +62,10 @@ class TestS7util(unittest.TestCase):
         test_array = bytearray(_bytearray)
         row = util.DB_Row(test_array, test_spec, layout_offset=4)
         x = row['ID']
+        y = row['testint2']
         self.assertEqual(x, 0)
-
+        self.assertEqual(y, 0)
+        
     def test_set_int(self):
         test_array = bytearray(_bytearray)
         row = util.DB_Row(test_array, test_spec, layout_offset=4)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -28,7 +28,7 @@ _bytearray = bytearray([
     128*0 + 64*0 + 32*0 + 16*0 +
     8*1 + 4*1 + 2*1 + 1*1,                         # test bools
     68, 78, 211, 51,                               # test real
-    255, 255, 255, 255                             # test dword
+    255, 255, 255, 255,                            # test dword
     0, 0,                                          # test int 2
     ])
 


### PR DESCRIPTION
get_int would fail with 'struct.error: pack expected 2 items for packing (got 0)' when a byte index other than 0 was supplied. 
Fixes:

- Test added to read an int from the end of the byte array
- data byte array end range changed to byte_index+2 instead of a fixed value of 2



