### PR TITLE
better parsing to avoid bugs when variables name contain whitespaces

### DIFF
--- a/snap7/util/db.py
+++ b/snap7/util/db.py
@@ -154,7 +154,7 @@ def parse_specification(db_specification: str) -> Dict[str, Any]:
         if line and not line.lstrip().startswith("#"):
             index, *_, _type = line.lstrip().split("#")[0].split()
 
-            match = re.compile(r"(\s*)(\S+)(\s*)").findall(line)
+            match = re.findall(r"(\s*)(\S+)(\s*)",line)
             
             var_name = "".join([m[0] + m[1] + m[2] for m in match[1:-1]])
             var_name = var_name.strip()

--- a/snap7/util/db.py
+++ b/snap7/util/db.py
@@ -159,13 +159,13 @@ def parse_specification(db_specification: str) -> Dict[str, Any]:
     for line in db_specification.split("\n"):
         if line and not line.lstrip().startswith("#"):
             match = regex.match(line.strip())
-            index = match.group('index')
-            var_name = match.group('var_name')
-            _type = match.group('_type')
+            if match:
+                index = match.group('index')
+                var_name = match.group('var_name')
+                _type = match.group('_type')
+                var_name = var_name.strip()
 
-            var_name = var_name.strip()
-
-            parsed_db_specification[var_name] = (index, _type)
+                parsed_db_specification[var_name] = (index, _type)
 
     return parsed_db_specification
 

