### PR TITLE
Update read_multi.py

### DIFF
--- a/example/read_multi.py
+++ b/example/read_multi.py
@@ -54,16 +54,17 @@ result, data_items = client.read_multi_vars(data_items)
 for di in data_items:
     check_error(di.Result)
 
-# struct formats
-fmts = ['>f', '>f', '>h']
+result_values = []
+# function to cast bytes to match data_types[] above
+byte_to_value = [util.get_real, util.get_real, util.get_int]
 
-# unpack and print the result of each read
+# unpack and test the result of each read
 for i in range(0, len(data_items)):
-    fmt = fmts[i]
+    btv = byte_to_value[i]
     di = data_items[i]
-    foo = ''.join([chr(di.pData[i]) for i in range(0, di.Amount)])
-    fnum = struct.unpack(fmt, foo)[0]
-    print(fnum)
+    value = btv(di.pData, 0)
+    result_values.append(value)
+print(result_values)
 
 client.disconnect()
 client.destroy()


### PR DESCRIPTION
There was an error in the original code for extracting the read  values. Line 64 `foo = ''.join([chr(di.pData[i]) for i in range(0, di.Amount)])` always breaks. Replaced code block from line 57-66 with similar code block on test_client.py