### PR TITLE
add the readszl() function #196

### DIFF
--- a/snap7/client.py
+++ b/snap7/client.py
@@ -836,7 +836,7 @@ class Client:
         # Cli_ReadMultiVars
         raise NotImplementedError
 
-    def readszl(self, ssl_id: int, index: int=0x0000) -> S7SZL:
+    def readszl(self, ssl_id: int, index: int = 0x0000) -> S7SZL:
         # Cli_ReadSZL
         data = S7SZL()
         size = c_int(sizeof(data))

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -11,8 +11,7 @@ import snap7
 from snap7.common import check_error, load_library, ipv4
 from snap7.exceptions import Snap7Exception
 from snap7.types import S7Object, buffer_type, buffer_size, BlocksList
-from snap7.types import TS7BlockInfo, param_types, cpu_statuses
-from snap7.types import SystemStatusListHeader, SystemStatusList, S7SZLHeader, S7SZL
+from snap7.types import TS7BlockInfo, param_types, cpu_statuses, S7SZL
 
 logger = logging.getLogger(__name__)
 
@@ -837,17 +836,13 @@ class Client:
         # Cli_ReadMultiVars
         raise NotImplementedError
 
-    def readszl(self, ssl_id: int, index: int = 0x0000) -> SystemStatusList:
+    def readszl(self, ssl_id: int, index: int = 0x0000) -> S7SZL:
         # Cli_ReadSZL
         s7szl = S7SZL()
         size = c_int(sizeof(s7szl))
         result = self._library.Cli_ReadSZL(self._pointer, ssl_id, index, byref(s7szl), byref(size))
         check_error(result, context="client")
-        ssl_header = SystemStatusListHeader(length_dr=s7szl.Header.LengthDR, number_dr=s7szl.Header.NDR)
-        payload_length = ssl_header.length_dr * ssl_header.number_dr
-        payload = bytes(s7szl.Data)[:payload_length]
-        ssl = SystemStatusList(header=ssl_header, data=payload)
-        return ssl
+        return s7szl
 
     def readszllist(self):
         # Cli_ReadSZLList

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -11,7 +11,7 @@ import snap7
 from snap7.common import check_error, load_library, ipv4
 from snap7.exceptions import Snap7Exception
 from snap7.types import S7Object, buffer_type, buffer_size, BlocksList
-from snap7.types import TS7BlockInfo, param_types, cpu_statuses
+from snap7.types import TS7BlockInfo, param_types, cpu_statuses, S7SZLHeader, S7SZL
 
 logger = logging.getLogger(__name__)
 
@@ -836,9 +836,13 @@ class Client:
         # Cli_ReadMultiVars
         raise NotImplementedError
 
-    def readszl(self):
+    def readszl(self, ssl_id: int, index: int=0x0000) -> S7SZL:
         # Cli_ReadSZL
-        raise NotImplementedError
+        data = S7SZL()
+        size = c_int(sizeof(data))
+        result = self._library.Cli_ReadSZL(self._pointer, ssl_id, index, byref(data), byref(size))
+        check_error(result, context="client")
+        return data
 
     def readszllist(self):
         # Cli_ReadSZLList

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -11,7 +11,8 @@ import snap7
 from snap7.common import check_error, load_library, ipv4
 from snap7.exceptions import Snap7Exception
 from snap7.types import S7Object, buffer_type, buffer_size, BlocksList
-from snap7.types import TS7BlockInfo, param_types, cpu_statuses, S7SZLHeader, S7SZL
+from snap7.types import TS7BlockInfo, param_types, cpu_statuses
+from snap7.types import SystemStatusListHeader, SystemStatusList, S7SZLHeader, S7SZL
 
 logger = logging.getLogger(__name__)
 
@@ -836,13 +837,17 @@ class Client:
         # Cli_ReadMultiVars
         raise NotImplementedError
 
-    def readszl(self, ssl_id: int, index: int = 0x0000) -> S7SZL:
+    def readszl(self, ssl_id: int, index: int = 0x0000) -> SystemStatusList:
         # Cli_ReadSZL
