### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -7,6 +7,8 @@ jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/gijzelaerr/python-snap7/security/code-scanning/4](https://github.com/gijzelaerr/python-snap7/security/code-scanning/4)

In general, the fix is to explicitly restrict the GITHUB_TOKEN permissions to the minimum needed, either at the workflow root (for all jobs) or per job. Here, `publish` and `test-published-package` already have appropriate `permissions` blocks, but `build` does not. The best fix is to add a job-level `permissions` block under `build:` that grants only `contents: read`, because the build job just checks out code, installs dependencies, builds artifacts, and uploads them; it does not need to write to the repository or other GitHub resources.

Concretely, edit `.github/workflows/publish-test-pypi.yml` in the `build` job definition. Right after `runs-on: ubuntu-latest` (line 9), insert:

```yaml
    permissions:
      contents: read
```

No new imports or external dependencies are required; this is purely a YAML configuration change within the existing workflow. Functionality of the workflow remains the same, while the `build` job’s GITHUB_TOKEN is now explicitly limited.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
