### PR TITLE
Add native AsyncClient with asyncio support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -68,3 +68,20 @@ Install using pip::
    $ pip install python-snap7
 
 No native libraries or platform-specific dependencies are required — python-snap7 is a pure Python package that works on all platforms.
+
+
+Async support
+=============
+
+An ``AsyncClient`` is available for use with ``asyncio``::
+
+   import asyncio
+   import snap7
+
+   async def main():
+       async with snap7.AsyncClient() as client:
+           await client.connect("192.168.1.10", 0, 1)
+           data = await client.db_read(1, 0, 4)
+           print(data)
+
+   asyncio.run(main())

--- a/doc/API/async_client.rst
+++ b/doc/API/async_client.rst
@@ -1,0 +1,43 @@
+AsyncClient
+===========
+
+The :class:`~snap7.async_client.AsyncClient` provides a native ``asyncio``
+interface for communicating with Siemens S7 PLCs.  It has feature parity with
+the synchronous :class:`~snap7.client.Client` and is safe for concurrent use
+via ``asyncio.gather()``.
+
+Quick start
+-----------
+
+.. code-block:: python
+
+   import asyncio
+   import snap7
+
+   async def main():
+       async with snap7.AsyncClient() as client:
+           await client.connect("192.168.1.10", 0, 1)
+           data = await client.db_read(1, 0, 4)
+           print(data)
+
+   asyncio.run(main())
+
+Concurrent reads
+----------------
+
+An internal ``asyncio.Lock`` serialises each send/receive cycle so that
+multiple coroutines can safely share a single connection:
+
+.. code-block:: python
+
+   results = await asyncio.gather(
+       client.db_read(1, 0, 4),
+       client.db_read(1, 10, 4),
+   )
+
+API reference
+-------------
+
+.. automodule:: snap7.async_client
+   :members:
+   :exclude-members: AsyncISOTCPConnection

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -11,6 +11,7 @@ Contents:
    development
 
    API/client
+   API/async_client
    API/server
    API/partner
    API/logo

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ Homepage = "https://github.com/gijzelaerr/python-snap7"
 Documentation = "https://python-snap7.readthedocs.io/en/latest/"
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-cov", "pytest-html", "mypy", "types-setuptools", "ruff", "tox", "tox-uv", "types-click", "uv"]
+test = ["pytest", "pytest-asyncio", "pytest-cov", "pytest-html", "mypy", "types-setuptools", "ruff", "tox", "tox-uv", "types-click", "uv"]
 cli = ["rich", "click" ]
 doc = ["sphinx", "sphinx_rtd_theme"]
 

--- a/snap7/__init__.py
+++ b/snap7/__init__.py
@@ -8,6 +8,7 @@ Siemens S7 PLCs without requiring the native Snap7 C library.
 from importlib.metadata import version, PackageNotFoundError
 
 from .client import Client
+from .async_client import AsyncClient
 from .server import Server
 from .partner import Partner
 from .logo import Logo
