### PR TITLE
Fix broken build configs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,4 +12,8 @@ sphinx:
 
 python:
   install:
-    - requirements: requirements-dev.txt
+    - method: pip
+      path: .
+      extra_requirements:
+        - doc
+        - cli

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,14 +2,11 @@ FROM ubuntu:24.04
 ENV DEBIAN_FRONTEND=noninteractive
 
 LABEL org.opencontainers.image.source=https://github.com/gijzelaerr/python-snap7
-LABEL org.opencontainers.image.description="The snap7 library is used to communicate with Siemens S7 PLCs. This is a Python wrapper for the snap7 library."
+LABEL org.opencontainers.image.description="Pure Python S7 communication library for interfacing with Siemens S7 PLCs."
 LABEL org.opencontainers.image.licenses=MIT
 
 RUN apt update \
-    && apt install -y software-properties-common python3-pip python3-venv \
-    && add-apt-repository ppa:gijzelaar/snap7 \
-    && apt update \
-    && apt install -y libsnap7-dev libsnap7-1
+    && apt install -y python3-pip python3-venv
 ADD . /code
 WORKDIR /venv
 RUN python3 -m venv /venv


### PR DESCRIPTION
## Summary

- Fix `.readthedocs.yaml` referencing non-existent `requirements-dev.txt` by switching to pip install with `[doc,cli]` extras from `pyproject.toml`.
- Update `Dockerfile` to remove unnecessary C snap7 library dependencies (`libsnap7-dev`, `libsnap7-1`, `software-properties-common`, PPA setup) since python-snap7 3.0 is pure Python.
- Update Docker image description label to reflect the pure Python nature of the library.

## Test plan

- [ ] Verify Read the Docs build succeeds with the new `.readthedocs.yaml` configuration
- [ ] Verify Docker image builds successfully without C snap7 library dependencies
- [ ] Confirm documentation renders correctly on Read the Docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)