### PR TITLE
Fix windows_test action

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,10 +15,9 @@ jobs:
         run: choco install 7zip wget python
       - name: Get snap7
         run: |
-          wget.exe --content-disposition -c https://sourceforge.net/projects/snap7/files/1.4.2/snap7-full-1.4.2.7z/download
+          wget.exe -O snap7-full-1.4.2.7z -c https://sourceforge.net/projects/snap7/files/1.4.2/snap7-full-1.4.2.7z/download
           7z x snap7-full-1.4.2.7z
-          Copy-Item snap7-full-1.4.2\release\Windows\Win64\snap7.dll snap7\.
-          Copy-Item snap7-full-1.4.2\release\Windows\Win64\snap7.dll C:\Windows\System32\.
+          Copy-Item snap7-full-1.4.2\release\Windows\Win64\snap7.dll C:\Windows\System32\
       - name: Upgrade pip and wheel for all pythons
         run:  python.exe -m pip install --upgrade pip wheel
       - name: Install python libraries

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,9 +15,10 @@ jobs:
         run: choco install 7zip wget python
       - name: Get snap7
         run: |
-          wget.exe -O snap7-full-1.4.2.7z -c https://sourceforge.net/projects/snap7/files/1.4.2/snap7-full-1.4.2.7z/download
+          wget.exe -O snap7-full-1.4.2.7z --content-disposition -c https://sourceforge.net/projects/snap7/files/1.4.2/snap7-full-1.4.2.7z/download
           7z x snap7-full-1.4.2.7z
-          Copy-Item snap7-full-1.4.2\release\Windows\Win64\snap7.dll C:\Windows\System32\
+          Copy-Item snap7-full-1.4.2\release\Windows\Win64\snap7.dll snap7\.
+          Copy-Item snap7-full-1.4.2\release\Windows\Win64\snap7.dll C:\Windows\System32\.
       - name: Upgrade pip and wheel for all pythons
         run:  python.exe -m pip install --upgrade pip wheel
       - name: Install python libraries

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -37,7 +37,7 @@ class TestClient(unittest.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        kill(cls.process.pid, 1)
+        cls.process.terminate()
 
     def setUp(self):
         self.client = snap7.client.Client()


### PR DESCRIPTION
1.  wget saves the archive with an incorrect name. I set output filename to fix "The system cannot find the file specified" error. 
2.  os.kill(pid, 1) on Windows kills a process with exit code 1, which may be the cause of issue #203 . It looks like the .terminate() method kills the `mainloop` process correctly.