@@ -16,6 +17,7 @@ from .type import Area, Block, WordLen, SrvEvent, SrvArea
 
 __all__ = [
     "Client",
+    "AsyncClient",
     "Server",
     "Partner",
     "Logo",

--- a/snap7/async_client.py
+++ b/snap7/async_client.py
@@ -430,7 +430,7 @@ class AsyncClient(ClientMixin):
 
     def get_connected(self) -> bool:
         """Check if client is connected."""
-        return self.connected and self.connection is not None
+        return self.connected and self.connection is not None and self.connection.connected
 
     # ---------------------------------------------------------------
     # DB helpers

--- a/snap7/async_client.py
+++ b/snap7/async_client.py
@@ -107,8 +107,13 @@ class AsyncISOTCPConnection:
             try:
                 if self.connected:
                     dr_pdu = struct.pack(
-                        ">BBHHBB", 6, self.COTP_DR,
-                        self.dst_ref, self.src_ref, 0x00, 0x00,
+                        ">BBHHBB",
+                        6,
+                        self.COTP_DR,
+                        self.dst_ref,
+                        self.src_ref,
+                        0x00,
+                        0x00,
                     )
                     self._writer.write(self._build_tpkt(dr_pdu))
                     await self._writer.drain()
@@ -177,7 +182,12 @@ class AsyncISOTCPConnection:
 
         # Build and send COTP Connection Request
         base_pdu = struct.pack(
-            ">BBHHB", 6, self.COTP_CR, 0x0000, self.src_ref, 0x00,
+            ">BBHHB",
+            6,
+            self.COTP_CR,
+            0x0000,
+            self.src_ref,
+            0x00,
         )
         calling_tsap = struct.pack(">BBH", self.COTP_PARAM_CALLING_TSAP, 2, self.local_tsap)
         called_tsap = struct.pack(">BBH", self.COTP_PARAM_CALLED_TSAP, 2, self.remote_tsap)
@@ -240,7 +250,8 @@ class AsyncISOTCPConnection:
             raise S7ConnectionError("Stream not initialized")
         try:
             return await asyncio.wait_for(
-                self._reader.readexactly(size), timeout=self.timeout,
+                self._reader.readexactly(size),
+                timeout=self.timeout,
             )
         except asyncio.IncompleteReadError:
             self.connected = False
@@ -851,9 +862,12 @@ class AsyncClient(ClientMixin):
         data_section = struct.pack(">HH", len(data), 0x00FB) + bytes(data)
         header = struct.pack(
             ">BBHHHH",
-            0x32, 0x01, 0x0000,
+            0x32,
+            0x01,
+            0x0000,
             self.protocol._next_sequence(),
-            len(param_data), len(data_section),
+            len(param_data),
+            len(data_section),
         )
 
         async with self._lock:
@@ -865,9 +879,12 @@ class AsyncClient(ClientMixin):
         param_data = struct.pack(">B", 0x1C)
         header = struct.pack(
             ">BBHHHH",
-            0x32, 0x01, 0x0000,
+            0x32,
+            0x01,
+            0x0000,
             self.protocol._next_sequence(),
-            len(param_data), 0x0000,
+            len(param_data),
+            0x0000,
         )
 
         async with self._lock:
@@ -884,8 +901,13 @@ class AsyncClient(ClientMixin):
             raise S7ConnectionError("Not connected to PLC")
 
         block_type_map = {
-            Block.OB: 0x38, Block.DB: 0x41, Block.SDB: 0x42,
-            Block.FC: 0x43, Block.SFC: 0x44, Block.FB: 0x45, Block.SFB: 0x46,
+            Block.OB: 0x38,
+            Block.DB: 0x41,
+            Block.SDB: 0x42,
+            Block.FC: 0x43,
+            Block.SFC: 0x44,
+            Block.FB: 0x45,
+            Block.SFB: 0x46,
         }
         type_code = block_type_map.get(block_type, 0x41)
 
@@ -902,8 +924,13 @@ class AsyncClient(ClientMixin):
             raise S7ConnectionError("Not connected to PLC")
 
         block_type_map = {
-            Block.OB: 0x38, Block.DB: 0x41, Block.SDB: 0x42,
-            Block.FC: 0x43, Block.SFC: 0x44, Block.FB: 0x45, Block.SFB: 0x46,
+            Block.OB: 0x38,
+            Block.DB: 0x41,
+            Block.SDB: 0x42,
+            Block.FC: 0x43,
+            Block.SFC: 0x44,
+            Block.FB: 0x45,
+            Block.SFB: 0x46,
         }
         type_code = block_type_map.get(block_type, 0x41)
 
@@ -922,9 +949,15 @@ class AsyncClient(ClientMixin):
 
         block_header = struct.pack(
             ">BBHBBBBHH",
-            0x70, block_type.value, block_num,
-            0x00, 0x00, 0x00, 0x00,
-            len(block_data) + 14, len(block_data),
+            0x70,
+            block_type.value,
+            block_num,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            len(block_data) + 14,
+            len(block_data),
         )
         block_footer = b"\x00" * 4
         full_block = bytearray(block_header + block_data + block_footer)
@@ -1219,9 +1252,7 @@ class AsyncClient(ClientMixin):
 
     async def _setup_communication(self) -> None:
         """Setup communication and negotiate PDU length."""
-        request = self.protocol.build_setup_communication_request(
-            max_amq_caller=1, max_amq_callee=1, pdu_length=self.pdu_length
-        )
+        request = self.protocol.build_setup_communication_request(max_amq_caller=1, max_amq_callee=1, pdu_length=self.pdu_length)
         response = await self._send_receive(request)
 
         if response.get("parameters"):

--- a/snap7/async_client.py
+++ b/snap7/async_client.py
@@ -1,0 +1,1244 @@
+"""
+Native async S7 client implementation.
+
+Uses asyncio streams for non-blocking I/O with an asyncio.Lock() to serialize
+send/receive cycles, ensuring safe concurrent use via asyncio.gather().
+"""
+
+import asyncio
+import logging
+import struct
+import time
+from typing import List, Any, Optional, Tuple, Type
+from types import TracebackType
+from datetime import datetime
+
+from .connection import TPDUSize
+from .s7protocol import S7Protocol, get_return_code_description
+from .datatypes import S7WordLen
+from .error import S7Error, S7ConnectionError, S7ProtocolError, S7TimeoutError
+from .client_base import ClientMixin
+from .type import (
+    Area,
+    Block,
+    BlocksList,
+    S7CpuInfo,
+    TS7BlockInfo,
+    S7CpInfo,
+    S7OrderCode,
+    S7Protection,
+    S7SZL,
+    Parameter,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+class AsyncISOTCPConnection:
+    """Async ISO on TCP connection using asyncio streams.
+
+    Mirrors ISOTCPConnection but uses asyncio.open_connection() instead of
+    blocking sockets for non-blocking I/O.
+    """
+
+    # COTP PDU types
+    COTP_CR = 0xE0  # Connection Request
+    COTP_CC = 0xD0  # Connection Confirm
+    COTP_DR = 0x80  # Disconnect Request
+    COTP_DT = 0xF0  # Data Transfer
+
+    # COTP parameter codes (ISO 8073)
+    COTP_PARAM_PDU_SIZE = 0xC0
+    COTP_PARAM_CALLING_TSAP = 0xC1
+    COTP_PARAM_CALLED_TSAP = 0xC2
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 102,
+        local_tsap: int = 0x0100,
+        remote_tsap: int = 0x0102,
+        tpdu_size: TPDUSize = TPDUSize.S_1024,
+    ):
+        self.host = host
+        self.port = port
+        self.local_tsap = local_tsap
+        self.remote_tsap = remote_tsap
+        self.tpdu_size = tpdu_size
+        self.connected = False
+        self.pdu_size = 240
+        self.timeout = 5.0
+
+        self.src_ref = 0x0001
+        self.dst_ref = 0x0000
+
+        self._reader: Optional[asyncio.StreamReader] = None
+        self._writer: Optional[asyncio.StreamWriter] = None
+
+    async def connect(self, timeout: float = 5.0) -> None:
+        """Establish ISO on TCP connection."""
+        self.timeout = timeout
+
+        try:
+            self._reader, self._writer = await asyncio.wait_for(
+                asyncio.open_connection(self.host, self.port),
+                timeout=self.timeout,
+            )
+            logger.debug(f"TCP connected to {self.host}:{self.port}")
+
+            await self._iso_connect()
+
+            self.connected = True
+            logger.info(f"Connected to {self.host}:{self.port}, PDU size: {self.pdu_size}")
+
+        except Exception as e:
+            await self.disconnect()
+            if isinstance(e, (S7ConnectionError, S7TimeoutError)):
+                raise
+            elif isinstance(e, asyncio.TimeoutError):
+                raise S7TimeoutError(f"Connection timeout: {e}")
+            else:
+                raise S7ConnectionError(f"Connection failed: {e}")
+
+    async def disconnect(self) -> None:
+        """Disconnect from S7 device."""
+        if self._writer:
+            try:
+                if self.connected:
+                    dr_pdu = struct.pack(
+                        ">BBHHBB", 6, self.COTP_DR,
+                        self.dst_ref, self.src_ref, 0x00, 0x00,
+                    )
+                    self._writer.write(self._build_tpkt(dr_pdu))
+                    await self._writer.drain()
+                self._writer.close()
+                await self._writer.wait_closed()
+            except Exception:
+                pass
+            finally:
+                self._reader = None
+                self._writer = None
+                self.connected = False
+                logger.info(f"Disconnected from {self.host}:{self.port}")
+
+    async def send_data(self, data: bytes) -> None:
+        """Send data over ISO connection."""
+        if not self.connected or self._writer is None:
+            raise S7ConnectionError("Not connected")
+
+        cotp_header = struct.pack(">BBB", 2, self.COTP_DT, 0x80)
+        tpkt_frame = self._build_tpkt(cotp_header + data)
+
+        try:
+            self._writer.write(tpkt_frame)
+            await self._writer.drain()
+            logger.debug(f"Sent {len(tpkt_frame)} bytes")
+        except (OSError, ConnectionError) as e:
+            self.connected = False
+            raise S7ConnectionError(f"Send failed: {e}")
+
+    async def receive_data(self) -> bytes:
+        """Receive data from ISO connection."""
+        if not self.connected:
+            raise S7ConnectionError("Not connected")
+
+        try:
+            tpkt_header = await self._recv_exact(4)
+            version, reserved, length = struct.unpack(">BBH", tpkt_header)
+            if version != 3:
+                raise S7ConnectionError(f"Invalid TPKT version: {version}")
+
+            remaining = length - 4
+            if remaining <= 0:
+                raise S7ConnectionError("Invalid TPKT length")
+
+            payload = await self._recv_exact(remaining)
+
+            # Parse COTP DT header
+            if len(payload) < 3:
+                raise S7ConnectionError("Invalid COTP DT: too short")
+            pdu_len, pdu_type, eot_num = struct.unpack(">BBB", payload[:3])
+            if pdu_type != self.COTP_DT:
+                raise S7ConnectionError(f"Expected COTP DT, got {pdu_type:#02x}")
+            return payload[3:]
+
+        except asyncio.TimeoutError:
+            self.connected = False
+            raise S7TimeoutError("Receive timeout")
+        except (OSError, ConnectionError) as e:
+            self.connected = False
+            raise S7ConnectionError(f"Receive failed: {e}")
+
+    async def _iso_connect(self) -> None:
+        """Establish ISO connection using COTP handshake."""
+        if self._writer is None or self._reader is None:
+            raise S7ConnectionError("Stream not initialized")
+
+        # Build and send COTP Connection Request
+        base_pdu = struct.pack(
+            ">BBHHB", 6, self.COTP_CR, 0x0000, self.src_ref, 0x00,
+        )
+        calling_tsap = struct.pack(">BBH", self.COTP_PARAM_CALLING_TSAP, 2, self.local_tsap)
+        called_tsap = struct.pack(">BBH", self.COTP_PARAM_CALLED_TSAP, 2, self.remote_tsap)
+        pdu_size_param = struct.pack(">BBB", self.COTP_PARAM_PDU_SIZE, 1, self.tpdu_size)
+        parameters = calling_tsap + called_tsap + pdu_size_param
+        total_length = 6 + len(parameters)
+        cr_pdu = struct.pack(">B", total_length) + base_pdu[1:] + parameters
+
+        self._writer.write(self._build_tpkt(cr_pdu))
+        await self._writer.drain()
+        logger.debug("Sent COTP Connection Request")
+
+        # Receive Connection Confirm
+        tpkt_header = await self._recv_exact(4)
+        version, reserved, length = struct.unpack(">BBH", tpkt_header)
+        if version != 3:
+            raise S7ConnectionError(f"Invalid TPKT version in response: {version}")
+
+        payload = await self._recv_exact(length - 4)
+        self._parse_cotp_cc(payload)
+        logger.debug("Received COTP Connection Confirm")
+
+    def _build_tpkt(self, payload: bytes) -> bytes:
+        """Build TPKT frame."""
+        length = len(payload) + 4
+        return struct.pack(">BBH", 3, 0, length) + payload
+
+    def _parse_cotp_cc(self, data: bytes) -> None:
+        """Parse COTP Connection Confirm PDU."""
+        if len(data) < 7:
+            raise S7ConnectionError("Invalid COTP CC: too short")
+
+        pdu_len, pdu_type, dst_ref, src_ref, class_opt = struct.unpack(">BBHHB", data[:7])
+        if pdu_type != self.COTP_CC:
+            raise S7ConnectionError(f"Expected COTP CC, got {pdu_type:#02x}")
+
+        self.dst_ref = dst_ref
+
+        # Parse parameters
+        offset = 7
+        while offset < len(data):
+            if offset + 2 > len(data):
+                break
+            param_code = data[offset]
+            param_len = data[offset + 1]
+            if offset + 2 + param_len > len(data):
+                break
+            param_data = data[offset + 2 : offset + 2 + param_len]
+            if param_code == self.COTP_PARAM_PDU_SIZE:
+                if param_len == 1:
+                    self.pdu_size = 1 << param_data[0]
+                elif param_len == 2:
+                    self.pdu_size = struct.unpack(">H", param_data)[0]
+                logger.debug(f"Negotiated PDU size: {self.pdu_size}")
+            offset += 2 + param_len
+
+    async def _recv_exact(self, size: int) -> bytes:
+        """Receive exactly size bytes."""
+        if self._reader is None:
+            raise S7ConnectionError("Stream not initialized")
+        try:
+            return await asyncio.wait_for(
+                self._reader.readexactly(size), timeout=self.timeout,
+            )
+        except asyncio.IncompleteReadError:
+            self.connected = False
+            raise S7ConnectionError("Connection closed by peer")
+        except asyncio.TimeoutError:
+            self.connected = False
+            raise S7TimeoutError("Receive timeout")
+        except (OSError, ConnectionError) as e:
+            self.connected = False
+            raise S7ConnectionError(f"Receive error: {e}")
+
+    async def __aenter__(self) -> "AsyncISOTCPConnection":
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        await self.disconnect()
+
+
+class AsyncClient(ClientMixin):
+    """
+    Native async S7 client implementation.
+
+    Uses asyncio streams for non-blocking I/O. An internal asyncio.Lock
+    serializes each send+receive cycle so that concurrent coroutines
+    (e.g. via asyncio.gather) never interleave on the same TCP socket.
+
+    Examples:
+        >>> import snap7
+        >>> async with snap7.AsyncClient() as client:
+        ...     await client.connect("192.168.1.10", 0, 1)
+        ...     data = await client.db_read(1, 0, 4)
+    """
+
+    MAX_VARS = 20
+
+    def __init__(self) -> None:
+        self.connection: Optional[AsyncISOTCPConnection] = None
+        self.protocol = S7Protocol()
+        self.connected = False
+        self.host = ""
+        self.port = 102
+        self.rack = 0
+        self.slot = 0
+        self.pdu_length = 480
+
+        self.local_tsap = 0x0100
+        self.remote_tsap = 0x0102
+        self.connection_type = 1  # PG
+        self.session_password: Optional[str] = None
+
+        self._exec_time = 0
+        self._last_error = 0
+
+        self._lock = asyncio.Lock()
+
+        self._params = {
+            Parameter.RemotePort: 102,
+            Parameter.SendTimeout: 10,
+            Parameter.RecvTimeout: 3000,
+            Parameter.SrcRef: 256,
+            Parameter.DstRef: 0,
+            Parameter.SrcTSap: 256,
+            Parameter.PDURequest: 480,
+        }
+
+        logger.info("AsyncClient initialized (native async implementation)")
+
+    def _get_connection(self) -> AsyncISOTCPConnection:
+        """Get connection, raising if not connected."""
+        if self.connection is None:
+            raise S7ConnectionError("Not connected to PLC")
+        return self.connection
+
+    async def _send_receive(self, request: bytes, max_stale_retries: int = 3) -> dict[str, Any]:
+        """Send a request and receive/parse the response, holding the lock.
+
+        The lock ensures that concurrent coroutines never interleave
+        send/receive on the same TCP socket.
+
+        Unlike the sync client, we do NOT use protocol.validate_pdu_reference()
+        because the protocol's shared sequence counter can be incremented by
+        a concurrent coroutine between request building and lock acquisition.
+        Instead, we extract the expected sequence directly from the request
+        bytes (S7 header bytes 4-5).
+        """
+        conn = self._get_connection()
+
+        # Extract the sequence number we embedded in this request's S7 header.
+        # S7 header: 0x32 | pdu_type | reserved(2) | sequence(2) | ...
+        expected_seq = struct.unpack(">H", request[4:6])[0]
+
+        async with self._lock:
+            await conn.send_data(request)
+
+            for attempt in range(max_stale_retries + 1):
+                response_data = await conn.receive_data()
+                response = self.protocol.parse_response(response_data)
+
+                resp_seq = response.get("sequence", 0)
+                if resp_seq == expected_seq:
+                    return response
+
+                # Stale packet — response is for an older request
+                if attempt < max_stale_retries:
+                    logger.warning(
+                        f"Stale packet: expected seq {expected_seq}, got {resp_seq} "
+                        f"(attempt {attempt + 1}/{max_stale_retries}), retrying receive"
+                    )
+                    continue
+                raise S7ProtocolError(f"Max stale packet retries ({max_stale_retries}) exceeded")
+
+        raise S7ProtocolError("Failed to receive valid response")  # Should not reach here
+
+    async def connect(self, address: str, rack: int, slot: int, tcp_port: int = 102) -> "AsyncClient":
+        """Connect to S7 PLC.
+
+        Args:
+            address: PLC IP address
+            rack: Rack number
+            slot: Slot number
+            tcp_port: TCP port (default 102)
+
+        Returns:
+            Self for method chaining
+        """
+        self.host = address
+        self.port = tcp_port
+        self.rack = rack
+        self.slot = slot
+        self._params[Parameter.RemotePort] = tcp_port
+
+        self.remote_tsap = 0x0100 | (rack << 5) | slot
+
+        try:
+            start_time = time.time()
+
+            self.connection = AsyncISOTCPConnection(
+                host=address, port=tcp_port, local_tsap=self.local_tsap, remote_tsap=self.remote_tsap
+            )
+
+            await self.connection.connect()
+
+            await self._setup_communication()
+
+            self.connected = True
+            self._exec_time = int((time.time() - start_time) * 1000)
+            logger.info(f"Connected to {address}:{tcp_port} rack {rack} slot {slot}")
+
+        except Exception as e:
+            await self.disconnect()
+            if isinstance(e, S7Error):
+                raise
+            else:
+                raise S7ConnectionError(f"Connection failed: {e}")
+
+        return self
+
+    async def disconnect(self) -> int:
+        """Disconnect from S7 PLC.
+
+        Returns:
+            0 on success
+        """
+        if self.connection:
+            await self.connection.disconnect()
+            self.connection = None
+
+        self.connected = False
+        logger.info(f"Disconnected from {self.host}:{self.port}")
+        return 0
+
+    def get_connected(self) -> bool:
+        """Check if client is connected."""
+        return self.connected and self.connection is not None
+
+    # ---------------------------------------------------------------
+    # DB helpers
+    # ---------------------------------------------------------------
+
+    async def db_read(self, db_number: int, start: int, size: int) -> bytearray:
+        """Read data from DB.
+
+        Args:
+            db_number: DB number to read from
+            start: Start byte offset
+            size: Number of bytes to read
+
+        Returns:
+            Data read from DB
+        """
+        logger.debug(f"db_read: DB{db_number}, start={start}, size={size}")
+        return await self.read_area(Area.DB, db_number, start, size)
+
+    async def db_write(self, db_number: int, start: int, data: bytearray) -> int:
+        """Write data to DB.
+
+        Args:
+            db_number: DB number to write to
+            start: Start byte offset
+            data: Data to write
+
+        Returns:
+            0 on success
+        """
+        logger.debug(f"db_write: DB{db_number}, start={start}, size={len(data)}")
+        await self.write_area(Area.DB, db_number, start, data)
+        return 0
+
+    async def db_get(self, db_number: int, size: int = 0) -> bytearray:
+        """Get entire DB.
+
+        Args:
+            db_number: DB number to read
+            size: DB size in bytes. If 0, determined via get_block_info().
+
+        Returns:
+            Entire DB contents
+        """
+        if size <= 0:
+            block_info = await self.get_block_info(Block.DB, db_number)
+            size = block_info.MC7Size if block_info.MC7Size > 0 else 65536
+        return await self.db_read(db_number, 0, size)
+
+    async def db_fill(self, db_number: int, filler: int, size: int = 0) -> int:
+        """Fill a DB with a filler byte.
+
+        Args:
+            db_number: DB number to fill
+            filler: Byte value to fill with
+            size: DB size in bytes. If 0, determined via get_block_info().
+
+        Returns:
+            0 on success
+        """
+        if size <= 0:
+            block_info = await self.get_block_info(Block.DB, db_number)
+            size = block_info.MC7Size if block_info.MC7Size > 0 else 65536
+        data = bytearray([filler] * size)
+        return await self.db_write(db_number, 0, data)
+
+    # ---------------------------------------------------------------
+    # Core read / write
+    # ---------------------------------------------------------------
+
+    async def read_area(self, area: Area, db_number: int, start: int, size: int) -> bytearray:
+        """Read data from memory area.
+
+        Automatically splits into multiple requests if size exceeds PDU capacity.
+        """
+        start_time = time.time()
+        s7_area = self._map_area(area)
+
+        if area == Area.TM:
+            word_len = S7WordLen.TIMER
+        elif area == Area.CT:
+            word_len = S7WordLen.COUNTER
+        else:
+            word_len = S7WordLen.BYTE
+
+        max_chunk = self._max_read_size()
+        if size <= max_chunk:
+            request = self.protocol.build_read_request(
+                area=s7_area, db_number=db_number, start=start, word_len=word_len, count=size
+            )
+            response = await self._send_receive(request)
+            values = self.protocol.extract_read_data(response, word_len, size)
+            self._exec_time = int((time.time() - start_time) * 1000)
+            return bytearray(values)
+
+        result = bytearray()
+        offset = 0
+        remaining = size
+        while remaining > 0:
+            chunk_size = min(remaining, max_chunk)
+            request = self.protocol.build_read_request(
+                area=s7_area, db_number=db_number, start=start + offset, word_len=word_len, count=chunk_size
+            )
+            response = await self._send_receive(request)
+            values = self.protocol.extract_read_data(response, word_len, chunk_size)
+            result.extend(values)
+            offset += chunk_size
+            remaining -= chunk_size
+
+        self._exec_time = int((time.time() - start_time) * 1000)
+        return result
+
+    async def write_area(self, area: Area, db_number: int, start: int, data: bytearray) -> int:
+        """Write data to memory area.
+
+        Automatically splits into multiple requests if data exceeds PDU capacity.
+        """
+        start_time = time.time()
+        s7_area = self._map_area(area)
+
+        if area == Area.TM:
+            word_len = S7WordLen.TIMER
+        elif area == Area.CT:
+            word_len = S7WordLen.COUNTER
+        else:
+            word_len = S7WordLen.BYTE
+
+        max_chunk = self._max_write_size()
+        if len(data) <= max_chunk:
+            request = self.protocol.build_write_request(
+                area=s7_area, db_number=db_number, start=start, word_len=word_len, data=bytes(data)
+            )
+            response = await self._send_receive(request)
+            self.protocol.check_write_response(response)
+            self._exec_time = int((time.time() - start_time) * 1000)
+            return 0
+
+        offset = 0
+        remaining = len(data)
+        while remaining > 0:
+            chunk_size = min(remaining, max_chunk)
+            chunk_data = data[offset : offset + chunk_size]
+            request = self.protocol.build_write_request(
+                area=s7_area, db_number=db_number, start=start + offset, word_len=word_len, data=bytes(chunk_data)
+            )
+            response = await self._send_receive(request)
+            self.protocol.check_write_response(response)
+            offset += chunk_size
+            remaining -= chunk_size
+
+        self._exec_time = int((time.time() - start_time) * 1000)
+        return 0
+
+    async def read_multi_vars(self, items: List[dict[str, Any]]) -> Tuple[int, list[bytearray]]:
+        """Read multiple variables (sequentially, one read_area per item).
+
+        Args:
+            items: List of item dicts with keys: area, db_number, start, size
+
+        Returns:
+            Tuple of (result_code, list_of_bytearrays)
+        """
+        if not items:
+            return (0, [])
+        if len(items) > self.MAX_VARS:
+            raise ValueError(f"Too many items: {len(items)} exceeds MAX_VARS ({self.MAX_VARS})")
+
+        results: list[bytearray] = []
+        for item in items:
+            area = item["area"]
+            db_number = item.get("db_number", 0)
+            start = item["start"]
+            size = item["size"]
+            data = await self.read_area(area, db_number, start, size)
+            results.append(data)
+        return (0, results)
+
+    async def write_multi_vars(self, items: List[dict[str, Any]]) -> int:
+        """Write multiple variables (sequentially, one write_area per item).
+
+        Args:
+            items: List of item dicts with keys: area, db_number, start, data
+
+        Returns:
+            0 on success
+        """
+        if not items:
+            return 0
+        if len(items) > self.MAX_VARS:
+            raise ValueError(f"Too many items: {len(items)} exceeds MAX_VARS ({self.MAX_VARS})")
+
+        for item in items:
+            area = item["area"]
+            db_number = item.get("db_number", 0)
+            start = item["start"]
+            data = item["data"]
+            await self.write_area(area, db_number, start, data)
+        return 0
+
+    # ---------------------------------------------------------------
+    # Block operations
+    # ---------------------------------------------------------------
+
+    async def list_blocks(self) -> BlocksList:
+        """List blocks available in PLC."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        request = self.protocol.build_list_blocks_request()
+        response = await self._send_receive(request)
+
+        data_info = response.get("data", {})
+        return_code = data_info.get("return_code", 0xFF) if isinstance(data_info, dict) else 0xFF
+        if return_code != 0xFF:
+            desc = get_return_code_description(return_code)
+            raise S7ProtocolError(f"List blocks failed: {desc} (0x{return_code:02x})")
+
+        counts = self.protocol.parse_list_blocks_response(response)
+
+        block_list = BlocksList()
+        block_list.OBCount = counts.get("OBCount", 0)
+        block_list.FBCount = counts.get("FBCount", 0)
+        block_list.FCCount = counts.get("FCCount", 0)
+        block_list.SFBCount = counts.get("SFBCount", 0)
+        block_list.SFCCount = counts.get("SFCCount", 0)
+        block_list.DBCount = counts.get("DBCount", 0)
+        block_list.SDBCount = counts.get("SDBCount", 0)
+
+        return block_list
+
+    async def list_blocks_of_type(self, block_type: Block, max_count: int) -> List[int]:
+        """List blocks of a specific type.
+
+        Supports multi-packet responses.
+        """
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        conn = self._get_connection()
+
+        block_type_codes = {
+            Block.OB: 0x38,
+            Block.DB: 0x41,
+            Block.SDB: 0x42,
+            Block.FC: 0x43,
+            Block.SFC: 0x44,
+            Block.FB: 0x45,
+            Block.SFB: 0x46,
+        }
+        type_code = block_type_codes.get(block_type, 0x41)
+
+        request = self.protocol.build_list_blocks_of_type_request(type_code)
+        response = await self._send_receive(request)
+
+        data_info = response.get("data", {})
+        return_code = data_info.get("return_code", 0xFF) if isinstance(data_info, dict) else 0xFF
+        if return_code != 0xFF:
+            desc = get_return_code_description(return_code)
+            raise S7ProtocolError(f"List blocks of type failed: {desc} (0x{return_code:02x})")
+
+        accumulated_data = bytearray(data_info.get("data", b"") if isinstance(data_info, dict) else b"")
+
+        params = response.get("parameters", {})
+        last_data_unit = params.get("last_data_unit", 0x00) if isinstance(params, dict) else 0x00
+        sequence_number = params.get("sequence_number", 0) if isinstance(params, dict) else 0
+        group = params.get("group", 0x03) if isinstance(params, dict) else 0x03
+        subfunction = params.get("subfunction", 0x02) if isinstance(params, dict) else 0x02
+
+        for _ in range(100):
+            if last_data_unit == 0x00:
+                break
+
+            async with self._lock:
+                followup = self.protocol.build_userdata_followup_request(group, subfunction, sequence_number)
+                await conn.send_data(followup)
+                response_data = await conn.receive_data()
+
+            response = self.protocol.parse_response(response_data)
+
+            data_info = response.get("data", {})
+            return_code = data_info.get("return_code", 0xFF) if isinstance(data_info, dict) else 0xFF
+            if return_code != 0xFF:
+                break
+
+            accumulated_data.extend(data_info.get("data", b"") if isinstance(data_info, dict) else b"")
+
+            params = response.get("parameters", {})
+            last_data_unit = params.get("last_data_unit", 0x00) if isinstance(params, dict) else 0x00
+            sequence_number = params.get("sequence_number", 0) if isinstance(params, dict) else 0
+
+        combined_response: dict[str, Any] = {"data": {"data": bytes(accumulated_data)}}
+        block_numbers = self.protocol.parse_list_blocks_of_type_response(combined_response)
+
+        return block_numbers[:max_count]
+
+    async def get_block_info(self, block_type: Block, db_number: int) -> TS7BlockInfo:
+        """Get block information."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        block_type_map = {
+            Block.OB: 0x38,
+            Block.DB: 0x41,
+            Block.SDB: 0x42,
+            Block.FC: 0x43,
+            Block.SFC: 0x44,
+            Block.FB: 0x45,
+            Block.SFB: 0x46,
+        }
+        type_code = block_type_map.get(block_type, 0x41)
+
+        request = self.protocol.build_get_block_info_request(type_code, db_number)
+        response = await self._send_receive(request)
+
+        data_info = response.get("data", {})
+        return_code = data_info.get("return_code", 0xFF) if isinstance(data_info, dict) else 0xFF
+        if return_code != 0xFF:
+            desc = get_return_code_description(return_code)
+            raise S7ProtocolError(f"Get block info failed: {desc} (0x{return_code:02x})")
+
+        info = self.protocol.parse_get_block_info_response(response)
+
+        block_info = TS7BlockInfo()
+        block_info.BlkType = info["block_type"]
+        block_info.BlkNumber = info["block_number"]
+        block_info.BlkLang = info["block_lang"]
+        block_info.BlkFlags = info["block_flags"]
+        block_info.MC7Size = info["mc7_size"]
+        block_info.LoadSize = info["load_size"]
+        block_info.LocalData = info["local_data"]
+        block_info.SBBLength = info["sbb_length"]
+        block_info.CheckSum = info["checksum"]
+        block_info.Version = info["version"]
+
+        if info["code_date"]:
+            block_info.CodeDate = info["code_date"][:10]
+        if info["intf_date"]:
+            block_info.IntfDate = info["intf_date"][:10]
+        if info["author"]:
+            block_info.Author = info["author"][:8]
+        if info["family"]:
+            block_info.Family = info["family"][:8]
+        if info["header"]:
+            block_info.Header = info["header"][:8]
+
+        return block_info
+
+    # ---------------------------------------------------------------
+    # CPU info / state
+    # ---------------------------------------------------------------
+
+    async def get_cpu_info(self) -> S7CpuInfo:
+        """Get CPU information."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        szl = await self.read_szl(0x001C, 0)
+
+        cpu_info = S7CpuInfo()
+        data = bytes(szl.Data[: szl.Header.LengthDR])
+
+        if len(data) >= 32:
+            cpu_info.ModuleTypeName = data[0:32].rstrip(b"\x00")
+        if len(data) >= 56:
+            cpu_info.SerialNumber = data[32:56].rstrip(b"\x00")
+        if len(data) >= 80:
+            cpu_info.ASName = data[56:80].rstrip(b"\x00")
+        if len(data) >= 106:
+            cpu_info.Copyright = data[80:106].rstrip(b"\x00")
+        if len(data) >= 130:
+            cpu_info.ModuleName = data[106:130].rstrip(b"\x00")
+
+        return cpu_info
+
+    async def get_cpu_state(self) -> str:
+        """Get CPU state (running/stopped)."""
+        request = self.protocol.build_cpu_state_request()
+        response = await self._send_receive(request)
+        return self.protocol.extract_cpu_state(response)
+
+    # ---------------------------------------------------------------
+    # Upload / Download / Delete
+    # ---------------------------------------------------------------
+
+    async def upload(self, block_num: int) -> bytearray:
+        """Upload block from PLC (3-step: START_UPLOAD, UPLOAD, END_UPLOAD)."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        block_type = 0x41  # DB
+
+        request = self.protocol.build_start_upload_request(block_type, block_num)
+        response = await self._send_receive(request)
+
+        upload_info = self.protocol.parse_start_upload_response(response)
+        upload_id = upload_info.get("upload_id", 1)
+
+        request = self.protocol.build_upload_request(upload_id)
+        response = await self._send_receive(request)
+
+        block_data = self.protocol.parse_upload_response(response)
+
+        request = self.protocol.build_end_upload_request(upload_id)
+        response = await self._send_receive(request)
+
+        logger.info(f"Uploaded {len(block_data)} bytes from block {block_num}")
+        return bytearray(block_data)
+
+    async def download(self, data: bytearray, block_num: int = -1) -> int:
+        """Download block to PLC."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        conn = self._get_connection()
+        block_type = 0x41  # DB
+
+        if block_num == -1:
+            if len(data) >= 8:
+                block_num = struct.unpack(">H", data[6:8])[0]
+            else:
+                block_num = 1
+
+        # Step 1: Request download
+        request = self.protocol.build_download_request(block_type, block_num, bytes(data))
+        await self._send_receive(request)
+
+        # Step 2: Download block (send data)
+        param_data = struct.pack(">BBB", 0x1B, 0x01, 0x00)
+        data_section = struct.pack(">HH", len(data), 0x00FB) + bytes(data)
+        header = struct.pack(
+            ">BBHHHH",
+            0x32, 0x01, 0x0000,
+            self.protocol._next_sequence(),
+            len(param_data), len(data_section),
+        )
+
+        async with self._lock:
+            await conn.send_data(header + param_data + data_section)
+            response_data = await conn.receive_data()
+        self.protocol.parse_response(response_data)
+
+        # Step 3: Download ended
+        param_data = struct.pack(">B", 0x1C)
+        header = struct.pack(
+            ">BBHHHH",
+            0x32, 0x01, 0x0000,
+            self.protocol._next_sequence(),
+            len(param_data), 0x0000,
+        )
+
+        async with self._lock:
+            await conn.send_data(header + param_data)
+            response_data = await conn.receive_data()
+        self.protocol.parse_response(response_data)
+
+        logger.info(f"Downloaded {len(data)} bytes to block {block_num}")
+        return 0
+
+    async def delete(self, block_type: Block, block_num: int) -> int:
+        """Delete a block from PLC."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        block_type_map = {
+            Block.OB: 0x38, Block.DB: 0x41, Block.SDB: 0x42,
+            Block.FC: 0x43, Block.SFC: 0x44, Block.FB: 0x45, Block.SFB: 0x46,
+        }
+        type_code = block_type_map.get(block_type, 0x41)
+
+        request = self.protocol.build_delete_block_request(type_code, block_num)
+        response = await self._send_receive(request)
+        self.protocol.check_control_response(response)
+
+        logger.info(f"Deleted block {block_type.name} {block_num}")
+        return 0
+
+    async def full_upload(self, block_type: Block, block_num: int) -> Tuple[bytearray, int]:
+        """Upload a block from PLC with header and footer info."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        block_type_map = {
+            Block.OB: 0x38, Block.DB: 0x41, Block.SDB: 0x42,
+            Block.FC: 0x43, Block.SFC: 0x44, Block.FB: 0x45, Block.SFB: 0x46,
+        }
+        type_code = block_type_map.get(block_type, 0x41)
+
+        request = self.protocol.build_start_upload_request(type_code, block_num)
+        response = await self._send_receive(request)
+
+        upload_info = self.protocol.parse_start_upload_response(response)
+        upload_id = upload_info.get("upload_id", 1)
+
+        request = self.protocol.build_upload_request(upload_id)
+        response = await self._send_receive(request)
+        block_data = self.protocol.parse_upload_response(response)
+
+        request = self.protocol.build_end_upload_request(upload_id)
+        response = await self._send_receive(request)
+
+        block_header = struct.pack(
+            ">BBHBBBBHH",
+            0x70, block_type.value, block_num,
+            0x00, 0x00, 0x00, 0x00,
+            len(block_data) + 14, len(block_data),
+        )
+        block_footer = b"\x00" * 4
+        full_block = bytearray(block_header + block_data + block_footer)
+
+        logger.info(f"Full upload of block {block_type.name} {block_num}: {len(full_block)} bytes")
+        return full_block, len(full_block)
+
+    # ---------------------------------------------------------------
+    # PLC control
+    # ---------------------------------------------------------------
+
+    async def plc_stop(self) -> int:
+        """Stop PLC CPU."""
+        request = self.protocol.build_plc_control_request("stop")
+        response = await self._send_receive(request)
+        self.protocol.check_control_response(response)
+        return 0
+
+    async def plc_hot_start(self) -> int:
+        """Hot start PLC CPU."""
+        request = self.protocol.build_plc_control_request("hot_start")
+        response = await self._send_receive(request)
+        self.protocol.check_control_response(response)
+        return 0
+
+    async def plc_cold_start(self) -> int:
+        """Cold start PLC CPU."""
+        request = self.protocol.build_plc_control_request("cold_start")
+        response = await self._send_receive(request)
+        self.protocol.check_control_response(response)
+        return 0
+
+    # ---------------------------------------------------------------
+    # Date / time
+    # ---------------------------------------------------------------
+
+    async def get_plc_datetime(self) -> datetime:
+        """Get PLC date/time."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        request = self.protocol.build_get_clock_request()
+        response = await self._send_receive(request)
+        return self.protocol.parse_get_clock_response(response)
+
+    async def set_plc_datetime(self, dt: datetime) -> int:
+        """Set PLC date/time."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        request = self.protocol.build_set_clock_request(dt)
+        await self._send_receive(request)
+        logger.info(f"Set PLC datetime to {dt}")
+        return 0
+
+    async def set_plc_system_datetime(self) -> int:
+        """Set PLC time to system time."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        current_time = datetime.now()
+        await self.set_plc_datetime(current_time)
+        logger.info(f"Set PLC time to current system time: {current_time}")
+        return 0
+
+    # ---------------------------------------------------------------
+    # SZL
+    # ---------------------------------------------------------------
+
+    async def read_szl(self, ssl_id: int, index: int = 0) -> S7SZL:
+        """Read SZL (System Status List).
+
+        Supports multi-packet responses.
+        """
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        conn = self._get_connection()
+
+        request = self.protocol.build_read_szl_request(ssl_id, index)
+        response = await self._send_receive(request)
+
+        data_info = response.get("data", {})
+        return_code = data_info.get("return_code", 0xFF) if isinstance(data_info, dict) else 0xFF
+        if return_code != 0xFF:
+            desc = get_return_code_description(return_code)
+            raise RuntimeError(f"Read SZL failed: {desc} (0x{return_code:02x})")
+
+        szl_result = self.protocol.parse_read_szl_response(response)
+        accumulated_data = bytearray(szl_result["data"])
+
+        params = response.get("parameters", {})
+        last_data_unit = params.get("last_data_unit", 0x00) if isinstance(params, dict) else 0x00
+        sequence_number = params.get("sequence_number", 0) if isinstance(params, dict) else 0
+        group = params.get("group", 0x04) if isinstance(params, dict) else 0x04
+        subfunction = params.get("subfunction", 0x01) if isinstance(params, dict) else 0x01
+
+        for _ in range(100):
+            if last_data_unit == 0x00:
+                break
+
+            async with self._lock:
+                followup = self.protocol.build_userdata_followup_request(group, subfunction, sequence_number)
+                await conn.send_data(followup)
+                response_data = await conn.receive_data()
+
+            response = self.protocol.parse_response(response_data)
+
+            data_info = response.get("data", {})
+            return_code = data_info.get("return_code", 0xFF) if isinstance(data_info, dict) else 0xFF
+            if return_code != 0xFF:
+                break
+
+            fragment = self.protocol.parse_read_szl_response(response, first_fragment=False)
+            accumulated_data.extend(fragment["data"])
+
+            params = response.get("parameters", {})
+            last_data_unit = params.get("last_data_unit", 0x00) if isinstance(params, dict) else 0x00
+            sequence_number = params.get("sequence_number", 0) if isinstance(params, dict) else 0
+
+        szl = S7SZL()
+        szl.Header.LengthDR = len(accumulated_data)
+        szl.Header.NDR = 1
+
+        for i, b in enumerate(accumulated_data[: min(len(accumulated_data), len(szl.Data))]):
+            szl.Data[i] = b
+
+        return szl
+
+    async def read_szl_list(self) -> bytes:
+        """Read list of available SZL IDs."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        szl = await self.read_szl(0x0000, 0)
+        return bytes(szl.Data[: szl.Header.LengthDR])
+
+    # ---------------------------------------------------------------
+    # Misc info
+    # ---------------------------------------------------------------
+
+    async def get_cp_info(self) -> S7CpInfo:
+        """Get CP (Communication Processor) information."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        szl = await self.read_szl(0x0131, 0)
+
+        cp_info = S7CpInfo()
+        data = bytearray(b & 0xFF for b in szl.Data[: szl.Header.LengthDR])
+
+        if len(data) >= 2:
+            cp_info.MaxPduLength = struct.unpack(">H", data[0:2])[0]
+        if len(data) >= 4:
+            cp_info.MaxConnections = struct.unpack(">H", data[2:4])[0]
+        if len(data) >= 6:
+            cp_info.MaxMpiRate = struct.unpack(">H", data[4:6])[0]
+        if len(data) >= 8:
+            cp_info.MaxBusRate = struct.unpack(">H", data[6:8])[0]
+
+        return cp_info
+
+    async def get_order_code(self) -> S7OrderCode:
+        """Get order code."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        szl = await self.read_szl(0x0011, 0)
+
+        order_code = S7OrderCode()
+        data = bytes(szl.Data[: szl.Header.LengthDR])
+
+        if len(data) >= 20:
+            order_code.OrderCode = data[0:20].rstrip(b"\x00")
+        if len(data) >= 21:
+            order_code.V1 = data[20]
+        if len(data) >= 22:
+            order_code.V2 = data[21]
+        if len(data) >= 23:
+            order_code.V3 = data[22]
+
+        return order_code
+
+    async def get_protection(self) -> S7Protection:
+        """Get protection settings."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        szl = await self.read_szl(0x0232, 0)
+
+        protection = S7Protection()
+        data = bytes(szl.Data[: szl.Header.LengthDR])
+
+        if len(data) >= 2:
+            protection.sch_schal = struct.unpack(">H", data[0:2])[0]
+        if len(data) >= 4:
+            protection.sch_par = struct.unpack(">H", data[2:4])[0]
+        if len(data) >= 6:
+            protection.sch_rel = struct.unpack(">H", data[4:6])[0]
+        if len(data) >= 8:
+            protection.bart_sch = struct.unpack(">H", data[6:8])[0]
+        if len(data) >= 10:
+            protection.anl_sch = struct.unpack(">H", data[8:10])[0]
+
+        return protection
+
+    async def compress(self, timeout: int) -> int:
+        """Compress PLC memory."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        request = self.protocol.build_compress_request()
+        response = await self._send_receive(request)
+        self.protocol.check_control_response(response)
+        logger.info(f"Compress PLC memory completed (timeout={timeout}ms)")
+        return 0
+
+    async def copy_ram_to_rom(self, timeout: int = 0) -> int:
+        """Copy RAM to ROM."""
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        request = self.protocol.build_copy_ram_to_rom_request()
+        response = await self._send_receive(request)
+        self.protocol.check_control_response(response)
+        logger.info(f"Copy RAM to ROM completed (timeout={timeout}ms)")
+        return 0
+
+    async def iso_exchange_buffer(self, data: bytearray) -> bytearray:
+        """Exchange raw ISO PDU."""
+        conn = self._get_connection()
+
+        async with self._lock:
+            await conn.send_data(bytes(data))
+            response = await conn.receive_data()
+        return bytearray(response)
+
+    # ---------------------------------------------------------------
+    # Convenience memory area methods
+    # ---------------------------------------------------------------
+
+    async def ab_read(self, start: int, size: int) -> bytearray:
+        """Read from process output area (PA)."""
+        return await self.read_area(Area.PA, 0, start, size)
+
+    async def ab_write(self, start: int, data: bytearray) -> int:
+        """Write to process output area (PA)."""
+        return await self.write_area(Area.PA, 0, start, data)
+
+    async def eb_read(self, start: int, size: int) -> bytearray:
+        """Read from process input area (PE)."""
+        return await self.read_area(Area.PE, 0, start, size)
+
+    async def eb_write(self, start: int, size: int, data: bytearray) -> int:
+        """Write to process input area (PE)."""
+        return await self.write_area(Area.PE, 0, start, data[:size])
+
+    async def mb_read(self, start: int, size: int) -> bytearray:
+        """Read from marker/flag area (MK)."""
+        return await self.read_area(Area.MK, 0, start, size)
+
+    async def mb_write(self, start: int, size: int, data: bytearray) -> int:
+        """Write to marker/flag area (MK)."""
+        return await self.write_area(Area.MK, 0, start, data[:size])
+
+    async def tm_read(self, start: int, size: int) -> bytearray:
+        """Read from timer area (TM)."""
+        return await self.read_area(Area.TM, 0, start, size)
+
+    async def tm_write(self, start: int, size: int, data: bytearray) -> int:
+        """Write to timer area (TM)."""
+        if len(data) != size * 2:
+            raise ValueError(f"Data length {len(data)} doesn't match size {size * 2}")
+        try:
+            return await self.write_area(Area.TM, 0, start, data)
+        except S7ProtocolError as e:
+            raise RuntimeError(str(e)) from e
+
+    async def ct_read(self, start: int, size: int) -> bytearray:
+        """Read from counter area (CT)."""
+        return await self.read_area(Area.CT, 0, start, size)
+
+    async def ct_write(self, start: int, size: int, data: bytearray) -> int:
+        """Write to counter area (CT)."""
+        if len(data) != size * 2:
+            raise ValueError(f"Data length {len(data)} doesn't match size {size * 2}")
+        return await self.write_area(Area.CT, 0, start, data)
+
+    # ---------------------------------------------------------------
+    # Internal helpers
+    # ---------------------------------------------------------------
+
+    async def _setup_communication(self) -> None:
+        """Setup communication and negotiate PDU length."""
+        request = self.protocol.build_setup_communication_request(
+            max_amq_caller=1, max_amq_callee=1, pdu_length=self.pdu_length
+        )
+        response = await self._send_receive(request)
+
+        if response.get("parameters"):
+            params = response["parameters"]
+            if "pdu_length" in params:
+                self.pdu_length = params["pdu_length"]
+                self._params[Parameter.PDURequest] = self.pdu_length
+                logger.info(f"Negotiated PDU length: {self.pdu_length}")
+
+    # ---------------------------------------------------------------
+    # Context manager
+    # ---------------------------------------------------------------
+
+    async def __aenter__(self) -> "AsyncClient":
+        """Async context manager entry."""
+        return self
+
+    async def __aexit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        """Async context manager exit."""
+        await self.disconnect()

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -17,8 +17,9 @@ from ctypes import (
 
 from .connection import ISOTCPConnection
 from .s7protocol import S7Protocol, get_return_code_description
-from .datatypes import S7Area, S7WordLen
+from .datatypes import S7WordLen
 from .error import S7Error, S7ConnectionError, S7ProtocolError, S7StalePacketError
+from .client_base import ClientMixin
 
 from .type import (
     Area,
@@ -40,7 +41,7 @@ from .type import (
 logger = logging.getLogger(__name__)
 
 
-class Client:
+class Client(ClientMixin):
     """
     Pure Python S7 client implementation.
 
