### PR TITLE
set_int was just adding data to the array, moving everything else

### DIFF
--- a/snap7/util.py
+++ b/snap7/util.py
@@ -135,7 +135,7 @@ def set_int(_bytearray, byte_index, _int):
     # make sure were dealing with an int
     _int = int(_int)
     _bytes = struct.unpack('2B', struct.pack('>h', _int))
-    _bytearray[byte_index:2] = _bytes
+    _bytearray[byte_index:byte_index + 2] = _bytes
 
 
 def get_int(_bytearray, byte_index):


### PR DESCRIPTION
As I wrote in this issue (https://github.com/gijzelaerr/python-snap7/issues/94), when I tried to write to an INT memory, the memories below it were changed.

Turned out the problem was that the set_int was just adding the data to the array and moving everything else, instead of override the memory.

I tested here and works perfectly now.