### PR TITLE
The method lock_area should call Srv_LockArea

### DIFF
--- a/snap7/server.py
+++ b/snap7/server.py
@@ -212,7 +212,7 @@ class Server(object):
         """Locks a shared memory area.
         """
         logger.debug("locking area code %s index %s" % (code, index))
-        return self.library.Srv_UnlockArea(self.pointer, code, index)
+        return self.library.Srv_LockArea(self.pointer, code, index)
 
     @error_wrap
     def start_to(self, ip, tcpport=102):


### PR DESCRIPTION
The method lock_area currently calls Srv_UnlockArea.

I'm not very proud of the test, as it relies on waiting on thread and that one second is enough time to prove that a thread is blocked... Didn't come up with any better idea though. The test and the fix are in different commits. It should therefore be possible to merge just the fix if the test looks too horrible.