### PR TITLE
Permit the usage of write functions with read-only buffers

### DIFF
--- a/snap7/client.py
+++ b/snap7/client.py
@@ -153,7 +153,7 @@ class Client(object):
         wordlen = snap7.snap7types.S7WLByte
         type_ = snap7.snap7types.wordlen_to_ctypes[wordlen]
         size = len(data)
-        cdata = (type_ * size).from_buffer(data)
+        cdata = (type_ * size).from_buffer_copy(data)
         logger.debug("db_write db_number:%s start:%s size:%s data:%s" %
                      (db_number, start, size, data))
         return self.library.Cli_DBWrite(self.pointer, db_number, start, size,
@@ -207,7 +207,7 @@ class Client(object):
         """
         type_ = c_byte
         size = len(data)
-        cdata = (type_ * len(data)).from_buffer(data)
+        cdata = (type_ * len(data)).from_buffer_copy(data)
         result = self.library.Cli_Download(self.pointer, block_num,
                                            byref(cdata), size)
         return result
@@ -258,7 +258,7 @@ class Client(object):
         size = len(data)
         logger.debug("writing area: %s dbnumber: %s start: %s: size %s: "
                       "type: %s" % (area, dbnumber, start, size, type_))
-        cdata = (type_ * len(data)).from_buffer(data)
+        cdata = (type_ * len(data)).from_buffer_copy(data)
         return self.library.Cli_WriteArea(self.pointer, area, dbnumber, start,
                                           size, wordlen, byref(cdata))
 
@@ -402,7 +402,7 @@ class Client(object):
         wordlen = snap7.snap7types.S7WLByte
         type_ = snap7.snap7types.wordlen_to_ctypes[wordlen]
         size = len(data)
-        cdata = (type_ * size).from_buffer(data)
+        cdata = (type_ * size).from_buffer_copy(data)
         logger.debug("ab write: start: %s: size: %s: " % (start, size))
         return self.library.Cli_ABWrite(
             self.pointer, start, size, byref(cdata))
@@ -427,7 +427,7 @@ class Client(object):
         wordlen = snap7.snap7types.S7WLByte
         type_ = snap7.snap7types.wordlen_to_ctypes[wordlen]
         size = len(data)
-        cdata = (type_ * size).from_buffer(data)
+        cdata = (type_ * size).from_buffer_copy(data)
         logger.debug("ab write: start: %s: size: %s: " % (start, size))
         return self.library.Cli_AsABWrite(
             self.pointer, start, size, byref(cdata))
@@ -498,7 +498,7 @@ class Client(object):
         wordlen = snap7.snap7types.S7WLByte
         type_ = snap7.snap7types.wordlen_to_ctypes[wordlen]
         size = len(data)
-        cdata = (type_ * size).from_buffer(data)
+        cdata = (type_ * size).from_buffer_copy(data)
         logger.debug("db_write db_number:%s start:%s size:%s data:%s" %
                      (db_number, start, size, data))
         return self.library.Cli_AsDBWrite(
@@ -517,7 +517,7 @@ class Client(object):
         """
         size = len(data)
         type_ = c_byte * len(data)
-        cdata = type_.from_buffer(data)
+        cdata = type_.from_buffer_copy(data)
         return self.library.Cli_AsDownload(self.pointer, block_num,
                                            byref(cdata), size)
 

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -337,6 +337,113 @@ class TestClient(unittest.TestCase):
         for param, value in expected:
             self.assertEqual(getattr(cpuInfo, param).decode('utf-8'), value)
 
+    def test_db_write_with_byte_literal_does_not_throw(self):
+        mock_write = mock.MagicMock()
+        mock_write.return_value = None
+        original = self.client.library.Cli_DBWrite
+        self.client.library.Cli_DBWrite = mock_write
+        data = b'\xDE\xAD\xBE\xEF'
+
+        try:
+            self.client.db_write(db_number=1, start=0, data=data)
+        except TypeError as e:
+            self.fail(str(e))
+        finally:
+            self.client.library.Cli_DBWrite = original
+
+    def test_download_with_byte_literal_does_not_throw(self):
+        mock_download = mock.MagicMock()
+        mock_download.return_value = None
+        original = self.client.library.Cli_Download
+        self.client.library.Cli_Download = mock_download
+        data = b'\xDE\xAD\xBE\xEF'
+
+        try:
+            self.client.download(block_num=db_number, data=data)
+        except TypeError as e:
+            self.fail(str(e))
+        finally:
+            self.client.library.Cli_Download = original
+
+    def test_write_area_with_byte_literal_does_not_throw(self):
+        mock_writearea = mock.MagicMock()
+        mock_writearea.return_value = None
+        original = self.client.library.Cli_WriteArea
+        self.client.library.Cli_WriteArea = mock_writearea
+
+        area = snap7.snap7types.areas.DB
+        dbnumber = 1
+        size = 4
+        start = 1
+        data = b'\xDE\xAD\xBE\xEF'
+
+        try:
+            self.client.write_area(area, dbnumber, start, data)
+        except TypeError as e:
+            self.fail(str(e))
+        finally:
+            self.client.library.Cli_WriteArea = original
+
+    def test_ab_write_with_byte_literal_does_not_throw(self):
+        mock_write = mock.MagicMock()
+        mock_write.return_value = None
+        original = self.client.library.Cli_ABWrite
+        self.client.library.Cli_ABWrite = mock_write
+
+        start = 1
+        data = b'\xDE\xAD\xBE\xEF'
+
+        try:
+            self.client.ab_write(start=start, data=data)
+        except TypeError as e:
+            self.fail(str(e))
+        finally:
+            self.client.library.Cli_ABWrite = original
+
+    def test_as_ab_write_with_byte_literal_does_not_throw(self):
+        mock_write = mock.MagicMock()
+        mock_write.return_value = None
+        original = self.client.library.Cli_AsABWrite
+        self.client.library.Cli_AsABWrite = mock_write
+
+        start = 1
+        data = b'\xDE\xAD\xBE\xEF'
+
+        try:
+            self.client.as_ab_write(start=start, data=data)
+        except TypeError as e:
+            self.fail(str(e))
+        finally:
+            self.client.library.Cli_AsABWrite = original
+
+    def test_as_db_write_with_byte_literal_does_not_throw(self):
+        mock_write = mock.MagicMock()
+        mock_write.return_value = None
+        original = self.client.library.Cli_AsDBWrite
+        self.client.library.Cli_AsDBWrite = mock_write
+        data = b'\xDE\xAD\xBE\xEF'
+
+        try:
+            self.client.db_write(db_number=1, start=0, data=data)
+        except TypeError as e:
+            self.fail(str(e))
+        finally:
+            self.client.library.Cli_AsDBWrite = original
+
+    def test_as_download_with_byte_literal_does_not_throw(self):
+        mock_download = mock.MagicMock()
+        mock_download.return_value = None
+        original = self.client.library.Cli_AsDownload
+        self.client.library.Cli_AsDownload = mock_download
+        data = b'\xDE\xAD\xBE\xEF'
+
+        try:
+            self.client.as_download(block_num=db_number, data=data)
+        except TypeError as e:
+            self.fail(str(e))
+        finally:
+            self.client.library.Cli_AsDownload = original
+
 
 
 class TestClientBeforeConnect(unittest.TestCase):


### PR DESCRIPTION
With Python3, when an byte string (e.g. b'\x00\x02') is iterated over, it provides a read-only view, and thus the usage of ctypes' from_buffer function in the write functions cause an 'underlying buffer is not writable' exception to be thrown.

e.g.

import snap7
c = snap7.Client()
c.connect('192.168.1.1', 0, 0)
c.write(464, b'\x00\x02')

This pull request modifies the write functions to use the from_buffer_copy function.  I suppose it's possible that there's a performance impact, but I expect it to be minimal given the capacity of the usual devices.