### PR TITLE
Update read_multi.py

### DIFF
--- a/example/read_multi.py
+++ b/example/read_multi.py
@@ -7,7 +7,7 @@ This was tested against a S7-319 CPU
 import ctypes
 
 from snap7 import Client
-from error import check_error
+from snap7.error import check_error
 from snap7.type import S7DataItem, Area, WordLen
 from snap7.util import get_real, get_int
 


### PR DESCRIPTION
If you use: `from error import check_error`, you shall encounter the follow error owing to the incorrect mapping. 
ModuleNotFoundError: No module named 'error'

Instead of the same, you `from snap7.error import check_error` and the code shall execute correctly. 