### PR TITLE
Fix TestPyPI workflow index resolution

### DIFF
--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -68,5 +68,5 @@ jobs:
       - name: Install and test python-snap7
         run: |
           uv venv
-          uv pip install --extra-index-url https://test.pypi.org/simple/ python-snap7[test]
+          uv pip install --index-strategy unsafe-best-match --extra-index-url https://test.pypi.org/simple/ python-snap7[test]
           uv run python -c "import snap7; print('snap7 imported successfully')"


### PR DESCRIPTION
## Summary
- Fix TestPyPI publish workflow failing because uv finds junk packages (e.g. `pytest v0.0.0.dev1`) on TestPyPI before checking PyPI
- Add `--index-strategy unsafe-best-match` so uv picks the best version across all indexes

## Context
The `test-published-package` job fails with:
```
Failed to download and build pytest==0.0.0.dev1
```
Because uv's default strategy locks to the first index that has a package. With `unsafe-best-match`, it considers all indexes and picks the best matching version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)