### PR TITLE
Mark connection as disconnected on TCP errors

### DIFF
--- a/snap7/connection.py
+++ b/snap7/connection.py
@@ -129,6 +129,7 @@ class ISOTCPConnection:
             self.socket.sendall(tpkt_frame)
             logger.debug(f"Sent {len(tpkt_frame)} bytes")
         except socket.error as e:
+            self.connected = False
             raise S7ConnectionError(f"Send failed: {e}")
 
     def receive_data(self) -> bytes:
@@ -162,8 +163,10 @@ class ISOTCPConnection:
             return self._parse_cotp_data(payload)
 
         except socket.timeout:
+            self.connected = False
             raise S7TimeoutError("Receive timeout")
         except socket.error as e:
+            self.connected = False
             raise S7ConnectionError(f"Receive failed: {e}")
 
     def _tcp_connect(self) -> None:
@@ -373,11 +376,14 @@ class ISOTCPConnection:
             try:
                 chunk = self.socket.recv(size - len(data))
                 if not chunk:
+                    self.connected = False
                     raise S7ConnectionError("Connection closed by peer")
                 data.extend(chunk)
             except socket.timeout:
+                self.connected = False
                 raise S7TimeoutError("Receive timeout")
             except socket.error as e:
+                self.connected = False
                 raise S7ConnectionError(f"Receive error: {e}")
 
         return bytes(data)


### PR DESCRIPTION
## Summary

Fixes #70

After a TCP timeout, subsequent reads could return stale data from previous requests because the connection was left in an indeterminate state. The connection appeared valid but the TCP stream was out of sync.

## Root cause analysis

When a TCP timeout or connection error occurred during `send_data()`, `receive_data()`, or `_recv_exact()`, the code raised the appropriate exception but **did not update `self.connected`**:

```python
# BEFORE
except socket.timeout:
    raise S7TimeoutError("Receive timeout")  # connected flag stays True!
except socket.error as e:
    raise S7ConnectionError(f"Receive failed: {e}")  # connected flag stays True!
```

After catching such an exception, users could immediately retry another read/write. Since `self.connected` was still `True`, the operation would proceed on the same socket. But the TCP stream was now out of sync — the response to the timed-out request might arrive and be incorrectly interpreted as the response to the new request. This caused the "stale data" behavior described in the issue:

```
db_read(3, 260, 4)  → returns 100 ✓
db_read(3, 272, 4)  → TIMEOUT (response for this arrives late)
db_read(1, 104, 4)  → returns 200 ✗ (this is actually the late response from the previous read!)
```

The original Snap7 author confirmed that **a reconnection is required after TCP timeout errors** — this is fundamental to the S7/ISO-on-TCP protocol.

## Fix

Added `self.connected = False` in all error paths in `connection.py`:

- `send_data()`: on `socket.error`
- `receive_data()`: on `socket.timeout` and `socket.error`
- `_recv_exact()`: on connection closed, `socket.timeout`, and `socket.error`

This ensures that after any TCP-level error, `get_connected()` returns `False` and subsequent operations fail immediately with "Not connected" instead of silently returning wrong data. Users must reconnect, which establishes a fresh TCP stream with proper synchronization.

## Test plan

- [x] All 326 existing tests pass
- [ ] Verify that after a timeout, `get_connected()` returns `False`
- [ ] Verify that reconnecting after a timeout restores normal operation
- [ ] Verify no false disconnections during normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)