### PR TITLE
Added GET SET small_int support functions, and to the class DB_Row

### DIFF
--- a/snap7/util.py
+++ b/snap7/util.py
@@ -324,19 +324,6 @@ def get_dt(_bytearray, byte_index):
     return date_and_time
 
 
-
-def get_small_int(bytearray_, byte_index):
-    """
-    Get small int value from bytearray.
-
-    small int is represented as 1 byte
-    """
-    data = bytearray_[byte_index] & 0xff
-    packed = struct.pack('B', data)
-    value = struct.unpack('>B', packed)[0]
-    return value
-
-
 def set_small_int(bytearray_, byte_index, _int):
     """
     Set value in bytearray to int
@@ -347,6 +334,16 @@ def set_small_int(bytearray_, byte_index, _int):
     _bytes = struct.unpack('B', struct.pack('>B', _int))
     bytearray_[byte_index] = _bytes[0]
     return bytearray_
+def get_small_int(bytearray_, byte_index):
+    """
+    Get small int value from bytearray.
+
+    small int is represented as 1 byte
+    """
+    data = bytearray_[byte_index] & 0xff
+    packed = struct.pack('B', data)
+    value = struct.unpack('>B', packed)[0]
+    return value
 
 
 def parse_specification(db_specification):

--- a/snap7/util.py
+++ b/snap7/util.py
@@ -560,6 +560,9 @@ class DB_Row:
         if _type == 'USINT':
             return get_usint(_bytearray, byte_index)
 
+        if _type == 'SINT':
+            return 'read SINT not implemented'
+
         # add these three not implemented data typ to avoid
         # 'Unable to get repr for class<snap7.util.DB_ROW>' error
         if _type == 'TIME':
@@ -605,6 +608,9 @@ class DB_Row:
 
         if _type == 'USINT':
             return set_usint(_bytearray, byte_index, value)
+
+        if _type == 'SINT':
+            return 'read SINT not implemented'
 
         raise ValueError
 

--- a/snap7/util.py
+++ b/snap7/util.py
@@ -361,7 +361,7 @@ def set_sint(bytearray_, byte_index, _int):
     return bytearray_
 
 
-def get_sint(bytearray_, byte_index, _int):
+def get_sint(bytearray_, byte_index):
     """
     Get small int from bytearray
 

--- a/snap7/util.py
+++ b/snap7/util.py
@@ -340,7 +340,7 @@ def set_usint(bytearray_, byte_index, _int):
     bytearray_[byte_index] = _bytes[0]
     return bytearray_
 
-    
+
 def get_usint(bytearray_, byte_index):
     """get the unsigned small int from the bytearray
 
@@ -384,7 +384,7 @@ def get_sint(bytearray_, byte_index):
     Returns:
         int: small int (-127 - 128)
     """
-    data = bytearray_[byte_index] 
+    data = bytearray_[byte_index]
     packed = struct.pack('B', data)
     value = struct.unpack('>b', packed)[0]
     return value
@@ -597,7 +597,7 @@ class DB_Row:
 
         if _type == 'DATE_AND_TIME':
             data_dt = get_dt(_bytearray, byte_index)
-            return data_dt           
+            return data_dt
 
         if _type == 'USINT':
             return get_usint(_bytearray, byte_index)

--- a/snap7/util.py
+++ b/snap7/util.py
@@ -324,7 +324,7 @@ def get_dt(_bytearray, byte_index):
     return date_and_time
 
 
-def set_small_int(bytearray_, byte_index, _int):
+def set_usint(bytearray_, byte_index, _int):
     """
     Set value in bytearray to int
 
@@ -336,7 +336,7 @@ def set_small_int(bytearray_, byte_index, _int):
     return bytearray_
 
     
-def get_small_int(bytearray_, byte_index):
+def get_usint(bytearray_, byte_index):
     """
     Get small int value from bytearray.
 
@@ -558,7 +558,7 @@ class DB_Row:
             return data_dt           
 
         if _type == 'SINT':
-            return get_small_int(_bytearray, byte_index)
+            return get_usint(_bytearray, byte_index)
 
         # add these three not implemented data typ to avoid
         # 'Unable to get repr for class<snap7.util.DB_ROW>' error
