### PR TITLE
Documentationf or Logo enhancement added

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -17,6 +17,7 @@ Contents:
    client
    server
    partner
+   logo
 
    util
 

--- a/doc/logo.rst
+++ b/doc/logo.rst
@@ -1,0 +1,5 @@
+Logo
+====
+
+.. autoclass:: snap7.logo.Logo
+   :members:

--- a/example/logo_7_8.py
+++ b/example/logo_7_8.py
@@ -12,7 +12,7 @@ Logo_7 = True
 
 logger = logging.getLogger(__name__)
 
-plc = snap7.logo.Client()
+plc = snap7.logo.Logo()
 plc.connect("192.168.0.41",0x1000,0x2000)
 
 if plc.get_connected():

--- a/test/test_logo_client.py
+++ b/test/test_logo_client.py
@@ -30,7 +30,7 @@ class TestLogoClient(unittest.TestCase):
         kill(cls.server_pid, 1)
 
     def setUp(self):
-        self.client = snap7.logo.Client()
+        self.client = snap7.logo.Logo()
         self.client.connect(ip, rack, slot, tcpport)
 
     def tearDown(self):
@@ -48,21 +48,6 @@ class TestLogoClient(unittest.TestCase):
         vm_address = "V20"
         value = 8
         self.client.write(vm_address, value)
-
-    def test_read_area(self):
-        area = snap7.snap7types.areas.DB
-        dbnumber = 1
-        amount = 1
-        start = 1
-        self.client.read_area(area, dbnumber, start, amount)
-
-    def test_write_area(self):
-        area = snap7.snap7types.areas.DB
-        dbnumber = 1
-        size = 1
-        start = 20
-        data = bytearray(size)
-        self.client.write_area(area, dbnumber, start, data)
 
     def test_get_connected(self):
         self.client.get_connected()


### PR DESCRIPTION
Logo documentation added. error_wrap decorator removed. Reason: The sphinx documentation generator can not handle decorators. There is a workaround available for the function name, but the parameters are not printed in the documentation. 
Logo class not needed functions removed. 
Unit tests updated