-        data = S7SZL()
-        size = c_int(sizeof(data))
-        result = self._library.Cli_ReadSZL(self._pointer, ssl_id, index, byref(data), byref(size))
+        s7szl = S7SZL()
+        size = c_int(sizeof(s7szl))
+        result = self._library.Cli_ReadSZL(self._pointer, ssl_id, index, byref(s7szl), byref(size))
         check_error(result, context="client")
-        return data
+        ssl_header = SystemStatusListHeader(length_dr=s7szl.Header.LengthDR, number_dr=s7szl.Header.NDR)
+        payload_length = ssl_header.length_dr * ssl_header.number_dr
+        payload = bytes(s7szl.Data)[:payload_length]
+        ssl = SystemStatusList(header=ssl_header, data=payload)
+        return ssl
 
     def readszllist(self):
         # Cli_ReadSZLList

--- a/snap7/types.py
+++ b/snap7/types.py
@@ -2,6 +2,7 @@
 Python equivalent for snap7 specific types.
 """
 import ctypes
+import typing
 
 from snap7.common import ADict
 
@@ -224,6 +225,10 @@ class S7CpuInfo(ctypes.Structure):
 
 
 class S7SZLHeader(ctypes.Structure):
+    """
+        LengthDR: Length of a data record of the partial list in bytes
+        NDR: Number of data records contained in the partial list
+    """
     _fields_ = [
         ('LengthDR', ctypes.c_uint16),
         ('NDR', ctypes.c_uint16)
@@ -235,3 +240,13 @@ class S7SZL(ctypes.Structure):
         ('Header', S7SZLHeader),
         ('Data', ctypes.c_byte * (0x4000 - 4))
     ]
+
+
+class SystemStatusListHeader(typing.NamedTuple):
+    length_dr: int
+    number_dr: int
+
+
+class SystemStatusList(typing.NamedTuple):
+    header: SystemStatusListHeader
+    data: bytes

--- a/snap7/types.py
+++ b/snap7/types.py
@@ -221,3 +221,17 @@ class S7CpuInfo(ctypes.Structure):
         ('Copyright', ctypes.c_char * 27),
         ('ModuleName', ctypes.c_char * 25)
     ]
+
+
+class S7SZLHeader(ctypes.Structure):
+    _fields_ = [
+        ('LengthDR', ctypes.c_uint16),
+        ('NDR', ctypes.c_uint16)
+    ]
+
+
+class S7SZL(ctypes.Structure):
+    _fields_ = [
+        ('Header', S7SZLHeader),
+        ('Data', ctypes.c_byte * (0x4000 - 4))
+    ]

--- a/snap7/types.py
+++ b/snap7/types.py
@@ -240,13 +240,3 @@ class S7SZL(ctypes.Structure):
         ('Header', S7SZLHeader),
         ('Data', ctypes.c_byte * (0x4000 - 4))
     ]
-
-
-class SystemStatusListHeader(typing.NamedTuple):
-    length_dr: int
-    number_dr: int
-
-
-class SystemStatusList(typing.NamedTuple):
-    header: SystemStatusListHeader
-    data: bytes

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -815,15 +815,15 @@ class TestClient(unittest.TestCase):
         expected_length_of_record = 34
         ssl_id = 0x001c
         response = self.client.readszl(ssl_id)
-        self.assertEqual(expected_number_of_records, response.Header.NDR)
-        self.assertEqual(expected_length_of_record, response.Header.LengthDR)
+        self.assertEqual(expected_number_of_records, response.header.number_dr)
+        self.assertEqual(expected_length_of_record, response.header.length_dr)
 
     def test_readszl_single_data_record(self):
         expected = b'S C-C2UR28922012\x00\x00\x00\x00\x00\x00\x00\x00'
         ssl_id = 0x011c
         index = 0x0005
         response = self.client.readszl(ssl_id, index)
-        result = bytes(response.Data[2:26])
+        result = response.data[2:26]
         self.assertEqual(expected, result)
 
     def test_readszl_order_number(self):
@@ -831,7 +831,7 @@ class TestClient(unittest.TestCase):
         ssl_id = 0x0111
         index = 0x0001
         response = self.client.readszl(ssl_id, index)
-        result = bytes(response.Data[2:22])
+        result = response.data[2:22]
         self.assertEqual(expected, result)
 
     def test_readszl_invalid_id(self):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -810,10 +810,35 @@ class TestClient(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             self.client.readmultivars()
 
-    def test_readszl(self):
-        # Cli_ReadSZL
-        with self.assertRaises(NotImplementedError):
-            self.client.readszl()
+    def test_readszl_partial_list(self):
+        expected_number_of_records = 10
+        expected_length_of_record = 34
+        ssl_id = 0x001c
+        response = self.client.readszl(ssl_id)
+        self.assertEqual(expected_number_of_records, response.Header.NDR)
+        self.assertEqual(expected_length_of_record, response.Header.LengthDR)
+
+    def test_readszl_single_data_record(self):
+        expected = b'S C-C2UR28922012\x00\x00\x00\x00\x00\x00\x00\x00'
+        ssl_id = 0x011c
+        index = 0x0005
+        response = self.client.readszl(ssl_id, index)
+        result = bytes(response.Data[2:26])
+        self.assertEqual(expected, result)
+
+    def test_readszl_order_number(self):
+        expected = b'6ES7 315-2EH14-0AB0 '
+        ssl_id = 0x0111
+        index = 0x0001
+        response = self.client.readszl(ssl_id, index)
+        result = bytes(response.Data[2:22])
+        self.assertEqual(expected, result)
+    
+    def test_readszl_invalid_id(self):
+        ssl_id = 0xffff
+        index = 0xffff
+        self.assertRaises(Snap7Exception, self.client.readszl, ssl_id)
+        self.assertRaises(Snap7Exception, self.client.readszl, ssl_id, index)
 
     def test_readszllist(self):
         # Cli_ReadSZLList

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -823,7 +823,7 @@ class TestClient(unittest.TestCase):
         ssl_id = 0x011c
         index = 0x0005
         response = self.client.readszl(ssl_id, index)
-        result = response.Data[2:26]
+        result = bytes(response.Data)[2:26]
         self.assertEqual(expected, result)
 
     def test_readszl_order_number(self):
@@ -831,7 +831,7 @@ class TestClient(unittest.TestCase):
         ssl_id = 0x0111
         index = 0x0001
         response = self.client.readszl(ssl_id, index)
-        result = response.Data[2:22]
+        result = bytes(response.Data[2:22])
         self.assertEqual(expected, result)
 
     def test_readszl_invalid_id(self):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -815,15 +815,15 @@ class TestClient(unittest.TestCase):
         expected_length_of_record = 34
         ssl_id = 0x001c
         response = self.client.readszl(ssl_id)
-        self.assertEqual(expected_number_of_records, response.header.number_dr)
-        self.assertEqual(expected_length_of_record, response.header.length_dr)
+        self.assertEqual(expected_number_of_records, response.Header.NDR)
+        self.assertEqual(expected_length_of_record, response.Header.LengthDR)
 
     def test_readszl_single_data_record(self):
         expected = b'S C-C2UR28922012\x00\x00\x00\x00\x00\x00\x00\x00'
         ssl_id = 0x011c
         index = 0x0005
         response = self.client.readszl(ssl_id, index)
-        result = response.data[2:26]
+        result = response.Data[2:26]
         self.assertEqual(expected, result)
 
     def test_readszl_order_number(self):
@@ -831,7 +831,7 @@ class TestClient(unittest.TestCase):
         ssl_id = 0x0111
         index = 0x0001
         response = self.client.readszl(ssl_id, index)
-        result = response.data[2:22]
+        result = response.Data[2:22]
         self.assertEqual(expected, result)
 
     def test_readszl_invalid_id(self):

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -833,7 +833,7 @@ class TestClient(unittest.TestCase):
         response = self.client.readszl(ssl_id, index)
         result = bytes(response.Data[2:22])
         self.assertEqual(expected, result)
-    
+
     def test_readszl_invalid_id(self):
         ssl_id = 0xffff
         index = 0xffff


### PR DESCRIPTION
Feature request #196 

* add the function
* add types for a partial list and for the header of a partial list
* add tests

Code has been tested with 1200(151-214-1hg31-0xb0) and ET200S(151-8ab01-0ab0).
I'm not sure about the return type. Is it okay to return a ctypes.Structure? Or is it better to convert it to dict, for example?