### PR TITLE
remove SrcTSap parameter from test

### DIFF
--- a/test/test_partner.py
+++ b/test/test_partner.py
@@ -54,7 +54,6 @@ class TestPartner(unittest.TestCase):
             (snap7.types.RecvTimeout, 3000),
             (snap7.types.SrcRef, 256),
             (snap7.types.DstRef, 0),
-            (snap7.types.SrcTSap, 0),
             (snap7.types.PDURequest, 480),
             (snap7.types.WorkInterval, 100),
             (snap7.types.BSendTimeout, 3000),


### PR DESCRIPTION
It seems like, in python3.9, SrcTSap parameter is chosen randomly, so there is no point in checking it.