### PR TITLE
Add 3.0 release messaging and version bump

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,25 @@
 CHANGES
 =======
 
+3.0.0
+-----
+
+Major release: python-snap7 is now a pure Python S7 communication library.
+
+* **Breaking**: The C snap7 library is no longer required or used
+* Complete rewrite of the S7 protocol stack in pure Python
+* Native Python implementation of TPKT (RFC 1006) and COTP (ISO 8073) layers
+* Native S7 protocol PDU encoding/decoding
+* Pure Python server implementation for testing and simulation
+* No platform-specific binary dependencies
+* Improved error handling and connection management
+* Full type annotations with mypy strict mode
+* CLI interface for running an S7 server emulator (`pip install "python-snap7[cli]"`)
+
+If you experience issues with 3.0, pin to the last pre-3.0 release:
+
+    $ pip install "python-snap7<3"
+
 1.2
 ---
 

--- a/README.rst
+++ b/README.rst
@@ -8,6 +8,20 @@ Python-snap7 is tested with Python 3.10+, on Windows, Linux and OS X.
 The full documentation is available on `Read The Docs <https://python-snap7.readthedocs.io/en/latest/>`_.
 
 
+Version 3.0 - Breaking Changes
+===============================
+
+Version 3.0 is a major release that rewrites python-snap7 as a pure Python
+implementation. The C snap7 library is no longer required.
+
+This release may contain breaking changes. If you experience issues, you can
+pin to the last pre-3.0 release::
+
+    $ pip install "python-snap7<3"
+
+The latest stable pre-3.0 release is version 2.1.0.
+
+
 Installation
 ============
 

--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -1,81 +1,21 @@
-Binary Wheel Installation
-=========================
+Installation
+============
 
-We advice you to install python-snap7 using a binary wheel. The binary wheels
-should work on Windows 64x, OS X (intel), Linux x64 and Linux ARM.
-python-snap7 is available on `PyPI <https://pypi.python.org/pypi/python-snap7/>`_. You can install
-it by using pip::
+python-snap7 is a pure Python package with no native dependencies. Install it
+using pip::
 
   $ pip install python-snap7
 
- If you want to use the CLI interface for running an emulator, you should install it with::
+If you want to use the CLI interface for running an emulator, install it with::
 
   $ pip install "python-snap7[cli]"
 
+That's it! No native libraries or platform-specific setup is required.
 
-Manual Installation (not recommended)
-=====================================
+Upgrading from 2.x
+-------------------
 
-If you are running an unsupported platform you need to do a bit more work.
-This involves two steps. First, install the snap7 library,
-followed by the installation of the python-snap7 package.
+Version 3.0 is a major rewrite. If you experience issues after upgrading,
+you can pin to the last pre-3.0 release::
 
-Snap7
------
-
-Ubuntu
-~~~~~~
-
-If you are using Ubuntu you can use the Ubuntu packages from our
-`launchpad PPA <https://launchpad.net/~gijzelaar/+archive/snap7>`_. To install::
-
-    $ sudo add-apt-repository ppa:gijzelaar/snap7
-    $ sudo apt-get update
-    $ sudo apt-get install libsnap7-1 libsnap7-dev
-
-Windows
-~~~~~~~
-
-Download the zip file from the
-`sourceforce page <https://sourceforge.net/projects/snap7/files/>`_.
-Unzip the zip file, and copy ``release\\Windows\\Win64\\snap7.dll`` somewhere
-in your system PATH, for example ``%systemroot%\System32\``. Alternatively you can
-copy the file somewhere on your file system and adjust the system PATH.
-
-OSX
-~~~
-
-The snap7 library is available on `Homebrew <https://brew.sh/>`_::
-
-  $ brew install snap7
-
-
-Compile from source
-~~~~~~~~~~~~~~~~~~~
-
-Download the latest source from
-`the sourceforce page <https://sourceforge.net/projects/snap7/files/>`_ and do
-a manual compile. Download the file and run::
-
-     $ p7zip -d snap7-full-1.0.0.7z  # requires the p7 program
-     $ cd build/<platform>           # where platform is unix or windows
-     $ make -f <arch>.mk install     # where arch is your architecture, for example x86_64_linux
-
-For more information about or help with compilation please check out the
-documentation on the `snap7 website <https://snap7.sourceforge.net/>`_.
-
-
-Python-Snap7
-------------
-
-Once snap7 is available in your library or system path, you can install it from the git
-repository or from a source tarball. It is recommended to install it in a virtualenv.
-
-To create a virtualenv and activate it::
-
-  $ python3 -m venv venv
-  $ source venv/bin/activate
-
-Now you can install your python-snap7 package::
-
-  $ pip3 install .
+  $ pip install "python-snap7<3"

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -1,12 +1,12 @@
 Introduction
 ============
 
-python-snap7 is a Python wrapper for the
-`Snap7 library <https://snap7.sourceforge.net>`_. Snap7 is an open source,
-32/64 bit, multi-platform Ethernet communication suite for interfacing natively
-with Siemens S7 PLCs.
+python-snap7 is a pure Python S7 communication library for interfacing
+natively with Siemens S7 PLCs. The library implements the complete S7
+protocol stack including TPKT (RFC 1006), COTP (ISO 8073), and S7
+protocol layers.
 
-Python-snap7 is developed for snap7 1.4.2 and Python 3.10+. It is tested
-on Windows, macOS and Linux. Python versions below 3.10 are not supported.
+python-snap7 requires Python 3.10+ and runs on Windows, macOS and Linux
+without any native dependencies.
 
 The project development is centralized on `github <https://github.com/gijzelaerr/python-snap7>`_.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-snap7"
-version = "2.1.0"
+version = "3.0.0"
 description = "Pure Python S7 communication library for Siemens PLCs"
 readme = "README.rst"
 authors = [


### PR DESCRIPTION
## Summary

* Bump version from 2.1.0 to 3.0.0 in `pyproject.toml`
* Update `README.rst` with a breaking changes warning for 3.0 and instructions to pin to `python-snap7<3`
* Add 3.0.0 changelog entry to `CHANGES.md` documenting the pure Python rewrite
* Rewrite `doc/introduction.rst` to describe the pure Python S7 protocol stack
* Rewrite `doc/installation.rst` to remove all C library installation instructions (Ubuntu PPA, Windows DLL, Homebrew, compile from source) and replace with simple pip install

## Test plan

- [ ] Verify `pip install python-snap7` installs 3.0.0
- [ ] Verify README renders correctly on PyPI and GitHub
- [ ] Verify docs build cleanly on Read The Docs
- [ ] Confirm `pip install "python-snap7<3"` still installs 2.1.0 from PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)