### PR TITLE
Fix example

### DIFF
--- a/example/boolean.py
+++ b/example/boolean.py
@@ -35,7 +35,10 @@ from snap7.types import areas
 
 
 # play with these functions.
-plc.read_area(areas['MK'], dbnumber, start, size)
-plc.write_area(areas['MK'], dbnumber, start, size)
+plc.read_area(area=areas['MK'], dbnumber=0, start=20, size=2)
+
+data = bytearray()
+snap7.util.set_int(data, 0, 127)
+plc.write_area(area=areas['MK'], dbnumber=0, start=20, data=data)
 # read the client source code!
 # and official snap7 documentation

--- a/example/read_multi.py
+++ b/example/read_multi.py
@@ -9,6 +9,7 @@ import ctypes
 import snap7
 from snap7.common import check_error
 from snap7.types import S7DataItem, S7AreaDB, S7WLByte
+from snap7 import util
 
 client = snap7.client.Client()
 client.connect('10.100.5.2', 0, 2)


### PR DESCRIPTION
I have found a few minor issues in the example files:

- In _read_multi.py_ the "util" submodule is not imported
- in _boolean.py_ "read_area" and "write_area" use variables that are never declared 