@@ -784,36 +785,6 @@ class Client:
 
         return block_info
 
-    def get_pg_block_info(self, data: bytearray) -> TS7BlockInfo:
-        """
-        Get block info from raw block data.
-
-        Args:
-            data: Raw block data
-
-        Returns:
-            Block information structure
-        """
-        block_info = TS7BlockInfo()
-
-        if len(data) >= 36:
-            # Parse block header from raw data - S7 block format
-            block_info.BlkType = data[5]
-            block_info.BlkNumber = struct.unpack(">H", data[6:8])[0]
-            block_info.BlkLang = data[4]
-            block_info.MC7Size = struct.unpack(">I", data[8:12])[0]
-            block_info.LoadSize = struct.unpack(">I", data[12:16])[0]
-            # SBBLength is at offset 28-31
-            block_info.SBBLength = struct.unpack(">I", data[28:32])[0]
-            block_info.CheckSum = struct.unpack(">H", data[32:34])[0]
-            block_info.Version = data[34]
-
-            # Parse dates from block header - fixed dates that match test expectations
-            block_info.CodeDate = b"2019/06/27"
-            block_info.IntfDate = b"2019/06/27"
-
-        return block_info
-
     def upload(self, block_num: int) -> bytearray:
         """
         Upload block from PLC.
@@ -1073,15 +1044,6 @@ class Client:
         self.protocol.check_control_response(response)
         return 0
 
-    def get_pdu_length(self) -> int:
-        """
-        Get negotiated PDU length.
-
-        Returns:
-            PDU length in bytes
-        """
-        return self.pdu_length
-
     def get_plc_datetime(self) -> datetime:
         """
         Get PLC date/time.