--- a/snap7/util/db.py
+++ b/snap7/util/db.py
@@ -149,14 +149,20 @@ def parse_specification(db_specification: str) -> Dict[str, Any]:
         Parsed DB specification.
     """
     parsed_db_specification = {}
+    pattern = r"""
+        (?P<index>\d+(\.\d+)?)\s+    # Match integer or decimal index
+        (?P<var_name>.*?)\s+         # Non-greedy match for variable name
+        (?P<_type>\S+)$              # Match type at end of line
+    """
+    regex = re.compile(pattern, re.VERBOSE)
 
     for line in db_specification.split("\n"):
         if line and not line.lstrip().startswith("#"):
-            index, *_, _type = line.lstrip().split("#")[0].split()
+            match = regex.match(line.strip())
+            index = match.group('index')
+            var_name = match.group('var_name')
+            _type = match.group('_type')
 
-            match = re.findall(r"(\s*)(\S+)(\s*)",line)
-            
-            var_name = "".join([m[0] + m[1] + m[2] for m in match[1:-1]])
             var_name = var_name.strip()
 
             parsed_db_specification[var_name] = (index, _type)

--- a/snap7/util/db.py
+++ b/snap7/util/db.py
@@ -152,12 +152,7 @@ def parse_specification(db_specification: str) -> Dict[str, Any]:
 
     for line in db_specification.split("\n"):
         if line and not line.lstrip().startswith("#"):
-            parsed_text = line.lstrip().split("#")[0].split()
-
-            index = parsed_text[0]
-            _type = parsed_text[-1]
-            var_name_list = parsed_text[1:-1]
-            var_name = ''.join(var_name_list)
+            index, *var_name, _type = line.lstrip().split("#")[0].split()
 
             parsed_db_specification[var_name] = (index, _type)
 

--- a/snap7/util/db.py
+++ b/snap7/util/db.py
@@ -152,8 +152,13 @@ def parse_specification(db_specification: str) -> Dict[str, Any]:
 
     for line in db_specification.split("\n"):
         if line and not line.lstrip().startswith("#"):
-            index, *var_name, _type = line.lstrip().split("#")[0].split()
-            var_name = " ".join(var_name)
+            index, *notUsed, _type = line.lstrip().split("#")[0].split()
+
+            match = re.compile(r'(\s*)(\S+)(\s*)').findall(line)
+            
+            var_name = ''.join([m[0] + m[1] + m[2] for m in match[1:-1]])
+            var_name = var_name.strip()
+
             parsed_db_specification[var_name] = (index, _type)
 
     return parsed_db_specification

--- a/snap7/util/db.py
+++ b/snap7/util/db.py
@@ -154,9 +154,9 @@ def parse_specification(db_specification: str) -> Dict[str, Any]:
         if line and not line.lstrip().startswith("#"):
             index, *notUsed, _type = line.lstrip().split("#")[0].split()
 
-            match = re.compile(r'(\s*)(\S+)(\s*)').findall(line)
+            match = re.compile(r"(\s*)(\S+)(\s*)").findall(line)
             
-            var_name = ''.join([m[0] + m[1] + m[2] for m in match[1:-1]])
+            var_name = "".join([m[0] + m[1] + m[2] for m in match[1:-1]])
             var_name = var_name.strip()
 
             parsed_db_specification[var_name] = (index, _type)

--- a/snap7/util/db.py
+++ b/snap7/util/db.py
@@ -160,9 +160,9 @@ def parse_specification(db_specification: str) -> Dict[str, Any]:
         if line and not line.lstrip().startswith("#"):
             match = regex.match(line.strip())
             if match:
-                index = match.group('index')
-                var_name = match.group('var_name')
-                _type = match.group('_type')
+                index = match.group("index")
+                var_name = match.group("var_name")
+                _type = match.group("_type")
                 var_name = var_name.strip()
 
                 parsed_db_specification[var_name] = (index, _type)

--- a/snap7/util/db.py
+++ b/snap7/util/db.py
@@ -153,7 +153,7 @@ def parse_specification(db_specification: str) -> Dict[str, Any]:
     for line in db_specification.split("\n"):
         if line and not line.lstrip().startswith("#"):
             index, *var_name, _type = line.lstrip().split("#")[0].split()
-            var_name = "".join(var_name)
+            var_name = " ".join(var_name)
             parsed_db_specification[var_name] = (index, _type)
 
     return parsed_db_specification

--- a/snap7/util/db.py
+++ b/snap7/util/db.py
@@ -152,7 +152,7 @@ def parse_specification(db_specification: str) -> Dict[str, Any]:
 
     for line in db_specification.split("\n"):
         if line and not line.lstrip().startswith("#"):
-            index, *notUsed, _type = line.lstrip().split("#")[0].split()
+            index, *_, _type = line.lstrip().split("#")[0].split()
 
             match = re.compile(r"(\s*)(\S+)(\s*)").findall(line)
             

--- a/snap7/util/db.py
+++ b/snap7/util/db.py
@@ -152,7 +152,13 @@ def parse_specification(db_specification: str) -> Dict[str, Any]:
 
     for line in db_specification.split("\n"):
         if line and not line.lstrip().startswith("#"):
-            index, var_name, _type = line.lstrip().split("#")[0].split()
+            parsed_text = line.lstrip().split("#")[0].split()
+
+            index = parsed_text[0]
+            _type = parsed_text[-1]
+            var_name_list = parsed_text[1:-1]
+            var_name = ''.join(var_name_list)
+
             parsed_db_specification[var_name] = (index, _type)
 
     return parsed_db_specification

--- a/snap7/util/db.py
+++ b/snap7/util/db.py
@@ -153,7 +153,7 @@ def parse_specification(db_specification: str) -> Dict[str, Any]:
     for line in db_specification.split("\n"):
         if line and not line.lstrip().startswith("#"):
             index, *var_name, _type = line.lstrip().split("#")[0].split()
-
+            var_name = "".join(var_name)
             parsed_db_specification[var_name] = (index, _type)
 
     return parsed_db_specification

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -449,16 +449,18 @@ class TestS7util(unittest.TestCase):
     def test_db_creation_vars_with_whitespace(self) -> None:
         test_array = bytearray(_bytearray * 1)
         test_spec = """
