### PR TITLE
Fix Documentation - Escape Backslashes

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -23,8 +23,8 @@ Windows
 
 Download the zip file from the
 `sourceforce page <http://sourceforge.net/projects/snap7/files/>`_.
-Unzip the zip file, and copy* release\Windows\<Win64/Win32>\snap7.dll* somewhere
-in you system PATH, for example *C:\WINDOWS\system32*. Alternatively you can
+Unzip the zip file, and copy* release\\Windows\\<Win64/Win32>\\snap7.dll* somewhere
+in you system PATH, for example *C:\\WINDOWS\\system32*. Alternatively you can
 copy the file somewhere on your file system and adjust the system PATH.
 
 


### PR DESCRIPTION
The documentation contains windows Paths, which use backslashes. These haven't been escaped so it looks like a giant string of text when it is actually a path.

![image](https://user-images.githubusercontent.com/28988626/117117699-c14a6300-ad87-11eb-8f38-a6ae361db00d.png)

This confused me when I first tried to use this library, so I hope this can be merged in order to help future documentation users.

Thanks,
Conor