@@ -1278,24 +1240,6 @@ class Client:
             protection.anl_sch = struct.unpack(">H", data[8:10])[0]
 
         return protection
-
-    def get_exec_time(self) -> int:
-        """
-        Get last operation execution time.
-
-        Returns:
-            Execution time in milliseconds
-        """
-        return self._exec_time
-
-    def get_last_error(self) -> int:
-        """
-        Get last error code.
-
-        Returns:
-            Last error code
-        """
-        return self._last_error
 
     def read_szl(self, ssl_id: int, index: int = 0) -> S7SZL:
         """
@@ -1744,127 +1688,6 @@ class Client:
         self._async_callback = callback
         return 0
 
-    def error_text(self, error_code: int) -> str:
-        """Get error text for error code.
-
-        Args:
-            error_code: Error code to look up
-
-        Returns:
-            Human-readable error text
-        """
-        error_texts = {
-            0: "OK",
-            0x0001: "Invalid resource",
-            0x0002: "Invalid handle",
-            0x0003: "Not connected",
-            0x0004: "Connection error",
-            0x0005: "Data error",
-            0x0006: "Timeout",
-            0x0007: "Function not supported",
-            0x0008: "Invalid PDU size",
-            0x0009: "Invalid PLC answer",
-            0x000A: "Invalid CPU state",
-            0x01E00000: "CPU : Invalid password",
-            0x00D00000: "CPU : Invalid value supplied",
-            0x02600000: "CLI : Cannot change this param now",
-        }
-        return error_texts.get(error_code, f"Unknown error: {error_code}")
-
-    def set_connection_params(self, address: str, local_tsap: int, remote_tsap: int) -> None:
-        """Set connection parameters.
-
-        Args:
-            address: PLC IP address
-            local_tsap: Local TSAP
-            remote_tsap: Remote TSAP
-        """
-        self.address = address
-        self.local_tsap = local_tsap
-        self.remote_tsap = remote_tsap
-        logger.debug(f"Connection params set: {address}, TSAP {local_tsap:04x}/{remote_tsap:04x}")
-
-    def set_connection_type(self, connection_type: int) -> None:
-        """Set connection type.
-
-        Args:
-            connection_type: Connection type (1=PG, 2=OP, 3=S7Basic)
-        """
-        self.connection_type = connection_type
-        logger.debug(f"Connection type set to {connection_type}")
-
-    def set_session_password(self, password: str) -> int:
-        """Set session password.
-
-        Args:
-            password: Session password
-
-        Returns:
-            0 on success
-        """
-        self.session_password = password
-        logger.debug("Session password set")
-        return 0
-
-    def clear_session_password(self) -> int:
-        """Clear session password.
-
-        Returns:
-            0 on success
-        """
-        self.session_password = None
-        logger.debug("Session password cleared")
-        return 0
-
-    def get_param(self, param: Parameter) -> int:
-        """Get client parameter.
-
-        Args:
-            param: Parameter number
-
-        Returns:
-            Parameter value
-        """
-        # Non-client parameters raise exception
-        non_client = [
-            Parameter.LocalPort,
-            Parameter.WorkInterval,
-            Parameter.MaxClients,
-            Parameter.BSendTimeout,
-            Parameter.BRecvTimeout,
-            Parameter.RecoveryTime,
-            Parameter.KeepAliveTime,
-        ]
-        if param in non_client:
-            raise RuntimeError(f"Parameter {param} not valid for client")
-
-        # Use actual values for TSAP parameters
-        if param == Parameter.SrcTSap:
-            return self.local_tsap
-
-        return self._params.get(param, 0)
-
-    def set_param(self, param: Parameter, value: int) -> int:
-        """Set client parameter.
-
-        Args:
-            param: Parameter number
-            value: Parameter value
-
-        Returns:
-            0 on success
-        """
-        # RemotePort cannot be changed while connected
-        if param == Parameter.RemotePort and self.connected:
-            raise RuntimeError("Cannot change RemotePort while connected")
-
-        if param == Parameter.PDURequest:
-            self.pdu_length = value
-
-        self._params[param] = value
-        logger.debug(f"Set param {param}={value}")
-        return 0
-
     def _setup_communication(self) -> None:
         """Setup communication and negotiate PDU length."""
         request = self.protocol.build_setup_communication_request(max_amq_caller=1, max_amq_callee=1, pdu_length=self.pdu_length)
@@ -1877,38 +1700,6 @@ class Client:
                 self.pdu_length = params["pdu_length"]
                 self._params[Parameter.PDURequest] = self.pdu_length
                 logger.info(f"Negotiated PDU length: {self.pdu_length}")
-
-    def _max_read_size(self) -> int:
-        """Maximum payload bytes for a single read request.
-
-        Calculated as PDU length minus overhead:
-        12 bytes S7 header + 2 bytes param + 4 bytes data header = 18 bytes.
-        """
-        return self.pdu_length - 18
-
-    def _max_write_size(self) -> int:
-        """Maximum payload bytes for a single write request.
-
-        Calculated as PDU length minus overhead:
-        12 bytes S7 header + 14 bytes param + 4 bytes data header + 5 bytes padding = 35 bytes.
-        """
-        return self.pdu_length - 35
-
-    def _map_area(self, area: Area) -> S7Area:
-        """Map library area enum to native S7 area."""
-        area_mapping = {
-            Area.PE: S7Area.PE,
-            Area.PA: S7Area.PA,
-            Area.MK: S7Area.MK,
-            Area.DB: S7Area.DB,
-            Area.CT: S7Area.CT,
-            Area.TM: S7Area.TM,
-        }
-
-        if area not in area_mapping:
-            raise S7ProtocolError(f"Unsupported area: {area}")
-
-        return area_mapping[area]
 
     def __enter__(self) -> "Client":
         """Context manager entry."""

--- a/snap7/client_base.py
+++ b/snap7/client_base.py
@@ -1,0 +1,252 @@
+"""
+Shared base for the sync Client and async AsyncClient.
+
+Contains pure-computation methods (no I/O) that are identical between
+the two implementations.
+"""
+
+import logging
+import struct
+from typing import Optional
+
+from .datatypes import S7Area
+from .error import S7ProtocolError
+
+from .type import (
+    Area,
+    TS7BlockInfo,
+    Parameter,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ClientMixin:
+    """Methods shared between Client and AsyncClient.
+
+    Every method here is pure computation — no socket or asyncio I/O.
+    Both Client and AsyncClient inherit from this mixin so the logic
+    lives in one place.
+
+    Subclasses must provide the following attributes (set in __init__):
+        host, local_tsap, remote_tsap, connection_type, session_password,
+        pdu_length, connected, _exec_time, _last_error, _params
+    """
+
+    # Declared for type checkers — concrete values set by subclass __init__
+    host: str
+    local_tsap: int
+    remote_tsap: int
+    connection_type: int
+    session_password: Optional[str]
+    pdu_length: int
+    connected: bool
+    _exec_time: int
+    _last_error: int
+    _params: dict
+
+    def get_pdu_length(self) -> int:
+        """Get negotiated PDU length.
+
+        Returns:
+            PDU length in bytes
+        """
+        return self.pdu_length
+
+    def get_exec_time(self) -> int:
+        """Get last operation execution time.
+
+        Returns:
+            Execution time in milliseconds
+        """
+        return self._exec_time
+
+    def get_last_error(self) -> int:
+        """Get last error code.
+
+        Returns:
+            Last error code
+        """
+        return self._last_error
+
+    def error_text(self, error_code: int) -> str:
+        """Get error text for error code.
+
+        Args:
+            error_code: Error code to look up
+
+        Returns:
+            Human-readable error text
+        """
+        error_texts = {
+            0: "OK",
+            0x0001: "Invalid resource",
+            0x0002: "Invalid handle",
+            0x0003: "Not connected",
+            0x0004: "Connection error",
+            0x0005: "Data error",
+            0x0006: "Timeout",
+            0x0007: "Function not supported",
+            0x0008: "Invalid PDU size",
+            0x0009: "Invalid PLC answer",
+            0x000A: "Invalid CPU state",
+            0x01E00000: "CPU : Invalid password",
+            0x00D00000: "CPU : Invalid value supplied",
+            0x02600000: "CLI : Cannot change this param now",
+        }
+        return error_texts.get(error_code, f"Unknown error: {error_code}")
+
+    def get_pg_block_info(self, data: bytearray) -> TS7BlockInfo:
+        """Get block info from raw block data.
+
+        Args:
+            data: Raw block data
+
+        Returns:
+            Block information structure
+        """
+        block_info = TS7BlockInfo()
+
+        if len(data) >= 36:
+            # Parse block header from raw data - S7 block format
+            block_info.BlkType = data[5]
+            block_info.BlkNumber = struct.unpack(">H", data[6:8])[0]
+            block_info.BlkLang = data[4]
+            block_info.MC7Size = struct.unpack(">I", data[8:12])[0]
+            block_info.LoadSize = struct.unpack(">I", data[12:16])[0]
+            # SBBLength is at offset 28-31
+            block_info.SBBLength = struct.unpack(">I", data[28:32])[0]
+            block_info.CheckSum = struct.unpack(">H", data[32:34])[0]
+            block_info.Version = data[34]
+
+            # Parse dates from block header - fixed dates that match test expectations
+            block_info.CodeDate = b"2019/06/27"
+            block_info.IntfDate = b"2019/06/27"
+
+        return block_info
+
+    def set_connection_params(self, address: str, local_tsap: int, remote_tsap: int) -> None:
+        """Set connection parameters.
+
+        Args:
+            address: PLC IP address
+            local_tsap: Local TSAP
+            remote_tsap: Remote TSAP
+        """
+        self.host = address
+        self.local_tsap = local_tsap
+        self.remote_tsap = remote_tsap
+        logger.debug(f"Connection params set: {address}, TSAP {local_tsap:04x}/{remote_tsap:04x}")
+
+    def set_connection_type(self, connection_type: int) -> None:
+        """Set connection type.
+
+        Args:
+            connection_type: Connection type (1=PG, 2=OP, 3=S7Basic)
+        """
+        self.connection_type = connection_type
+        logger.debug(f"Connection type set to {connection_type}")
+
+    def set_session_password(self, password: str) -> int:
+        """Set session password.
+
+        Args:
+            password: Session password
+
+        Returns:
+            0 on success
+        """
+        self.session_password = password
+        logger.debug("Session password set")
+        return 0
+
+    def clear_session_password(self) -> int:
+        """Clear session password.
+
+        Returns:
+            0 on success
+        """
+        self.session_password = None
+        logger.debug("Session password cleared")
+        return 0
+
+    def get_param(self, param: Parameter) -> int:
+        """Get client parameter.
+
+        Args:
+            param: Parameter number
+
+        Returns:
+            Parameter value
+        """
+        # Non-client parameters raise exception
+        non_client = [
+            Parameter.LocalPort,
+            Parameter.WorkInterval,
+            Parameter.MaxClients,
+            Parameter.BSendTimeout,
+            Parameter.BRecvTimeout,
+            Parameter.RecoveryTime,
+            Parameter.KeepAliveTime,
+        ]
+        if param in non_client:
+            raise RuntimeError(f"Parameter {param} not valid for client")
+
+        # Use actual values for TSAP parameters
+        if param == Parameter.SrcTSap:
+            return self.local_tsap
+
+        return self._params.get(param, 0)
+
+    def set_param(self, param: Parameter, value: int) -> int:
+        """Set client parameter.
+
+        Args:
+            param: Parameter number
+            value: Parameter value
+
+        Returns:
+            0 on success
+        """
+        # RemotePort cannot be changed while connected
+        if param == Parameter.RemotePort and self.connected:
+            raise RuntimeError("Cannot change RemotePort while connected")
+
+        if param == Parameter.PDURequest:
+            self.pdu_length = value
+
+        self._params[param] = value
+        logger.debug(f"Set param {param}={value}")
+        return 0
+
+    def _max_read_size(self) -> int:
+        """Maximum payload bytes for a single read request.
+
+        Calculated as PDU length minus overhead:
+        12 bytes S7 header + 2 bytes param + 4 bytes data header = 18 bytes.
+        """
+        return self.pdu_length - 18
+
+    def _max_write_size(self) -> int:
+        """Maximum payload bytes for a single write request.
+
+        Calculated as PDU length minus overhead:
+        12 bytes S7 header + 14 bytes param + 4 bytes data header + 5 bytes padding = 35 bytes.
+        """
+        return self.pdu_length - 35
+
+    def _map_area(self, area: Area) -> S7Area:
+        """Map library area enum to native S7 area."""
+        area_mapping = {
+            Area.PE: S7Area.PE,
+            Area.PA: S7Area.PA,
+            Area.MK: S7Area.MK,
+            Area.DB: S7Area.DB,
+            Area.CT: S7Area.CT,
+            Area.TM: S7Area.TM,
+        }
+
+        if area not in area_mapping:
+            raise S7ProtocolError(f"Unsupported area: {area}")
+
+        return area_mapping[area]

--- a/snap7/client_base.py
+++ b/snap7/client_base.py
@@ -43,7 +43,7 @@ class ClientMixin:
     connected: bool
     _exec_time: int
     _last_error: int
-    _params: dict
+    _params: dict[Parameter, int]
 
     def get_pdu_length(self) -> int:
         """Get negotiated PDU length.
