### PR TITLE
Fix get_connected to detect lost network connections

### DIFF
--- a/snap7/client.py
+++ b/snap7/client.py
@@ -184,8 +184,14 @@ class Client:
         self.disconnect()
 
     def get_connected(self) -> bool:
-        """Check if client is connected to PLC."""
-        return self.connected and self.connection is not None and self.connection.connected
+        """Check if client is connected to PLC.
+
+        Performs an active check on the underlying TCP socket to detect
+        broken connections, rather than just checking a cached flag.
+        """
+        if not self.connected or self.connection is None:
+            return False
+        return self.connection.check_connection()
 
     def db_read(self, db_number: int, start: int, size: int) -> bytearray:
         """

--- a/snap7/connection.py
+++ b/snap7/connection.py
@@ -382,6 +382,34 @@ class ISOTCPConnection:
 
         return bytes(data)
 
+    def check_connection(self) -> bool:
+        """Check if the TCP connection is still alive.
+
+        Uses a non-blocking socket peek to detect broken connections.
+        """
+        if not self.connected or self.socket is None:
+            return False
+
+        try:
+            original_timeout = self.socket.gettimeout()
+            self.socket.settimeout(0)
+            try:
+                data = self.socket.recv(1, socket.MSG_PEEK)
+                if not data:
+                    self.connected = False
+                    return False
+                return True
+            except BlockingIOError:
+                # No data available but connection is still alive
+                return True
+            except (socket.error, OSError):
+                self.connected = False
+                return False
+            finally:
+                self.socket.settimeout(original_timeout)
+        except Exception:
+            return False
+
     def __enter__(self) -> "ISOTCPConnection":
         """Context manager entry."""
         return self


### PR DESCRIPTION
## Summary

Fixes #111

`get_connected()` returned `True` even after the network connection was physically lost (e.g., cable unplugged, PLC powered off), because it only checked a cached boolean flag rather than the actual socket state.

## Root cause analysis

The previous implementation simply returned the cached `self.connected` flag:

```python
def get_connected(self) -> bool:
    return self.connected and self.connection is not None and self.connection.connected
```

This flag was only set to `False` by an explicit `disconnect()` call. If the TCP connection was lost at the network level (cable unplugged, PLC rebooted, firewall drop), the flag remained `True`, causing users to believe the connection was healthy. Subsequent `db_read()`/`db_write()` calls would then crash with confusing errors instead of a clean "not connected" status.

This was originally reported as an upstream bug in the Snap7 C library, but now that python-snap7 has a pure Python implementation, we own the TCP connection and can fix it properly.

## Fix

Added `check_connection()` to `ISOTCPConnection` that performs a **non-blocking socket peek** using `recv(1, MSG_PEEK)`:

- **No data available** (`BlockingIOError`): Connection is alive, no pending data — returns `True`
- **Data available**: Connection is alive, data waiting — returns `True`  
- **Empty data returned**: Peer closed the connection (FIN received) — returns `False`
- **Socket error/OSError**: Connection is broken — returns `False`

The peek is non-blocking (timeout set to 0) so it returns immediately and does not interfere with normal operations. The original socket timeout is restored afterward.

Updated `Client.get_connected()` to use this active check instead of the cached flag.

## Test plan

- [x] All 326 existing tests pass
- [ ] Verify `get_connected()` returns `False` after unplugging network cable
- [ ] Verify `get_connected()` returns `True` during normal operation
- [ ] Verify no performance impact from the non-blocking peek

🤖 Generated with [Claude Code](https://claude.com/claude-code)