### PR TITLE
Add byte type parsing to DB_Row API + set parsing case insensitive

### DIFF
--- a/snap7/util.py
+++ b/snap7/util.py
@@ -1069,6 +1069,7 @@ class DB_Row:
         """
 
         bytearray_ = self.get_bytearray()
+        type_ = type_.upper()
 
         if type_ == 'BOOL':
             byte_index, bool_index = str(byte_index).split('.')
@@ -1101,6 +1102,9 @@ class DB_Row:
 
         elif type_ == 'WORD':
             return get_word(bytearray_, byte_index)
+        
+        elif type_ == 'BYTE':
+            return get_byte(bytearray_, byte_index)
 
         elif type_ == 'S5TIME':
             data_s5time = get_s5time(bytearray_, byte_index)


### PR DESCRIPTION
I added the BYTE type to the parsing to DB_Row API to avoid ValueError exception when parsing a specification with BYTE type value.
I also set the string value to upper case in order to do a case insensitive search for the type of the value when parsing the specification (e.g. : BYTE, Byte, byte, etc ... are all acceptable).