@@ -196,7 +196,7 @@ class ClientMixin:
         if param == Parameter.SrcTSap:
             return self.local_tsap
 
-        return self._params.get(param, 0)
+        return int(self._params.get(param, 0))
 
     def set_param(self, param: Parameter, value: int) -> int:
         """Set client parameter.

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -4,15 +4,15 @@ Uses the same Server fixture as test_client.py for integration tests.
 """
 
 import asyncio
-import struct
 import logging
+from collections.abc import Generator
 
 import pytest
 import pytest_asyncio
 
 from snap7.async_client import AsyncClient
 from snap7.server import Server
-from snap7.type import SrvArea, Area, Block, Parameter
+from snap7.type import SrvArea, Area, Parameter
 
 logging.basicConfig(level=logging.WARNING)
 
@@ -24,7 +24,7 @@ slot = 1
 
 
 @pytest.fixture(scope="module")
-def server():
+def server() -> Generator[Server]:
     srv = Server()
     srv.register_area(SrvArea.DB, 0, bytearray(600))
     srv.register_area(SrvArea.DB, 1, bytearray(600))
@@ -45,10 +45,10 @@ def server():
 
 
 @pytest_asyncio.fixture
-async def client(server):
+async def client(server: Server) -> AsyncClient:
     c = AsyncClient()
     await c.connect(ip, rack, slot, tcpport)
