### PR TITLE
 fixing ip string paramters to c function

### DIFF
--- a/snap7/partner.py
+++ b/snap7/partner.py
@@ -215,9 +215,9 @@ class Partner:
         if not re.match(ipv4, remote_ip):
             raise ValueError(f"{remote_ip} is invalid ipv4")
         logger.info(f"starting partnering from {local_ip} to {remote_ip}")
-        return self._library.Par_StartTo(self._pointer, local_ip, remote_ip,
-                                         c_uint16(local_tsap),
-                                         c_uint16(remote_tsap))
+        return self._library.Par_StartTo(self._pointer, local_ip.encode(), remote_ip.encode(),
+                                         snap7.types.word(local_tsap),
+                                         snap7.types.word(remote_tsap))
 
     def stop(self) -> int:
         """

--- a/snap7/server.py
+++ b/snap7/server.py
@@ -265,7 +265,7 @@ class Server:
         if not re.match(ipv4, ip):
             raise ValueError(f"{ip} is invalid ipv4")
         logger.info(f"starting server to {ip}:102")
-        return self.library.Srv_StartTo(self.pointer, ip)
+        return self.library.Srv_StartTo(self.pointer, ip.encode())
 
     @error_wrap
     def set_param(self, number: int, value: int):


### PR DESCRIPTION
ctypes doesnt convert python3 string to c_char_p but bytes are therefore .encode() is needed 