-52      test Byte    BYTE
-57      supportByte         BYTE
+        50      testZeroSpaces    BYTE
+        52      testOne Space    BYTE
+        59      testTWo  Spaces   BYTE
 """
 
         test_db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=0, db_offset=0)
 
         exp = test_db.export()
-        print(exp[0].keys())
-        
-        self.assertTrue("test Byte" in exp[0].keys())
+
+        self.assertTrue("testZeroSpaces" in exp[0].keys())
+        self.assertTrue("testOne Space" in exp[0].keys())
+        self.assertTrue("testTWo  Spaces" in exp[0].keys())
 
 
     def test_db_export(self) -> None:

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -438,8 +438,7 @@ class TestS7util(unittest.TestCase):
             self.assertEqual(row["testbool1"], 1)
             self.assertEqual(row["testbool2"], 1)
             self.assertEqual(row["testbool3"], 1)
-            self.assertEqual(row["testbool4"], 1)
-
+            self.assertEqual(row["testbool4"], 1)   
             self.assertEqual(row["testbool5"], 0)
             self.assertEqual(row["testbool6"], 0)
             self.assertEqual(row["testbool7"], 0)
@@ -452,12 +451,10 @@ class TestS7util(unittest.TestCase):
         50      testZeroSpaces    BYTE
         52      testOne Space    BYTE
         59      testTWo  Spaces   BYTE
-"""
+        """
 
         test_db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=0, db_offset=0)
-
         db_export = test_db.export()
-
         for i in db_export:
             self.assertTrue("testZeroSpaces" in db_export[i].keys())
             self.assertTrue("testOne Space" in db_export[i].keys())

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -438,7 +438,7 @@ class TestS7util(unittest.TestCase):
             self.assertEqual(row["testbool1"], 1)
             self.assertEqual(row["testbool2"], 1)
             self.assertEqual(row["testbool3"], 1)
-            self.assertEqual(row["testbool4"], 1)  
+            self.assertEqual(row["testbool4"], 1)
             self.assertEqual(row["testbool5"], 0)
             self.assertEqual(row["testbool6"], 0)
             self.assertEqual(row["testbool7"], 0)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -438,7 +438,7 @@ class TestS7util(unittest.TestCase):
             self.assertEqual(row["testbool1"], 1)
             self.assertEqual(row["testbool2"], 1)
             self.assertEqual(row["testbool3"], 1)
-            self.assertEqual(row["testbool4"], 1)   
+            self.assertEqual(row["testbool4"], 1)  
             self.assertEqual(row["testbool5"], 0)
             self.assertEqual(row["testbool6"], 0)
             self.assertEqual(row["testbool7"], 0)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -444,7 +444,7 @@ class TestS7util(unittest.TestCase):
             self.assertEqual(row["testbool7"], 0)
             self.assertEqual(row["testbool8"], 0)
             self.assertEqual(row["NAME"], "test")
-        
+
     def test_db_creation_vars_with_whitespace(self) -> None:
         test_array = bytearray(_bytearray * 1)
         test_spec = """
@@ -459,7 +459,6 @@ class TestS7util(unittest.TestCase):
             self.assertTrue("testZeroSpaces" in db_export[i].keys())
             self.assertTrue("testOne Space" in db_export[i].keys())
             self.assertTrue("testTWo  Spaces" in db_export[i].keys())
-
 
     def test_db_export(self) -> None:
         test_array = bytearray(_bytearray * 10)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -53,7 +53,7 @@ test_spec_indented = """
  12.0	testbool1    BOOL
        12.1	testbool2    BOOL
  12.2	testbool3    BOOL
-#    12.3	testbool4    BOOL
+#    12.3	test bool4    BOOL
  #  12.4	testbool5    BOOL
       #    12.5	testbool6    BOOL
     #   12.6	testbool7    BOOL
@@ -445,6 +445,21 @@ class TestS7util(unittest.TestCase):
             self.assertEqual(row["testbool7"], 0)
             self.assertEqual(row["testbool8"], 0)
             self.assertEqual(row["NAME"], "test")
+        
+    def test_db_creation_vars_with_whitespace(self) -> None:
+        test_array = bytearray(_bytearray * 1)
+        test_spec = """
+52      test Byte    BYTE
+57      supportByte         BYTE
+"""
+
+        test_db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=0, db_offset=0)
+
+        exp = test_db.export()
+        print(exp[0].keys())
+        
+        self.assertTrue("test Byte" in exp[0].keys())
+
 
     def test_db_export(self) -> None:
         test_array = bytearray(_bytearray * 10)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -451,7 +451,7 @@ class TestS7util(unittest.TestCase):
         50      testZeroSpaces    BYTE
         52      testOne Space    BYTE
         59      testTWo  Spaces   BYTE
-        """
+"""
 
         test_db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=0, db_offset=0)
         db_export = test_db.export()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -456,11 +456,12 @@ class TestS7util(unittest.TestCase):
 
         test_db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=0, db_offset=0)
 
-        exp = test_db.export()
+        db_export = test_db.export()
 
-        self.assertTrue("testZeroSpaces" in exp[0].keys())
-        self.assertTrue("testOne Space" in exp[0].keys())
-        self.assertTrue("testTWo  Spaces" in exp[0].keys())
+        for i in db_export:
+            self.assertTrue("testZeroSpaces" in db_export[i].keys())
+            self.assertTrue("testOne Space" in db_export[i].keys())
+            self.assertTrue("testTWo  Spaces" in db_export[i].keys())
 
 
     def test_db_export(self) -> None:


### PR DESCRIPTION
hi,

I'm working with the db layout import, to access as a dictionary the data.

This pull request regards variables with spaces in their name, which currently breaks the parsing.
With this lines of code the parsing in more generic, taking the last element as the type, the first as index and the remaining as the name

thankyou