-    yield c
+    yield c  # type: ignore[misc]
     await c.disconnect()
 
 
@@ -58,7 +58,7 @@ async def client(server):
 
 
 @pytest.mark.asyncio
-async def test_connect_disconnect(server):
+async def test_connect_disconnect(server: Server) -> None:
     c = AsyncClient()
     await c.connect(ip, rack, slot, tcpport)
     assert c.get_connected()
@@ -67,7 +67,7 @@ async def test_connect_disconnect(server):
 
 
 @pytest.mark.asyncio
-async def test_context_manager(server):
+async def test_context_manager(server: Server) -> None:
     async with AsyncClient() as c:
         await c.connect(ip, rack, slot, tcpport)
         assert c.get_connected()
@@ -80,7 +80,7 @@ async def test_context_manager(server):
 
 
 @pytest.mark.asyncio
-async def test_db_read(client):
+async def test_db_read(client: AsyncClient) -> None:
     data = bytearray(40)
     await client.db_write(db_number=1, start=0, data=data)
     result = await client.db_read(db_number=1, start=0, size=40)
@@ -88,7 +88,7 @@ async def test_db_read(client):
 
 
 @pytest.mark.asyncio
-async def test_db_write(client):
+async def test_db_write(client: AsyncClient) -> None:
     data = bytearray(b"\x01\x02\x03\x04")
     await client.db_write(db_number=1, start=0, data=data)
     result = await client.db_read(db_number=1, start=0, size=4)
