### PR TITLE
Add missing set_date function

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-snap7"
-version = "1.3"
+version = "1.3.1"
 description = "Python wrapper for the snap7 library"
 authors = [
     {name = "Gijs Molenaar", email = "gijs@pythonic.nl"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-snap7"
-version = "1.3.1"
+version = "1.3"
 description = "Python wrapper for the snap7 library"
 authors = [
     {name = "Gijs Molenaar", email = "gijs@pythonic.nl"},

--- a/snap7/util.py
+++ b/snap7/util.py
@@ -1175,6 +1175,35 @@ def get_date(bytearray_: bytearray, byte_index: int = 0) -> date:
         raise ValueError("date_val is higher than specification allows.")
     return date_val
 
+def set_date(bytearray_: bytearray, byte_index: int, date: date) -> bytearray:
+    """Set value in bytearray to date
+
+        Notes:
+            Datatype `date` consists in the number of days elapsed from 1990-01-01.
+            It is stored as an int (2 bytes) in the PLC.
+
+        Args:
+            bytearray_: buffer to write.
+            byte_index: byte index from where to start writing.
+            date: date object
+
+        Examples:
+            >>> data = bytearray(2)
+
+            >>> snap7.util.set_date(data, 0, date(2024, 3, 27))
+
+            >>> data
+                bytearray(b'\x30\xd8')
+        """
+    if date < date(1990, 1, 1):
+        raise ValueError("date_val is lower than specification allows.")
+    elif date > date(2168, 12, 31):
+        raise ValueError("date_val is higher than specification allows.")
+    _days = (date - date(1990, 1, 1)).days
+    _bytes = struct.unpack('2B', struct.pack('>h', _days))
+    bytearray_[byte_index:byte_index + 2] = _bytes
+    return bytearray_
+
 
 def get_ltime(bytearray_: bytearray, byte_index: int) -> str:
     raise NotImplementedError

--- a/snap7/util.py
+++ b/snap7/util.py
@@ -1175,7 +1175,7 @@ def get_date(bytearray_: bytearray, byte_index: int = 0) -> date:
         raise ValueError("date_val is higher than specification allows.")
     return date_val
 
-def set_date(bytearray_: bytearray, byte_index: int, date: date) -> bytearray:
+def set_date(bytearray_: bytearray, byte_index: int, date_: date) -> bytearray:
     """Set value in bytearray to date
 
         Notes:
@@ -1195,11 +1195,11 @@ def set_date(bytearray_: bytearray, byte_index: int, date: date) -> bytearray:
             >>> data
                 bytearray(b'\x30\xd8')
         """
-    if date < date(1990, 1, 1):
+    if date_ < date(1990, 1, 1):
         raise ValueError("date is lower than specification allows.")
-    elif date > date(2168, 12, 31):
+    elif date_ > date(2168, 12, 31):
         raise ValueError("date is higher than specification allows.")
-    _days = (date - date(1990, 1, 1)).days
+    _days = (date_ - date(1990, 1, 1)).days
     _bytes = struct.unpack('2B', struct.pack('>h', _days))
     bytearray_[byte_index:byte_index + 2] = _bytes
     return bytearray_
@@ -1847,6 +1847,9 @@ class DB_Row:
 
         if type_ == 'TIME' and isinstance(value, str):
             return set_time(bytearray_, byte_index, value)
+        
+        if type_ == 'DATE' and isinstance(value, date):
+            return set_date(bytearray_, byte_index, value)
 
         raise ValueError
 

--- a/snap7/util.py
+++ b/snap7/util.py
@@ -1196,9 +1196,9 @@ def set_date(bytearray_: bytearray, byte_index: int, date: date) -> bytearray:
                 bytearray(b'\x30\xd8')
         """
     if date < date(1990, 1, 1):
-        raise ValueError("date_val is lower than specification allows.")
+        raise ValueError("date is lower than specification allows.")
     elif date > date(2168, 12, 31):
-        raise ValueError("date_val is higher than specification allows.")
+        raise ValueError("date is higher than specification allows.")
     _days = (date - date(1990, 1, 1)).days
     _bytes = struct.unpack('2B', struct.pack('>h', _days))
     bytearray_[byte_index:byte_index + 2] = _bytes

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -531,6 +531,12 @@ class TestS7util(unittest.TestCase):
         val = row['testDtl']
         self.assertEqual(val, datetime.datetime(year=2022, month=3, day=9, hour=12, minute=34, second=45))
 
+    def test_set_date(self):
+        test_array = bytearray(_bytearray)
+        row = util.DB_Row(test_array, test_spec_indented, layout_offset=4)
+        row['testDate'] = datetime.date(day=28, month=3, year=2024)
+        self.assertEqual(row['testDate'], datetime.date(day=28, month=3, year=2024))
+
 
 def print_row(data):
     """print a single db row in chr and str


### PR DESCRIPTION
As written in this [comment](https://sourceforge.net/p/snap7/discussion/general/thread/f264e6cb/#4dac), a date variable is the number of days since 1990-01-01, written as a **int**.
I can't test it right now, but it's really simple so there shouldn't be any problems...