### PR TITLE
Deploy documentation to GitHub Pages

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -6,6 +6,8 @@ on:
     branches: [master]
 permissions:
   contents: read
+  pages: write
+  id-token: write
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -27,5 +29,21 @@ jobs:
         run: |
           uv venv
           uv pip install ".[doc,cli]"
-      - name: Run doc
+      - name: Build documentation
         run: uv run sphinx-build -N -bhtml doc/ doc/_build -W
+      - name: Upload Pages artifact
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: doc/_build
+  deploy:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-24.04
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Extend the existing documentation CI workflow to deploy built HTML docs to GitHub Pages on pushes to `master`.
- Pull requests continue to only build docs (as a validation check), without deploying.
- Uses `actions/upload-pages-artifact@v3` and `actions/deploy-pages@v4`.

## Setup required
A repository admin needs to enable GitHub Pages in **Settings > Pages** and set **Source** to **"GitHub Actions"**.

## Test plan
- [ ] Verify PR builds still only run the doc build step (no upload/deploy)
- [ ] Verify pushes to `master` build, upload the artifact, and deploy to GitHub Pages
- [ ] Confirm the deployed site is accessible at the GitHub Pages URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)