### PR TITLE
function to match a native TIA portal export to a DB layout specification string

### DIFF
--- a/snap7/util/db.py
+++ b/snap7/util/db.py
@@ -185,10 +185,9 @@ def prepare_tia_export_to_parse(txt_path: str) -> str:
             var_name = var_name + to_add
             var_names.append(var_name)
 
-            if var_type:
-                if var_type in valid_list:
-                    new_line = var_offset + "\t" + var_name + "\t" + var_type
-                    db_specification = db_specification + "\n" + new_line
+            if var_type in valid_list:
+                new_line = var_offset + "\t" + var_name + "\t" + var_type
+                db_specification = db_specification + "\n" + new_line
     return db_specification
 
 


### PR DESCRIPTION
Hi,
as anticipated I was working on a function that could ingest a native TIA portal export of a non-optimized db to generate a string compatible with the DB class layout_specification

It also manage  names duplicates by adding a suffix "_X" at the end of the variables, where "X" is a progressive numeration.