@@ -604,7 +604,7 @@ class DB_Row:
             return set_word(_bytearray, byte_index, value)
 
         if _type == 'SINT':
-            return set_small_int(_bytearray, byte_index, value)
+            return set_usint(_bytearray, byte_index, value)
 
         raise ValueError
 

--- a/snap7/util.py
+++ b/snap7/util.py
@@ -334,6 +334,8 @@ def set_small_int(bytearray_, byte_index, _int):
     _bytes = struct.unpack('B', struct.pack('>B', _int))
     bytearray_[byte_index] = _bytes[0]
     return bytearray_
+
+    
 def get_small_int(bytearray_, byte_index):
     """
     Get small int value from bytearray.

--- a/snap7/util.py
+++ b/snap7/util.py
@@ -325,11 +325,15 @@ def get_dt(_bytearray, byte_index):
 
 
 def set_usint(bytearray_, byte_index, _int):
-    """
-    Set value in bytearray to int
+    """set unsigned small int
 
-    unsigned small int is represented as 1 byte
-    where the 8th bit is the sign
+    Args:
+        bytearray_ (bytearray): bytearray
+        byte_index (int): index of the bytearray
+        _int (int): positive value to set (0 - 255)
+
+    Returns:
+        bytearray: bytearray of the db
     """
     _int = int(_int)
     _bytes = struct.unpack('B', struct.pack('>B', _int))
@@ -338,22 +342,31 @@ def set_usint(bytearray_, byte_index, _int):
 
     
 def get_usint(bytearray_, byte_index):
-    """
-    Get small int value from bytearray.
+    """get the unsigned small int from the bytearray
 
-    small int is represented as 1 byte
-    where the 8th bit is the sign
+    Args:
+        bytearray_ (bytearray)
+        byte_index (int): index of the bytearray
+
+    Returns:
+        int: unsigned small int (0 - 255)
     """
     data = bytearray_[byte_index] & 0xff
     packed = struct.pack('B', data)
     value = struct.unpack('>B', packed)[0]
     return value
 
-def set_sint(bytearray_, byte_index, _int):
-    """
-    Set value in bytearray to small int
 
-    small int is represented as 1 byte  -128 to 128
+def set_sint(bytearray_, byte_index, _int):
+    """set small int
+
+    Args:
+        bytearray_ (bytearray)
+        byte_index (int): index of the bytearray
+        _int (int): small int (-128 - 127)
+
+    Returns:
+        bytearray
     """
     _int = int(_int)
     _bytes = struct.unpack('B', struct.pack('>b', _int))
@@ -362,16 +375,19 @@ def set_sint(bytearray_, byte_index, _int):
 
 
 def get_sint(bytearray_, byte_index):
-    """
-    Get small int from bytearray
+    """get the small int
 
-    small int is represented as 1 byte -128 to 128
-    """   
+    Args:
+        bytearray_ (bytearray)
+        byte_index (int): index of the bytearray
+
+    Returns:
+        int: small int (-127 - 128)
+    """
     data = bytearray_[byte_index] 
     packed = struct.pack('B', data)
     value = struct.unpack('>b', packed)[0]
     return value
-
 
 
 def parse_specification(db_specification):

--- a/snap7/util.py
+++ b/snap7/util.py
@@ -557,7 +557,7 @@ class DB_Row:
             data_dt = get_dt(_bytearray, byte_index)
             return data_dt           
 
-        if _type == 'SINT':
+        if _type == 'USINT':
             return get_usint(_bytearray, byte_index)
 
         # add these three not implemented data typ to avoid
@@ -603,7 +603,7 @@ class DB_Row:
         if _type == 'WORD':
             return set_word(_bytearray, byte_index, value)
 
-        if _type == 'SINT':
+        if _type == 'USINT':
             return set_usint(_bytearray, byte_index, value)
 
         raise ValueError

--- a/snap7/util.py
+++ b/snap7/util.py
@@ -328,7 +328,8 @@ def set_usint(bytearray_, byte_index, _int):
     """
     Set value in bytearray to int
 
-    small int is represented as 1 byte
+    unsigned small int is represented as 1 byte
+    where the 8th bit is the sign
     """
     _int = int(_int)
     _bytes = struct.unpack('B', struct.pack('>B', _int))