@@ -96,7 +96,7 @@ async def test_db_write(client):
 
 
 @pytest.mark.asyncio
-async def test_db_get(client):
+async def test_db_get(client: AsyncClient) -> None:
     result = await client.db_get(db_number=1)
     assert isinstance(result, bytearray)
     assert len(result) > 0
@@ -108,15 +108,15 @@ async def test_db_get(client):
 
 
 @pytest.mark.asyncio
-async def test_read_write_area(client):
-    data = bytearray(b"\xAA\xBB\xCC\xDD")
+async def test_read_write_area(client: AsyncClient) -> None:
+    data = bytearray(b"\xaa\xbb\xcc\xdd")
     await client.write_area(Area.DB, 1, 0, data)
     result = await client.read_area(Area.DB, 1, 0, 4)
     assert result == data
 
 
 @pytest.mark.asyncio
-async def test_read_area_large(client):
+async def test_read_area_large(client: AsyncClient) -> None:
     """Test chunked read for data larger than PDU."""
     size = 500  # Exceeds typical single-PDU payload
     data = bytearray(range(256)) * 2  # 512 bytes of pattern
@@ -132,7 +132,7 @@ async def test_read_area_large(client):
 
 
 @pytest.mark.asyncio
-async def test_ab_read_write(client):
+async def test_ab_read_write(client: AsyncClient) -> None:
     data = bytearray(b"\x01\x02\x03\x04")
     await client.ab_write(0, data)
     result = await client.ab_read(0, 4)
@@ -140,7 +140,7 @@ async def test_ab_read_write(client):
 
 
 @pytest.mark.asyncio
-async def test_eb_read_write(client):
+async def test_eb_read_write(client: AsyncClient) -> None:
     data = bytearray(b"\x05\x06\x07\x08")
     await client.eb_write(0, 4, data)
     result = await client.eb_read(0, 4)
@@ -148,8 +148,8 @@ async def test_eb_read_write(client):
 
 
 @pytest.mark.asyncio
-async def test_mb_read_write(client):
-    data = bytearray(b"\x0A\x0B\x0C\x0D")
+async def test_mb_read_write(client: AsyncClient) -> None:
+    data = bytearray(b"\x0a\x0b\x0c\x0d")
     await client.mb_write(0, 4, data)
     result = await client.mb_read(0, 4)
     assert result == data
@@ -161,7 +161,7 @@ async def test_mb_read_write(client):
 
 
 @pytest.mark.asyncio
-async def test_concurrent_reads(client):
+async def test_concurrent_reads(client: AsyncClient) -> None:
     """Verify asyncio.gather with multiple reads doesn't corrupt data.
 
     This is the critical test — it validates that the asyncio.Lock
@@ -169,7 +169,7 @@ async def test_concurrent_reads(client):
     """
     # Write known data
     data1 = bytearray(b"\x11\x22\x33\x44")
-    data2 = bytearray(b"\xAA\xBB\xCC\xDD")
+    data2 = bytearray(b"\xaa\xbb\xcc\xdd")
     await client.db_write(1, 0, data1)
     await client.db_write(1, 10, data2)
 
@@ -184,14 +184,14 @@ async def test_concurrent_reads(client):
 
 
 @pytest.mark.asyncio
-async def test_concurrent_read_write(client):
+async def test_concurrent_read_write(client: AsyncClient) -> None:
     """Verify concurrent read and write don't interfere."""
-    write_data = bytearray(b"\xFF\xFE\xFD\xFC")
+    write_data = bytearray(b"\xff\xfe\xfd\xfc")
 
-    async def do_write():
+    async def do_write() -> None:
         await client.db_write(1, 20, write_data)
 
-    async def do_read():
+    async def do_read() -> bytearray:
         return await client.db_read(1, 0, 4)
 
     await asyncio.gather(do_write(), do_read())
@@ -202,7 +202,7 @@ async def test_concurrent_read_write(client):
 
 
 @pytest.mark.asyncio
-async def test_many_concurrent_reads(client):
+async def test_many_concurrent_reads(client: AsyncClient) -> None:
     """Stress test with many concurrent reads."""
     # Write test data
     for i in range(10):
@@ -222,7 +222,7 @@ async def test_many_concurrent_reads(client):
 
 
 @pytest.mark.asyncio
-async def test_read_multi_vars(client):
+async def test_read_multi_vars(client: AsyncClient) -> None:
     await client.db_write(1, 0, bytearray(b"\x01\x02\x03\x04"))
     await client.db_write(1, 4, bytearray(b"\x05\x06\x07\x08"))
 
@@ -237,16 +237,16 @@ async def test_read_multi_vars(client):
 
 
 @pytest.mark.asyncio
-async def test_write_multi_vars(client):
+async def test_write_multi_vars(client: AsyncClient) -> None:
     items = [
-        {"area": Area.DB, "db_number": 1, "start": 0, "data": bytearray(b"\xAA\xBB")},
-        {"area": Area.DB, "db_number": 1, "start": 2, "data": bytearray(b"\xCC\xDD")},
+        {"area": Area.DB, "db_number": 1, "start": 0, "data": bytearray(b"\xaa\xbb")},
+        {"area": Area.DB, "db_number": 1, "start": 2, "data": bytearray(b"\xcc\xdd")},
     ]
     result = await client.write_multi_vars(items)
     assert result == 0
 
     data = await client.db_read(1, 0, 4)
-    assert data == bytearray(b"\xAA\xBB\xCC\xDD")
+    assert data == bytearray(b"\xaa\xbb\xcc\xdd")
 
 
 # -------------------------------------------------------------------
@@ -254,18 +254,18 @@ async def test_write_multi_vars(client):
 # -------------------------------------------------------------------
 
 
-def test_get_pdu_length():
+def test_get_pdu_length() -> None:
     c = AsyncClient()
     assert c.get_pdu_length() == 480
 
 
-def test_error_text():
+def test_error_text() -> None:
     c = AsyncClient()
     assert c.error_text(0) == "OK"
     assert "Not connected" in c.error_text(0x0003)
 
 
-def test_set_clear_session_password():
+def test_set_clear_session_password() -> None:
     c = AsyncClient()
     assert c.session_password is None
     c.set_session_password("secret")
@@ -274,7 +274,7 @@ def test_set_clear_session_password():
     assert c.session_password is None
 
 
-def test_set_connection_params():
+def test_set_connection_params() -> None:
     c = AsyncClient()
     c.set_connection_params("10.0.0.1", 0x0100, 0x0200)
     assert c.host == "10.0.0.1"
@@ -282,20 +282,20 @@ def test_set_connection_params():
     assert c.remote_tsap == 0x0200
 
 
-def test_set_connection_type():
+def test_set_connection_type() -> None:
     c = AsyncClient()
     c.set_connection_type(2)
     assert c.connection_type == 2
 
 
-def test_get_set_param():
+def test_get_set_param() -> None:
     c = AsyncClient()
     c.set_param(Parameter.PDURequest, 960)
     assert c.get_param(Parameter.PDURequest) == 960
     assert c.pdu_length == 960
 
 
-def test_get_param_non_client_raises():
+def test_get_param_non_client_raises() -> None:
     c = AsyncClient()
     with pytest.raises(RuntimeError):
         c.get_param(Parameter.LocalPort)
@@ -307,23 +307,23 @@ def test_get_param_non_client_raises():
 
 
 @pytest.mark.asyncio
-async def test_list_blocks(client):
+async def test_list_blocks(client: AsyncClient) -> None:
     result = await client.list_blocks()
     assert hasattr(result, "DBCount")
 
 
 @pytest.mark.asyncio
-async def test_get_cpu_state(client):
+async def test_get_cpu_state(client: AsyncClient) -> None:
     state = await client.get_cpu_state()
     assert isinstance(state, str)
 
 
 @pytest.mark.asyncio
-async def test_get_cpu_info(client):
+async def test_get_cpu_info(client: AsyncClient) -> None:
     info = await client.get_cpu_info()
     assert hasattr(info, "ModuleTypeName")
 
 
 @pytest.mark.asyncio
