### PR TITLE
Deprecate old osx

### DIFF
--- a/.github/workflows/osx.yml
+++ b/.github/workflows/osx.yml
@@ -6,7 +6,7 @@ on:
     branches: [ master ]
 jobs:
   osx_wheel:
-    runs-on: macos-10.15
+    runs-on: macos-11
     steps:
       - name: Checkout
         uses: actions/checkout@v2


### PR DESCRIPTION
osx 10.15 doesn't run on github actions anymore, so we need to replace it with 11