@@ -341,11 +342,36 @@ def get_usint(bytearray_, byte_index):
     Get small int value from bytearray.
 
     small int is represented as 1 byte
+    where the 8th bit is the sign
     """
     data = bytearray_[byte_index] & 0xff
     packed = struct.pack('B', data)
     value = struct.unpack('>B', packed)[0]
     return value
+
+def set_sint(bytearray_, byte_index, _int):
+    """
+    Set value in bytearray to small int
+
+    small int is represented as 1 byte  -128 to 128
+    """
+    _int = int(_int)
+    _bytes = struct.unpack('B', struct.pack('>b', _int))
+    bytearray_[byte_index] = _bytes[0]
+    return bytearray_
+
+
+def get_sint(bytearray_, byte_index, _int):
+    """
+    Get small int from bytearray
+
+    small int is represented as 1 byte -128 to 128
+    """   
+    data = bytearray_[byte_index] 
+    packed = struct.pack('B', data)
+    value = struct.unpack('>b', packed)[0]
+    return value
+
 
 
 def parse_specification(db_specification):
@@ -561,7 +587,7 @@ class DB_Row:
             return get_usint(_bytearray, byte_index)
 
         if _type == 'SINT':
-            return 'read SINT not implemented'
+            return get_sint(_bytearray, byte_index)
 
         # add these three not implemented data typ to avoid
         # 'Unable to get repr for class<snap7.util.DB_ROW>' error
@@ -610,7 +636,7 @@ class DB_Row:
             return set_usint(_bytearray, byte_index, value)
 
         if _type == 'SINT':
-            return 'read SINT not implemented'
+            return set_sint(_bytearray, byte_index, value)
 
         raise ValueError
 

--- a/snap7/util.py
+++ b/snap7/util.py
@@ -324,6 +324,31 @@ def get_dt(_bytearray, byte_index):
     return date_and_time
 
 
+
+def get_small_int(bytearray_, byte_index):
+    """
+    Get small int value from bytearray.
+
+    small int is represented as 1 byte
+    """
+    data = bytearray_[byte_index] & 0xff
+    packed = struct.pack('B', data)
+    value = struct.unpack('>B', packed)[0]
+    return value
+
+
+def set_small_int(bytearray_, byte_index, _int):
+    """
+    Set value in bytearray to int
+
+    small int is represented as 1 byte
+    """
+    _int = int(_int)
+    _bytes = struct.unpack('B', struct.pack('>B', _int))
+    bytearray_[byte_index] = _bytes[0]
+    return bytearray_
+
+
 def parse_specification(db_specification):
     """
     Create a db specification derived from a
@@ -531,7 +556,10 @@ class DB_Row:
 
         if _type == 'DATE_AND_TIME':
             data_dt = get_dt(_bytearray, byte_index)
-            return data_dt
+            return data_dt           
+
+        if _type == 'SINT':
+            return get_small_int(_bytearray, byte_index)
 
         # add these three not implemented data typ to avoid
         # 'Unable to get repr for class<snap7.util.DB_ROW>' error
@@ -575,6 +603,9 @@ class DB_Row:
 
         if _type == 'WORD':
             return set_word(_bytearray, byte_index, value)