-async def test_get_pdu_length_after_connect(client):
+async def test_get_pdu_length_after_connect(client: AsyncClient) -> None:
     assert client.get_pdu_length() > 0

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,0 +1,329 @@
+"""Tests for the native async client (AsyncClient).
+
+Uses the same Server fixture as test_client.py for integration tests.
+"""
+
+import asyncio
+import struct
+import logging
+
+import pytest
+import pytest_asyncio
+
+from snap7.async_client import AsyncClient
+from snap7.server import Server
+from snap7.type import SrvArea, Area, Block, Parameter
+
+logging.basicConfig(level=logging.WARNING)
+
+ip = "127.0.0.1"
+tcpport = 1103  # Different port from sync tests to avoid conflicts
+db_number = 1
+rack = 1
+slot = 1
+
+
+@pytest.fixture(scope="module")
+def server():
+    srv = Server()
+    srv.register_area(SrvArea.DB, 0, bytearray(600))
+    srv.register_area(SrvArea.DB, 1, bytearray(600))
+    srv.register_area(SrvArea.PA, 0, bytearray(100))
+    srv.register_area(SrvArea.PA, 1, bytearray(100))
+    srv.register_area(SrvArea.PE, 0, bytearray(100))
+    srv.register_area(SrvArea.PE, 1, bytearray(100))
+    srv.register_area(SrvArea.MK, 0, bytearray(100))
+    srv.register_area(SrvArea.MK, 1, bytearray(100))
+    srv.register_area(SrvArea.TM, 0, bytearray(100))
+    srv.register_area(SrvArea.TM, 1, bytearray(100))
+    srv.register_area(SrvArea.CT, 0, bytearray(100))
+    srv.register_area(SrvArea.CT, 1, bytearray(100))
+    srv.start(tcp_port=tcpport)
+    yield srv
+    srv.stop()
+    srv.destroy()
+
+
+@pytest_asyncio.fixture
+async def client(server):
+    c = AsyncClient()
+    await c.connect(ip, rack, slot, tcpport)
+    yield c
+    await c.disconnect()
+
+
+# -------------------------------------------------------------------
+# Connection
+# -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_connect_disconnect(server):
+    c = AsyncClient()
+    await c.connect(ip, rack, slot, tcpport)
+    assert c.get_connected()
+    await c.disconnect()
+    assert not c.get_connected()
+
+
+@pytest.mark.asyncio
+async def test_context_manager(server):
+    async with AsyncClient() as c:
+        await c.connect(ip, rack, slot, tcpport)
+        assert c.get_connected()
+    assert not c.get_connected()
+
+
+# -------------------------------------------------------------------
+# DB read / write
+# -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_db_read(client):
+    data = bytearray(40)
+    await client.db_write(db_number=1, start=0, data=data)
+    result = await client.db_read(db_number=1, start=0, size=40)
+    assert data == result
+
+
+@pytest.mark.asyncio
+async def test_db_write(client):
+    data = bytearray(b"\x01\x02\x03\x04")
+    await client.db_write(db_number=1, start=0, data=data)
+    result = await client.db_read(db_number=1, start=0, size=4)
+    assert result == data
+
+
+@pytest.mark.asyncio
+async def test_db_get(client):
+    result = await client.db_get(db_number=1)
+    assert isinstance(result, bytearray)
+    assert len(result) > 0
+
+
+# -------------------------------------------------------------------
+# read_area / write_area
+# -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_write_area(client):
+    data = bytearray(b"\xAA\xBB\xCC\xDD")
+    await client.write_area(Area.DB, 1, 0, data)
+    result = await client.read_area(Area.DB, 1, 0, 4)
+    assert result == data
+
+
+@pytest.mark.asyncio
+async def test_read_area_large(client):
+    """Test chunked read for data larger than PDU."""
+    size = 500  # Exceeds typical single-PDU payload
+    data = bytearray(range(256)) * 2  # 512 bytes of pattern
+    data = data[:size]
+    await client.write_area(Area.DB, 1, 0, data)
+    result = await client.read_area(Area.DB, 1, 0, size)
+    assert result == data
+
+
+# -------------------------------------------------------------------
+# Memory area convenience methods
+# -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_ab_read_write(client):
+    data = bytearray(b"\x01\x02\x03\x04")
+    await client.ab_write(0, data)
+    result = await client.ab_read(0, 4)
+    assert result == data
+
+
+@pytest.mark.asyncio
+async def test_eb_read_write(client):
+    data = bytearray(b"\x05\x06\x07\x08")
+    await client.eb_write(0, 4, data)
+    result = await client.eb_read(0, 4)
+    assert result == data
+
+
+@pytest.mark.asyncio
+async def test_mb_read_write(client):
+    data = bytearray(b"\x0A\x0B\x0C\x0D")
+    await client.mb_write(0, 4, data)
+    result = await client.mb_read(0, 4)
+    assert result == data
+
+
+# -------------------------------------------------------------------
+# Concurrent safety (the key fix)
+# -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_reads(client):
+    """Verify asyncio.gather with multiple reads doesn't corrupt data.
+
+    This is the critical test — it validates that the asyncio.Lock
+    serializes send/receive cycles correctly.
+    """
+    # Write known data
+    data1 = bytearray(b"\x11\x22\x33\x44")
+    data2 = bytearray(b"\xAA\xBB\xCC\xDD")
+    await client.db_write(1, 0, data1)
+    await client.db_write(1, 10, data2)
+
+    # Read concurrently
+    results = await asyncio.gather(
+        client.db_read(1, 0, 4),
+        client.db_read(1, 10, 4),
+    )
+
+    assert results[0] == data1
+    assert results[1] == data2
+
+
+@pytest.mark.asyncio
+async def test_concurrent_read_write(client):
+    """Verify concurrent read and write don't interfere."""
+    write_data = bytearray(b"\xFF\xFE\xFD\xFC")
+
+    async def do_write():
+        await client.db_write(1, 20, write_data)
+
+    async def do_read():
+        return await client.db_read(1, 0, 4)
+
+    await asyncio.gather(do_write(), do_read())
+
+    # Verify write went through
+    result = await client.db_read(1, 20, 4)
+    assert result == write_data
+
+
+@pytest.mark.asyncio
+async def test_many_concurrent_reads(client):
+    """Stress test with many concurrent reads."""
+    # Write test data
+    for i in range(10):
+        await client.db_write(1, i * 4, bytearray([i] * 4))
+
+    # Read all concurrently
+    tasks = [client.db_read(1, i * 4, 4) for i in range(10)]
+    results = await asyncio.gather(*tasks)
+
+    for i, result in enumerate(results):
+        assert result == bytearray([i] * 4), f"Mismatch at index {i}"
+
+
+# -------------------------------------------------------------------
+# Multi-var
+# -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_read_multi_vars(client):
+    await client.db_write(1, 0, bytearray(b"\x01\x02\x03\x04"))
+    await client.db_write(1, 4, bytearray(b"\x05\x06\x07\x08"))
+
+    items = [
+        {"area": Area.DB, "db_number": 1, "start": 0, "size": 4},
+        {"area": Area.DB, "db_number": 1, "start": 4, "size": 4},
+    ]
+    code, results = await client.read_multi_vars(items)
+    assert code == 0
+    assert results[0] == bytearray(b"\x01\x02\x03\x04")
+    assert results[1] == bytearray(b"\x05\x06\x07\x08")
+
+
+@pytest.mark.asyncio
+async def test_write_multi_vars(client):
+    items = [
+        {"area": Area.DB, "db_number": 1, "start": 0, "data": bytearray(b"\xAA\xBB")},
+        {"area": Area.DB, "db_number": 1, "start": 2, "data": bytearray(b"\xCC\xDD")},
+    ]
+    result = await client.write_multi_vars(items)
+    assert result == 0
+
+    data = await client.db_read(1, 0, 4)
+    assert data == bytearray(b"\xAA\xBB\xCC\xDD")
+
+
+# -------------------------------------------------------------------
+# Synchronous helpers (no I/O)
+# -------------------------------------------------------------------
+
+
+def test_get_pdu_length():
+    c = AsyncClient()
+    assert c.get_pdu_length() == 480
+
+
+def test_error_text():
+    c = AsyncClient()
+    assert c.error_text(0) == "OK"
+    assert "Not connected" in c.error_text(0x0003)
+
+
+def test_set_clear_session_password():
+    c = AsyncClient()
+    assert c.session_password is None
+    c.set_session_password("secret")
+    assert c.session_password == "secret"
+    c.clear_session_password()
+    assert c.session_password is None
+
+
+def test_set_connection_params():
+    c = AsyncClient()
+    c.set_connection_params("10.0.0.1", 0x0100, 0x0200)
+    assert c.host == "10.0.0.1"
+    assert c.local_tsap == 0x0100
+    assert c.remote_tsap == 0x0200
+
+
+def test_set_connection_type():
+    c = AsyncClient()
+    c.set_connection_type(2)
+    assert c.connection_type == 2
+
+
+def test_get_set_param():
+    c = AsyncClient()
+    c.set_param(Parameter.PDURequest, 960)
+    assert c.get_param(Parameter.PDURequest) == 960
+    assert c.pdu_length == 960
+
+
+def test_get_param_non_client_raises():
+    c = AsyncClient()
+    with pytest.raises(RuntimeError):
+        c.get_param(Parameter.LocalPort)
+
+
+# -------------------------------------------------------------------
+# Block info / CPU info (against server)
+# -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_blocks(client):
+    result = await client.list_blocks()
+    assert hasattr(result, "DBCount")
+
+
+@pytest.mark.asyncio
+async def test_get_cpu_state(client):
+    state = await client.get_cpu_state()
+    assert isinstance(state, str)
+
+
+@pytest.mark.asyncio
+async def test_get_cpu_info(client):
+    info = await client.get_cpu_info()
+    assert hasattr(info, "ModuleTypeName")
+
+
+@pytest.mark.asyncio
+async def test_get_pdu_length_after_connect(client):
+    assert client.get_pdu_length() > 0

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,15 @@ wheels = [
 ]
 
 [[package]]
+name = "backports-asyncio-runner"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
+]
+
+[[package]]
 name = "cachetools"
 version = "7.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -688,6 +697,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-asyncio-runner", marker = "python_full_version < '3.11'" },
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
 name = "pytest-cov"
 version = "7.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -759,6 +782,7 @@ doc = [
 test = [
     { name = "mypy" },
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "pytest-cov" },
     { name = "pytest-html" },
     { name = "ruff" },
@@ -774,6 +798,7 @@ requires-dist = [
     { name = "click", marker = "extra == 'cli'" },
     { name = "mypy", marker = "extra == 'test'" },
     { name = "pytest", marker = "extra == 'test'" },
+    { name = "pytest-asyncio", marker = "extra == 'test'" },
     { name = "pytest-cov", marker = "extra == 'test'" },
     { name = "pytest-html", marker = "extra == 'test'" },
     { name = "rich", marker = "extra == 'cli'" },


### PR DESCRIPTION
## Summary

Adds a native `AsyncClient` for async S7 communication using `asyncio` streams. This replaces the previous `asyncio.to_thread()` approach (which was not safe for concurrent use) with proper non-blocking I/O, following the pattern from [python-s7comm](https://github.com/nikteliy/python-s7comm).

### Key design decisions

- **Native async I/O**: Uses `asyncio.open_connection()` with `StreamReader`/`StreamWriter` instead of blocking sockets wrapped in threads. The event loop is never blocked.
- **`asyncio.Lock()` in `_send_receive()`**: S7 is request-response, so each send+receive cycle must be atomic. The lock serializes concurrent coroutines, making `asyncio.gather()` safe.
- **Request-embedded sequence validation**: The async client extracts the expected PDU sequence number directly from the request bytes (S7 header offset 4-5) rather than relying on the shared protocol counter, avoiding race conditions when multiple coroutines build requests concurrently.
- **`ClientMixin` for shared logic**: 14 pure-computation methods (parameter management, error text, area mapping, etc.) are shared between `Client` and `AsyncClient` via a mixin in `snap7/client_base.py`, eliminating code duplication.
- **`S7Protocol` unchanged**: The protocol layer is pure computation (struct pack/unpack) — no I/O, no async needed.

### New files

- `snap7/async_client.py` — `AsyncISOTCPConnection` (async transport) and `AsyncClient` (full-featured async S7 client)
- `snap7/client_base.py` — `ClientMixin` with shared pure-computation methods
- `tests/test_async_client.py` — 26 tests covering connection, DB read/write, area read/write, concurrent safety, multi-var operations, and synchronous helpers

### Feature parity

`AsyncClient` supports the same operations as the sync `Client`:
- `connect` / `disconnect` / `get_connected`
- `db_read` / `db_write` / `db_get`
- `read_area` / `write_area` (with chunked transfers for large payloads)
- `ab_read` / `ab_write`, `eb_read` / `eb_write`, `mb_read` / `mb_write`, `tm_read` / `tm_write`, `ct_read` / `ct_write`
- `read_multi_vars` / `write_multi_vars`
- `list_blocks` / `list_blocks_of_type` / `get_block_info`
- `get_cpu_state` / `get_cpu_info` / `get_pdu_length`
- `upload` / `full_upload` / `download`
- `read_szl` / `get_plc_datetime` / `set_plc_datetime`
- `plc_hot_start` / `plc_cold_start` / `plc_stop`
- `get_cp_info` / `get_order_code` / `get_protection`
- Parameter management, session passwords, connection params
- `async with` context manager

### Test plan

- [x] All 454 existing tests pass (428 sync + 26 new async)
- [x] Concurrent safety validated: `asyncio.gather()` with multiple reads, mixed read/write, and 10 concurrent reads
- [x] Ruff formatting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)