### PR TITLE
Improve CI: add coverage reporting and complete publish test matrix

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-24.04", "macos-14", "windows-2022"]
-        python-version: ["3.10", "3.12", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-24.04", "macos-14", "windows-2022"]
-        python-version: ["3.10", "3.12", "3.14"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,4 +32,10 @@ jobs:
           uv venv --python python${{ matrix.python-version }}
           uv pip install ".[test]"
       - name: Run pytest
-        run: uv run pytest
+        run: uv run pytest --cov=snap7 --cov-report=xml --cov-report=term
+      - name: Upload coverage report
+        if: matrix.python-version == '3.13' && matrix.runs-on == 'ubuntu-24.04'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage.xml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ Homepage = "https://github.com/gijzelaerr/python-snap7"
 Documentation = "https://python-snap7.readthedocs.io/en/latest/"
 
 [project.optional-dependencies]
-test = ["pytest", "pytest-html", "mypy", "types-setuptools", "ruff", "tox", "tox-uv", "types-click", "uv"]
+test = ["pytest", "pytest-cov", "pytest-html", "mypy", "types-setuptools", "ruff", "tox", "tox-uv", "types-click", "uv"]
 cli = ["rich", "click" ]
 doc = ["sphinx", "sphinx_rtd_theme"]
 


### PR DESCRIPTION
## Summary
- Add `pytest-cov` to test dependencies in `pyproject.toml`
- Add coverage reporting (`--cov=snap7 --cov-report=xml --cov-report=term`) to the test workflow and upload coverage artifact for Python 3.13 on ubuntu-24.04
- Add Python 3.11 and 3.13 to the publish-pypi and publish-test-pypi workflow test matrices so all supported versions are tested before release

## Test plan
- [ ] Verify test workflow runs pytest with coverage flags
- [ ] Verify coverage artifact is uploaded only for Python 3.13 on ubuntu-24.04
- [ ] Verify publish-pypi test matrix includes all versions: 3.10, 3.11, 3.12, 3.13, 3.14
- [ ] Verify publish-test-pypi test matrix includes all versions: 3.10, 3.11, 3.12, 3.13, 3.14

🤖 Generated with [Claude Code](https://claude.com/claude-code)