+
+        if _type == 'SINT':
+            return set_small_int(_bytearray, byte_index, value)
 
         raise ValueError
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -23,7 +23,7 @@ test_spec = """
 27      testWord     WORD
 29      tests5time   S5TIME
 31      testdateandtime DATE_AND_TIME
-43      testsmallint0   SINT
+43      testusint0   USINT
 """
 
 _bytearray = bytearray([
@@ -38,10 +38,11 @@ _bytearray = bytearray([
     255, 255,                                      # test word
     0, 16,                                         # test s5time, 0 is the time base,
                                                    # 16 is value, those two integers should be declared together
-    32, 7, 18, 23, 50, 2, 133, 65,                  # these 8 values build the date and time 12 byte total 
+    65535, 255, 255, 255, 255, 255, 255, 4294967295,                  # these 8 values build the date and time 12 byte total 
                                                    # data typ together, for details under this link
                                                    # https://support.industry.siemens.com/cs/document/36479/date_and_time-format-bei-s7-?dti=0&lc=de-DE
-    254, 254, 254, 254, 254                         # test small int
+    255,                                           # test unsigned small int 1byte
+    -127,                                          # test signed small int 1byte
 ])
 
 
@@ -104,17 +105,17 @@ class TestS7util(unittest.TestCase):
         row['ID'] = 259
         self.assertEqual(row['ID'], 259)
 
-    def test_get_small_int(self):
+    def test_get_usint(self):
         test_array = bytearray(_bytearray)
         row = util.DB_Row(test_array, test_spec, layout_offset=4)
         value = row.get_value(43, 'SINT')  # get value
-        self.assertEqual(value, 254)
+        self.assertEqual(value, 255)
 
-    def test_set_small_int(self):
+    def test_set_usint(self):
         test_array = bytearray(_bytearray)
         row = util.DB_Row(test_array, test_spec, layout_offset=4)
-        row['testsmallint0'] = 254
-        self.assertEqual(row['testsmallint0'], 254)
+        row['testusint0'] = 255
+        self.assertEqual(row['testusint0'], 255)
         
 
     def test_set_int_roundtrip(self):

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -39,7 +39,7 @@ _bytearray = bytearray([
     255, 255,                                      # test word
     0, 16,                                         # test s5time, 0 is the time base,
                                                    # 16 is value, those two integers should be declared together
-    32, 7, 18, 23, 50, 2, 133, 65,                 # these 8 values build the date and time 12 byte total 
+    32, 7, 18, 23, 50, 2, 133, 65,                 # these 8 values build the date and time 12 byte total
                                                    # data typ together, for details under this link
                                                    # https://support.industry.siemens.com/cs/document/36479/date_and_time-format-bei-s7-?dti=0&lc=de-DE
     254, 254, 254, 254, 254, 127                   # test small int
@@ -243,8 +243,6 @@ class TestS7util(unittest.TestCase):
         row = util.DB_Row(test_array, test_spec, layout_offset=4)
         value = row.get_value(27, 'WORD')  # get value
         self.assertEqual(value, 65535)
-
- 
 
     def test_export(self):
         test_array = bytearray(_bytearray)

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -23,7 +23,8 @@ test_spec = """
 27      testWord     WORD
 29      tests5time   S5TIME
 31      testdateandtime DATE_AND_TIME
-43      testusint0   USINT
+43      testusint0      USINT
+44      testsint0       SINT
 """
 
 _bytearray = bytearray([
@@ -38,11 +39,10 @@ _bytearray = bytearray([
     255, 255,                                      # test word
     0, 16,                                         # test s5time, 0 is the time base,
                                                    # 16 is value, those two integers should be declared together
-    65535, 255, 255, 255, 255, 255, 255, 4294967295,                  # these 8 values build the date and time 12 byte total 
+    32, 7, 18, 23, 50, 2, 133, 65,                  # these 8 values build the date and time 12 byte total 
                                                    # data typ together, for details under this link
                                                    # https://support.industry.siemens.com/cs/document/36479/date_and_time-format-bei-s7-?dti=0&lc=de-DE
-    255,                                           # test unsigned small int 1byte
-    -127,                                          # test signed small int 1byte
+    254, 254, 254, 254, 254, 127                        # test small int
 ])
 
 
@@ -108,15 +108,26 @@ class TestS7util(unittest.TestCase):
     def test_get_usint(self):
         test_array = bytearray(_bytearray)
         row = util.DB_Row(test_array, test_spec, layout_offset=4)
-        value = row.get_value(43, 'SINT')  # get value
-        self.assertEqual(value, 255)
+        value = row.get_value(43, 'USINT')  # get value
+        self.assertEqual(value, 254)
 
     def test_set_usint(self):
         test_array = bytearray(_bytearray)
         row = util.DB_Row(test_array, test_spec, layout_offset=4)
         row['testusint0'] = 255
         self.assertEqual(row['testusint0'], 255)
-        
+
+    def test_get_sint(self):
+        test_array = bytearray(_bytearray)
+        row = util.DB_Row(test_array, test_spec, layout_offset=4)
+        value = row.get_value(44, 'SINT')  # get value
+        self.assertEqual(value, 127)
+
+    def test_set_sint(self):
+        test_array = bytearray(_bytearray)
+        row = util.DB_Row(test_array, test_spec, layout_offset=4)
+        row['testsint0'] = 127
+        self.assertEqual(row['testsint0'], 127)
 
     def test_set_int_roundtrip(self):
         DB1 = (types.wordlen_to_ctypes[types.S7WLByte] * 4)()

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -39,10 +39,10 @@ _bytearray = bytearray([
     255, 255,                                      # test word
     0, 16,                                         # test s5time, 0 is the time base,
                                                    # 16 is value, those two integers should be declared together
-    32, 7, 18, 23, 50, 2, 133, 65,                  # these 8 values build the date and time 12 byte total 
+    32, 7, 18, 23, 50, 2, 133, 65,                 # these 8 values build the date and time 12 byte total 
                                                    # data typ together, for details under this link
                                                    # https://support.industry.siemens.com/cs/document/36479/date_and_time-format-bei-s7-?dti=0&lc=de-DE
-    254, 254, 254, 254, 254, 127                        # test small int
+    254, 254, 254, 254, 254, 127                   # test small int
 ])
 
 

--- a/test/test_util.py
+++ b/test/test_util.py
@@ -23,6 +23,7 @@ test_spec = """
 27      testWord     WORD
 29      tests5time   S5TIME
 31      testdateandtime DATE_AND_TIME
+43      testsmallint0   SINT
 """
 
 _bytearray = bytearray([
@@ -37,9 +38,10 @@ _bytearray = bytearray([
     255, 255,                                      # test word
     0, 16,                                         # test s5time, 0 is the time base,
                                                    # 16 is value, those two integers should be declared together
-    32, 7, 18, 23, 50, 2, 133, 65                  # these 8 values build the date and time
+    32, 7, 18, 23, 50, 2, 133, 65,                  # these 8 values build the date and time 12 byte total 
                                                    # data typ together, for details under this link
                                                    # https://support.industry.siemens.com/cs/document/36479/date_and_time-format-bei-s7-?dti=0&lc=de-DE
+    254, 254, 254, 254, 254                         # test small int
 ])
 
 
@@ -101,6 +103,19 @@ class TestS7util(unittest.TestCase):
         row = util.DB_Row(test_array, test_spec, layout_offset=4)
         row['ID'] = 259
         self.assertEqual(row['ID'], 259)
+
+    def test_get_small_int(self):
+        test_array = bytearray(_bytearray)
+        row = util.DB_Row(test_array, test_spec, layout_offset=4)
+        value = row.get_value(43, 'SINT')  # get value
+        self.assertEqual(value, 254)
+
+    def test_set_small_int(self):
+        test_array = bytearray(_bytearray)
+        row = util.DB_Row(test_array, test_spec, layout_offset=4)
+        row['testsmallint0'] = 254
+        self.assertEqual(row['testsmallint0'], 254)
+        
 
     def test_set_int_roundtrip(self):
         DB1 = (types.wordlen_to_ctypes[types.S7WLByte] * 4)()
@@ -216,6 +231,8 @@ class TestS7util(unittest.TestCase):
         row = util.DB_Row(test_array, test_spec, layout_offset=4)
         value = row.get_value(27, 'WORD')  # get value
         self.assertEqual(value, 65535)
+
+ 
 
     def test_export(self):
         test_array = bytearray(_bytearray)


### PR DESCRIPTION
I added the following functions to the `snap7.util` module.
```python
def get_small_int(bytearray_, byte_index):
    """
    Get small int value from bytearray.

    small int is represented as 1 byte
    """
    data = bytearray_[byte_index] & 0xff
    packed = struct.pack('B', data)
    value = struct.unpack('>B', packed)[0]
    return value


def set_small_int(bytearray_, byte_index, _int):
    """
    Set value in bytearray to int

    small int is represented as 1 byte
    """
    _int = int(_int)
    _bytes = struct.unpack('B', struct.pack('>B', _int))
    bytearray_[byte_index] = _bytes[0]
    return bytearray_

```

Also added to the methods `get_value` and `set_value` of the ``` class DB_Row``` the following part:
```python
if _type == 'SINT':
    return get_small_int(_bytearray, byte_index)

if _type == 'SINT':
    return set_small_int(_bytearray, byte_index, value)

``` 