### PR TITLE
Fix off-by-two padding bug in set_string and empty string edge case

### DIFF
--- a/snap7/util/setters.py
+++ b/snap7/util/setters.py
@@ -182,14 +182,12 @@ def set_fstring(bytearray_: bytearray, byte_index: int, value: str, max_length: 
     if size > max_length:
         raise ValueError(f"size {size} > max_length {max_length} {value}")
 
-    i = 0
-
-    # fill array which chr integers
+    # fill array with chr integers
     for i, c in enumerate(value):
         bytearray_[byte_index + i] = ord(c)
 
     # fill the rest with empty space
-    for r in range(i + 1, max_length):
+    for r in range(len(value), max_length):
         bytearray_[byte_index + r] = ord(" ")
 
 
@@ -237,14 +235,12 @@ def set_string(bytearray_: bytearray, byte_index: int, value: str, max_size: int
     # set len count on first position
     bytearray_[byte_index + 1] = len(value)
 
-    i = 0
-
-    # fill array which chr integers
+    # fill array with chr integers
     for i, c in enumerate(value):
         bytearray_[byte_index + 2 + i] = ord(c)
 
     # fill the rest with empty space
-    for r in range(i + 1, bytearray_[byte_index] - 2):
+    for r in range(len(value), bytearray_[byte_index]):
         bytearray_[byte_index + 2 + r] = ord(" ")
 
 


### PR DESCRIPTION
## Summary

Fixes #479

`set_string()` left the last 2 character positions unpadded when writing a shorter string over a longer one, leaving stale data in the buffer. Additionally, both `set_string()` and `set_fstring()` failed to clear the first character position when writing an empty string.

## Root cause analysis

### Bug 1: Off-by-two in `set_string` padding (line 247)

```python
# BEFORE (buggy)
for r in range(i + 1, bytearray_[byte_index] - 2):
    bytearray_[byte_index + 2 + r] = ord(" ")
```

The `- 2` was an incorrect attempt to account for the 2-byte string header (max_size byte + length byte). However, the header offset is **already handled** by the `byte_index + 2 + r` indexing expression. The variable `r` is a relative index into the data area (positions 0 through max_size-1), so the range should go up to `max_size`, not `max_size - 2`.

**Impact:** When writing `"ab"` into a buffer with `max_size=10`, positions 8 and 9 (relative to the data area) were never cleared:

```
Expected: [10, 2, 'a', 'b', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ']
Actual:   [10, 2, 'a', 'b', ' ', ' ', ' ', ' ', ' ', ' ',  ?,  ?]
                                                             ^^  ^^
                                                       stale data!
```

### Bug 2: Empty string edge case (both `set_string` and `set_fstring`)

```python
i = 0
for i, c in enumerate(value):  # doesn't execute for empty string
    ...
for r in range(i + 1, ...):    # starts at 1, skipping position 0
    ...
```

When `value` is empty, the `enumerate` loop doesn't execute, so `i` stays at `0`. The padding loop then starts from `range(0 + 1, ...)`, skipping position 0 entirely.

For `set_string`, this bug was masked by `get_string()` which reads the length byte (0 for empty) and returns `""` regardless. But for `set_fstring`, the stale character at position 0 would be visible through `get_fstring()`.

## Fix

1. Changed `range(i + 1, bytearray_[byte_index] - 2)` to `range(len(value), bytearray_[byte_index])` in `set_string`
2. Changed `range(i + 1, max_length)` to `range(len(value), max_length)` in `set_fstring`

Using `len(value)` instead of `i + 1` correctly handles both the normal case and the empty string edge case, and removing `- 2` fixes the off-by-two.

## Test plan

- [x] All 326 existing tests pass
- [x] Manual verification that padding is correct for `"ab"` with max_size=10
- [x] Manual verification that empty string clears all positions
- [ ] Add unit tests that verify buffer contents after set_string (not just round-trip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)