### PR TITLE
Fix utils.get_time() for small negative values

### DIFF
--- a/snap7/util.py
+++ b/snap7/util.py
@@ -645,7 +645,8 @@ def get_time(bytearray_: bytearray, byte_index: int) -> str:
     hours = minutes // 60
     days = hours // 24
 
-    time_str = f"{days * sign!s}:{hours % 24!s}:{minutes % 60}:{seconds % 60!s}.{milli_seconds!s}"
+    sign_str = '' if sign >= 0 else '-'
+    time_str = f"{sign_str}{days!s}:{hours % 24!s}:{minutes % 60}:{seconds % 60!s}.{milli_seconds!s}"
 
     return time_str
 


### PR DESCRIPTION
I noticed utils.get_time() doesn't work for small (below one day) negative values.
For example `T#-1ms` returns `0:0:0:1.0`.

With this fix it will returns `-0:0:0:1.0`.

BTW, i'm wondering if it wouldn't be better to return timedelta (and datetime object for all others time function as get_dt(), etc ...
Or at least to let the user the choice to get a string or datetime object, maybe with a function parameter.
What you think ?