### PR TITLE
Add py.typed marker file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     author_email='gijs@pythonic.nl',
     url='https://github.com/gijzelaerr/python-snap7',
     packages=find_packages(),
+    package_data={'snap7': ['py.typed']},
     license='MIT licence',
     long_description=read('README.rst'),
     scripts=['snap7/bin/snap7-server.py'],


### PR DESCRIPTION
Currently `python-snap7` includes type annotations, but these are ignored when type-checking an application that uses this library. By including the `py.typed` marker file in the wheel, type checkers like `mypy` can check whether applications call `python-snap7` with the correct types.

https://www.python.org/dev/peps/pep-0561/#packaging-type-information
