### PR TITLE
avoid creating compressed tags set

### DIFF
--- a/.github/build_scripts/build_package.sh
+++ b/.github/build_scripts/build_package.sh
@@ -9,4 +9,4 @@ cp /usr/lib/libsnap7.so snap7/lib/
 ${INPUT_PYTHON} -m pip install --upgrade pip wheel build auditwheel patchelf setuptools
 ${INPUT_PYTHON} -m build . --wheel -C="--build-option=--plat-name=${INPUT_PLATFORM}"
 
-auditwheel repair dist/*.whl --plat ${INPUT_PLATFORM} -w ${INPUT_WHEELDIR}
+auditwheel repair dist/*.whl --plat ${INPUT_PLATFORM} -w ${INPUT_WHEELDIR} --only-plat


### PR DESCRIPTION
avoid creating [compressed tags set](https://packaging.python.org/en/latest/specifications/platform-compatibility-tags/#compressed-tag-sets) for linux wheels