### PR TITLE
smaller changes & add set_as_callback

### DIFF
--- a/snap7/client.py
+++ b/snap7/client.py
@@ -307,7 +307,7 @@ class Client:
         logger.debug(f"blocks: {blocksList}")
         return blocksList
 
-    def list_blocks_of_type(self, blocktype: str, size: int) -> Union[int, Array]:
+    def list_blocks_of_type(self, blocktype, size: int) -> Union[int, Array]:
         """This function returns the AG list of a specified block type."""
 
         blocktype = snap7.types.block_types.get(blocktype)

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -603,7 +603,9 @@ class Client:
 
     def set_as_callback(self, pfn_clicompletion, p_usr):
         # Cli_SetAsCallback
-        return self._library.Cli_SetAsCallback(self, pfn_clicompletion, p_usr)
+        result = self._library.Cli_SetAsCallback(self, pfn_clicompletion, p_usr)
+        check_error(result, context='client')
+        return result
 
     def wait_as_completion(self, timeout: int) -> int:
         """

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -974,6 +974,9 @@ class TestClient(unittest.TestCase):
         self.assertEqual(expected_list[1], self.client.ct_read(0, 2))
         self.assertEqual(expected_list[2], self.client.tm_read(0, 2))
 
+    @unittest.skip("TODO: not yet fully implemented")
+    def test_set_as_callback(self):
+        raise NotImplementedError
 
 class TestClientBeforeConnect(unittest.TestCase):
     """

--- a/test/test_client.py
+++ b/test/test_client.py
@@ -978,6 +978,7 @@ class TestClient(unittest.TestCase):
     def test_set_as_callback(self):
         raise NotImplementedError
 
+
 class TestClientBeforeConnect(unittest.TestCase):
     """
     Test suite of items that should run without an open connection.


### PR DESCRIPTION
Add set_as_callback to most neccessarry points
Correct some docstrings
Replace bytes with bytearray
Remove unused imports
Remove wrong parameter in docstring
Rename value, since it is used as an import statement
Change exception message with better expression
Rebase on master

_as_check_loop shall just be an optional tool for tests, instead of the using of wait_as_completion().