### PR TITLE
Add S7CommPlus protocol scaffolding for S7-1200/1500

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ markers =[
     "server",
     "util"
     ]
+asyncio_mode = "auto"
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/snap7/connection.py
+++ b/snap7/connection.py
@@ -9,7 +9,7 @@ import socket
 import struct
 import logging
 from enum import IntEnum
-from typing import Optional, Type
+from typing import Optional, Type, Union
 from types import TracebackType
 
 from .error import S7ConnectionError, S7TimeoutError
@@ -66,7 +66,7 @@ class ISOTCPConnection:
         host: str,
         port: int = 102,
         local_tsap: int = 0x0100,
-        remote_tsap: int = 0x0102,
+        remote_tsap: Union[int, bytes] = 0x0102,
         tpdu_size: TPDUSize = TPDUSize.S_1024,
     ):
         """
@@ -76,7 +76,8 @@ class ISOTCPConnection:
             host: Target PLC IP address
             port: TCP port (default 102 for S7)
             local_tsap: Local Transport Service Access Point
-            remote_tsap: Remote Transport Service Access Point
+            remote_tsap: Remote Transport Service Access Point (int for 2-byte TSAP,
+                         bytes for variable-length TSAP like b"SIMATIC-ROOT-HMI")
             tpdu_size: TPDU size to request during COTP negotiation
         """
         self.host = host
@@ -265,11 +266,13 @@ class ISOTCPConnection:
         )
 
         # Add TSAP parameters
-        tsap_length = 2  # TSAP values are 2 bytes (unsigned short)
-        # Calling TSAP (local)
-        calling_tsap = struct.pack(">BBH", self.COTP_PARAM_CALLING_TSAP, tsap_length, self.local_tsap)
-        # Called TSAP (remote)
-        called_tsap = struct.pack(">BBH", self.COTP_PARAM_CALLED_TSAP, tsap_length, self.remote_tsap)
+        # Calling TSAP (local) - always 2 bytes
+        calling_tsap = struct.pack(">BBH", self.COTP_PARAM_CALLING_TSAP, 2, self.local_tsap)
+        # Called TSAP (remote) - can be 2-byte int or variable-length bytes (e.g. "SIMATIC-ROOT-HMI")
+        if isinstance(self.remote_tsap, bytes):
+            called_tsap = struct.pack(">BB", self.COTP_PARAM_CALLED_TSAP, len(self.remote_tsap)) + self.remote_tsap
+        else:
+            called_tsap = struct.pack(">BBH", self.COTP_PARAM_CALLED_TSAP, 2, self.remote_tsap)
         # PDU Size parameter (ISO 8073 code, e.g. 0x0A = 1024 bytes)
         pdu_size_param = struct.pack(">BBB", self.COTP_PARAM_PDU_SIZE, 1, self.tpdu_size)
 

--- a/snap7/connection.py
+++ b/snap7/connection.py
@@ -154,7 +154,7 @@ class ISOTCPConnection:
         # Send over TCP
         try:
             self.socket.sendall(tpkt_frame)
-            logger.debug(f"Sent {len(tpkt_frame)} bytes")
+            logger.debug(f"Sent {len(tpkt_frame)} bytes: {tpkt_frame.hex(' ')}")
         except socket.error as e:
             self.connected = False
             raise S7ConnectionError(f"Send failed: {e}")
@@ -187,6 +187,7 @@ class ISOTCPConnection:
             payload = self._recv_exact(remaining)
 
             # Parse COTP header and extract data
+            logger.debug(f"Received TPKT: version={version} length={length} payload ({len(payload)} bytes): {payload.hex(' ')}")
             return self._parse_cotp_data(payload)
 
         except socket.timeout:

--- a/snap7/s7commplus/__init__.py
+++ b/snap7/s7commplus/__init__.py
@@ -7,9 +7,9 @@ engineering access (program download/upload, symbolic addressing, etc.).
 
 Supported PLC / firmware targets::
 
-    V1: S7-1200 FW V4.0+          (trivial anti-replay)
-    V2: S7-1200/1500 older FW      (proprietary session auth)
-    V3: S7-1200/1500 pre-TIA V17   (ECC key exchange)
+    V1: S7-1200 FW V4.0+          (simple session handshake)
+    V2: S7-1200/1500 older FW      (session authentication)
+    V3: S7-1200/1500 pre-TIA V17   (public-key key exchange)
     V3 + TLS: TIA Portal V17+      (TLS 1.3 with per-device certs)
 
 Protocol stack::

--- a/snap7/s7commplus/__init__.py
+++ b/snap7/s7commplus/__init__.py
@@ -1,0 +1,36 @@
+"""
+S7CommPlus protocol implementation for S7-1200/1500 PLCs.
+
+S7CommPlus (protocol ID 0x72) is the successor to S7comm (protocol ID 0x32),
+used by Siemens S7-1200 (firmware >= V4.0) and S7-1500 PLCs for full
+engineering access (program download/upload, symbolic addressing, etc.).
+
+Supported PLC / firmware targets::
+
+    V1: S7-1200 FW V4.0+          (trivial anti-replay)
+    V2: S7-1200/1500 older FW      (proprietary session auth)
+    V3: S7-1200/1500 pre-TIA V17   (ECC key exchange)
+    V3 + TLS: TIA Portal V17+      (TLS 1.3 with per-device certs)
+
+Protocol stack::
+
+    +-------------------------------+
+    |  S7CommPlus (Protocol ID 0x72)|
+    +-------------------------------+
+    |  TLS 1.3 (optional, V17+)    |
+    +-------------------------------+
+    |  COTP (ISO 8073)              |
+    +-------------------------------+
+    |  TPKT (RFC 1006)              |
+    +-------------------------------+
+    |  TCP (port 102)               |
+    +-------------------------------+
+
+The wire protocol (VLQ encoding, data types, function codes, object model)
+is the same across all versions -- only the session authentication differs.
+
+Status: experimental scaffolding -- not yet functional.
+
+Reference implementation:
+    https://github.com/thomas-v2/S7CommPlusDriver (C#, LGPL-3.0)
+"""

--- a/snap7/s7commplus/async_client.py
+++ b/snap7/s7commplus/async_client.py
@@ -89,8 +89,7 @@ class S7CommPlusAsyncClient:
 
             self._connected = True
             logger.info(
-                f"Async S7CommPlus connected to {host}:{port}, "
-                f"version=V{self._protocol_version}, session={self._session_id}"
+                f"Async S7CommPlus connected to {host}:{port}, version=V{self._protocol_version}, session={self._session_id}"
             )
         except Exception:
             await self.disconnect()
@@ -136,9 +135,7 @@ class S7CommPlusAsyncClient:
         payload += encode_uint32_vlq(start)
         payload += encode_uint32_vlq(size)
 
-        response = await self._send_request(
-            FunctionCode.GET_MULTI_VARIABLES, bytes(payload)
-        )
+        response = await self._send_request(FunctionCode.GET_MULTI_VARIABLES, bytes(payload))
 
         offset = 0
         _, consumed = decode_uint32_vlq(response, offset)
@@ -175,18 +172,14 @@ class S7CommPlusAsyncClient:
         payload += encode_uint32_vlq(len(data))
         payload += data
 
-        response = await self._send_request(
-            FunctionCode.SET_MULTI_VARIABLES, bytes(payload)
-        )
+        response = await self._send_request(FunctionCode.SET_MULTI_VARIABLES, bytes(payload))
 
         offset = 0
         return_code, consumed = decode_uint32_vlq(response, offset)
         if return_code != 0:
             raise RuntimeError(f"Write failed with return code {return_code}")
 
-    async def db_read_multi(
-        self, items: list[tuple[int, int, int]]
-    ) -> list[bytes]:
+    async def db_read_multi(self, items: list[tuple[int, int, int]]) -> list[bytes]:
         """Read multiple data block regions in a single request.
 
         Args:
@@ -203,9 +196,7 @@ class S7CommPlusAsyncClient:
             payload += encode_uint32_vlq(start)
             payload += encode_uint32_vlq(size)
 
-        response = await self._send_request(
-            FunctionCode.GET_MULTI_VARIABLES, bytes(payload)
-        )
+        response = await self._send_request(FunctionCode.GET_MULTI_VARIABLES, bytes(payload))
 
         offset = 0
         _, consumed = decode_uint32_vlq(response, offset)
@@ -245,16 +236,19 @@ class S7CommPlusAsyncClient:
 
             seq_num = self._next_sequence_number()
 
-            request = struct.pack(
-                ">BHHHHIB",
-                Opcode.REQUEST,
-                0x0000,
-                function_code,
-                0x0000,
-                seq_num,
-                self._session_id,
-                0x36,
-            ) + payload
+            request = (
+                struct.pack(
+                    ">BHHHHIB",
+                    Opcode.REQUEST,
+                    0x0000,
+                    function_code,
+                    0x0000,
+                    seq_num,
+                    self._session_id,
+                    0x36,
+                )
+                + payload
+            )
 
             frame = encode_header(self._protocol_version, len(request)) + request
             await self._send_cotp_dt(frame)

--- a/snap7/s7commplus/async_client.py
+++ b/snap7/s7commplus/async_client.py
@@ -28,7 +28,8 @@ from .protocol import (
     S7COMMPLUS_REMOTE_TSAP,
 )
 from .codec import encode_header, decode_header, encode_typed_value
-from .vlq import encode_uint32_vlq, decode_uint32_vlq
+from .vlq import encode_uint32_vlq
+from .client import _build_read_payload, _parse_read_response, _build_write_payload, _parse_write_response
 
 logger = logging.getLogger(__name__)
 
@@ -137,33 +138,15 @@ class S7CommPlusAsyncClient:
         Returns:
             Raw bytes read from the data block
         """
-        object_id = 0x00010000 | (db_number & 0xFFFF)
-        payload = bytearray()
-        payload += encode_uint32_vlq(1)
-        payload += encode_uint32_vlq(object_id)
-        payload += encode_uint32_vlq(start)
-        payload += encode_uint32_vlq(size)
+        payload = _build_read_payload([(db_number, start, size)])
+        response = await self._send_request(FunctionCode.GET_MULTI_VARIABLES, payload)
 
-        response = await self._send_request(FunctionCode.GET_MULTI_VARIABLES, bytes(payload))
-
-        offset = 0
-        _, consumed = decode_uint32_vlq(response, offset)
-        offset += consumed
-        item_count, consumed = decode_uint32_vlq(response, offset)
-        offset += consumed
-
-        if item_count == 0:
-            return b""
-
-        status, consumed = decode_uint32_vlq(response, offset)
-        offset += consumed
-        data_length, consumed = decode_uint32_vlq(response, offset)
-        offset += consumed
-
-        if status != 0:
-            raise RuntimeError(f"Read failed with status {status}")
-
-        return response[offset : offset + data_length]
+        results = _parse_read_response(response)
+        if not results:
+            raise RuntimeError("Read returned no data")
+        if results[0] is None:
+            raise RuntimeError("Read failed: PLC returned error for item")
+        return results[0]
 
     async def db_write(self, db_number: int, start: int, data: bytes) -> None:
         """Write raw bytes to a data block.
@@ -173,20 +156,9 @@ class S7CommPlusAsyncClient:
             start: Start byte offset
             data: Bytes to write
         """
-        object_id = 0x00010000 | (db_number & 0xFFFF)
-        payload = bytearray()
-        payload += encode_uint32_vlq(1)
-        payload += encode_uint32_vlq(object_id)
-        payload += encode_uint32_vlq(start)
-        payload += encode_uint32_vlq(len(data))
-        payload += data
-
-        response = await self._send_request(FunctionCode.SET_MULTI_VARIABLES, bytes(payload))
-
-        offset = 0
-        return_code, consumed = decode_uint32_vlq(response, offset)
-        if return_code != 0:
-            raise RuntimeError(f"Write failed with return code {return_code}")
+        payload = _build_write_payload([(db_number, start, data)])
+        response = await self._send_request(FunctionCode.SET_MULTI_VARIABLES, payload)
+        _parse_write_response(response)
 
     async def db_read_multi(self, items: list[tuple[int, int, int]]) -> list[bytes]:
         """Read multiple data block regions in a single request.
@@ -197,35 +169,11 @@ class S7CommPlusAsyncClient:
         Returns:
             List of raw bytes for each item
         """
-        payload = bytearray()
-        payload += encode_uint32_vlq(len(items))
-        for db_number, start, size in items:
-            object_id = 0x00010000 | (db_number & 0xFFFF)
-            payload += encode_uint32_vlq(object_id)
-            payload += encode_uint32_vlq(start)
-            payload += encode_uint32_vlq(size)
+        payload = _build_read_payload(items)
+        response = await self._send_request(FunctionCode.GET_MULTI_VARIABLES, payload)
 
-        response = await self._send_request(FunctionCode.GET_MULTI_VARIABLES, bytes(payload))
-
-        offset = 0
-        _, consumed = decode_uint32_vlq(response, offset)
-        offset += consumed
-        item_count, consumed = decode_uint32_vlq(response, offset)
-        offset += consumed
-
-        results: list[bytes] = []
-        for _ in range(item_count):
-            status, consumed = decode_uint32_vlq(response, offset)
-            offset += consumed
-            data_length, consumed = decode_uint32_vlq(response, offset)
-            offset += consumed
-            if status == 0 and data_length > 0:
-                results.append(response[offset : offset + data_length])
-                offset += data_length
-            else:
-                results.append(b"")
-
-        return results
+        results = _parse_read_response(response)
+        return [r if r is not None else b"" for r in results]
 
     async def explore(self) -> bytes:
         """Browse the PLC object tree.

--- a/snap7/s7commplus/async_client.py
+++ b/snap7/s7commplus/async_client.py
@@ -17,8 +17,17 @@ import logging
 import struct
 from typing import Any, Optional
 
-from .protocol import FunctionCode, Opcode, ProtocolVersion
-from .codec import encode_header, decode_header
+from .protocol import (
+    DataType,
+    ElementID,
+    FunctionCode,
+    ObjectId,
+    Opcode,
+    ProtocolVersion,
+    S7COMMPLUS_LOCAL_TSAP,
+    S7COMMPLUS_REMOTE_TSAP,
+)
+from .codec import encode_header, decode_header, encode_typed_value
 from .vlq import encode_uint32_vlq, decode_uint32_vlq
 
 logger = logging.getLogger(__name__)
@@ -74,15 +83,15 @@ class S7CommPlusAsyncClient:
             rack: PLC rack number
             slot: PLC slot number
         """
-        local_tsap = 0x0100
-        remote_tsap = 0x0100 | (rack << 5) | slot
-
         # TCP connect
         self._reader, self._writer = await asyncio.open_connection(host, port)
 
         try:
-            # COTP handshake
-            await self._cotp_connect(local_tsap, remote_tsap)
+            # COTP handshake with S7CommPlus TSAP values
+            await self._cotp_connect(S7COMMPLUS_LOCAL_TSAP, S7COMMPLUS_REMOTE_TSAP)
+
+            # InitSSL handshake
+            await self._init_ssl()
 
             # S7CommPlus session setup
             await self._create_session()
@@ -251,19 +260,20 @@ class S7CommPlusAsyncClient:
             )
 
             frame = encode_header(self._protocol_version, len(request)) + request
+            frame += struct.pack(">BBH", 0x72, self._protocol_version, 0x0000)
             await self._send_cotp_dt(frame)
 
             response_data = await self._recv_cotp_dt()
 
             version, data_length, consumed = decode_header(response_data)
-            response = response_data[consumed:]
+            response = response_data[consumed : consumed + data_length]
 
             if len(response) < 14:
                 raise RuntimeError("Response too short")
 
             return response[14:]
 
-    async def _cotp_connect(self, local_tsap: int, remote_tsap: int) -> None:
+    async def _cotp_connect(self, local_tsap: int, remote_tsap: bytes) -> None:
         """Perform COTP Connection Request / Confirm handshake."""
         if self._writer is None or self._reader is None:
             raise RuntimeError("Not connected")
@@ -271,7 +281,7 @@ class S7CommPlusAsyncClient:
         # Build COTP CR
         base_pdu = struct.pack(">BBHHB", 6, _COTP_CR, 0x0000, 0x0001, 0x00)
         calling_tsap = struct.pack(">BBH", 0xC1, 2, local_tsap)
-        called_tsap = struct.pack(">BBH", 0xC2, 2, remote_tsap)
+        called_tsap = struct.pack(">BB", 0xC2, len(remote_tsap)) + remote_tsap
         pdu_size_param = struct.pack(">BBB", 0xC0, 1, 0x0A)
 
         params = calling_tsap + called_tsap + pdu_size_param
@@ -290,10 +300,40 @@ class S7CommPlusAsyncClient:
         if len(payload) < 7 or payload[1] != _COTP_CC:
             raise RuntimeError(f"Expected COTP CC, got {payload[1]:#04x}")
 
+    async def _init_ssl(self) -> None:
+        """Send InitSSL request (required before CreateObject)."""
+        seq_num = self._next_sequence_number()
+
+        request = struct.pack(
+            ">BHHHHIB",
+            Opcode.REQUEST,
+            0x0000,
+            FunctionCode.INIT_SSL,
+            0x0000,
+            seq_num,
+            0x00000000,
+            0x30,  # Transport flags for InitSSL
+        )
+        request += struct.pack(">I", 0)
+
+        frame = encode_header(ProtocolVersion.V1, len(request)) + request
+        frame += struct.pack(">BBH", 0x72, ProtocolVersion.V1, 0x0000)
+        await self._send_cotp_dt(frame)
+
+        response_data = await self._recv_cotp_dt()
+        version, data_length, consumed = decode_header(response_data)
+        response = response_data[consumed : consumed + data_length]
+
+        if len(response) < 14:
+            raise RuntimeError("InitSSL response too short")
+
+        logger.debug(f"InitSSL response received, version=V{version}")
+
     async def _create_session(self) -> None:
         """Send CreateObject to establish S7CommPlus session."""
         seq_num = self._next_sequence_number()
 
+        # Build CreateObject request header
         request = struct.pack(
             ">BHHHHIB",
             Opcode.REQUEST,
@@ -301,17 +341,50 @@ class S7CommPlusAsyncClient:
             FunctionCode.CREATE_OBJECT,
             0x0000,
             seq_num,
-            0x00000000,
+            ObjectId.OBJECT_NULL_SERVER_SESSION,  # SessionId = 288
             0x36,
         )
+
+        # RequestId: ObjectServerSessionContainer (285)
+        request += struct.pack(">I", ObjectId.OBJECT_SERVER_SESSION_CONTAINER)
+
+        # RequestValue: ValueUDInt(0)
+        request += bytes([0x00, DataType.UDINT]) + encode_uint32_vlq(0)
+
+        # Unknown padding
         request += struct.pack(">I", 0)
 
+        # RequestObject: NullServerSession PObject
+        request += bytes([ElementID.START_OF_OBJECT])
+        request += struct.pack(">I", ObjectId.GET_NEW_RID_ON_SERVER)
+        request += encode_uint32_vlq(ObjectId.CLASS_SERVER_SESSION)
+        request += encode_uint32_vlq(0)  # ClassFlags
+        request += encode_uint32_vlq(0)  # AttributeId
+
+        # Attribute: ServerSessionClientRID = 0x80c3c901
+        request += bytes([ElementID.ATTRIBUTE])
+        request += encode_uint32_vlq(ObjectId.SERVER_SESSION_CLIENT_RID)
+        request += encode_typed_value(DataType.RID, 0x80C3C901)
+
+        # Nested: ClassSubscriptions
+        request += bytes([ElementID.START_OF_OBJECT])
+        request += struct.pack(">I", ObjectId.GET_NEW_RID_ON_SERVER)
+        request += encode_uint32_vlq(ObjectId.CLASS_SUBSCRIPTIONS)
+        request += encode_uint32_vlq(0)
+        request += encode_uint32_vlq(0)
+        request += bytes([ElementID.TERMINATING_OBJECT])
+
+        request += bytes([ElementID.TERMINATING_OBJECT])
+        request += struct.pack(">I", 0)
+
+        # Frame header + trailer
         frame = encode_header(ProtocolVersion.V1, len(request)) + request
+        frame += struct.pack(">BBH", 0x72, ProtocolVersion.V1, 0x0000)
         await self._send_cotp_dt(frame)
 
         response_data = await self._recv_cotp_dt()
         version, data_length, consumed = decode_header(response_data)
-        response = response_data[consumed:]
+        response = response_data[consumed : consumed + data_length]
 
         if len(response) < 14:
             raise RuntimeError("CreateObject response too short")
@@ -336,6 +409,7 @@ class S7CommPlusAsyncClient:
         request += struct.pack(">I", 0)
 
         frame = encode_header(self._protocol_version, len(request)) + request
+        frame += struct.pack(">BBH", 0x72, self._protocol_version, 0x0000)
         await self._send_cotp_dt(frame)
 
         try:

--- a/snap7/s7commplus/async_client.py
+++ b/snap7/s7commplus/async_client.py
@@ -4,6 +4,10 @@ Async S7CommPlus client for S7-1200/1500 PLCs.
 Provides the same API as S7CommPlusClient but using asyncio for
 non-blocking I/O. Uses asyncio.Lock for concurrent safety.
 
+When a PLC does not support S7CommPlus data operations, the client
+transparently falls back to the legacy S7 protocol for data block
+read/write operations (using synchronous calls in an executor).
+
 Example::
 
     async with S7CommPlusAsyncClient() as client:
@@ -27,8 +31,8 @@ from .protocol import (
     S7COMMPLUS_LOCAL_TSAP,
     S7COMMPLUS_REMOTE_TSAP,
 )
-from .codec import encode_header, decode_header, encode_typed_value
-from .vlq import encode_uint32_vlq
+from .codec import encode_header, decode_header, encode_typed_value, encode_object_qualifier
+from .vlq import encode_uint32_vlq, decode_uint64_vlq
 from .client import _build_read_payload, _parse_read_response, _build_write_payload, _parse_write_response
 
 logger = logging.getLogger(__name__)
@@ -46,6 +50,9 @@ class S7CommPlusAsyncClient:
 
     Uses asyncio for all I/O operations and asyncio.Lock for
     concurrent safety when shared between multiple coroutines.
+
+    When the PLC does not support S7CommPlus data operations, the client
+    automatically falls back to legacy S7 protocol for db_read/db_write.
     """
 
     def __init__(self) -> None:
@@ -56,9 +63,17 @@ class S7CommPlusAsyncClient:
         self._protocol_version: int = 0
         self._connected = False
         self._lock = asyncio.Lock()
+        self._legacy_client: Optional[Any] = None
+        self._use_legacy_data: bool = False
+        self._host: str = ""
+        self._port: int = 102
+        self._rack: int = 0
+        self._slot: int = 1
 
     @property
     def connected(self) -> bool:
+        if self._use_legacy_data and self._legacy_client is not None:
+            return bool(self._legacy_client.connected)
         return self._connected
 
     @property
@@ -69,6 +84,11 @@ class S7CommPlusAsyncClient:
     def session_id(self) -> int:
         return self._session_id
 
+    @property
+    def using_legacy_fallback(self) -> bool:
+        """Whether the client is using legacy S7 protocol for data operations."""
+        return self._use_legacy_data
+
     async def connect(
         self,
         host: str,
@@ -78,12 +98,20 @@ class S7CommPlusAsyncClient:
     ) -> None:
         """Connect to an S7-1200/1500 PLC.
 
+        If the PLC does not support S7CommPlus data operations, a secondary
+        legacy S7 connection is established transparently for data access.
+
         Args:
             host: PLC IP address or hostname
             port: TCP port (default 102)
             rack: PLC rack number
             slot: PLC slot number
         """
+        self._host = host
+        self._port = port
+        self._rack = rack
+        self._slot = slot
+
         # TCP connect
         self._reader, self._writer = await asyncio.open_connection(host, port)
 
@@ -101,12 +129,56 @@ class S7CommPlusAsyncClient:
             logger.info(
                 f"Async S7CommPlus connected to {host}:{port}, version=V{self._protocol_version}, session={self._session_id}"
             )
+
+            # Probe S7CommPlus data operations
+            if not await self._probe_s7commplus_data():
+                logger.info("S7CommPlus data operations not supported, falling back to legacy S7 protocol")
+                await self._setup_legacy_fallback()
+
         except Exception:
             await self.disconnect()
             raise
 
+    async def _probe_s7commplus_data(self) -> bool:
+        """Test if the PLC supports S7CommPlus data operations."""
+        try:
+            payload = struct.pack(">I", 0) + encode_uint32_vlq(0) + encode_uint32_vlq(0)
+            payload += encode_object_qualifier()
+            payload += struct.pack(">I", 0)
+
+            response = await self._send_request(FunctionCode.GET_MULTI_VARIABLES, payload)
+            if len(response) < 1:
+                return False
+            return_value, _ = decode_uint64_vlq(response, 0)
+            if return_value != 0:
+                logger.debug(f"S7CommPlus probe: PLC returned error {return_value}")
+                return False
+            return True
+        except Exception as e:
+            logger.debug(f"S7CommPlus probe failed: {e}")
+            return False
+
+    async def _setup_legacy_fallback(self) -> None:
+        """Establish a secondary legacy S7 connection for data operations."""
+        from ..client import Client
+
+        loop = asyncio.get_event_loop()
+        client = Client()
+        await loop.run_in_executor(None, lambda: client.connect(self._host, self._rack, self._slot, self._port))
+        self._legacy_client = client
+        self._use_legacy_data = True
+        logger.info(f"Legacy S7 fallback connected to {self._host}:{self._port}")
+
     async def disconnect(self) -> None:
         """Disconnect from PLC."""
+        if self._legacy_client is not None:
+            try:
+                self._legacy_client.disconnect()
+            except Exception:
+                pass
+            self._legacy_client = None
+            self._use_legacy_data = False
+
         if self._connected and self._session_id:
             try:
                 await self._delete_session()
@@ -138,6 +210,12 @@ class S7CommPlusAsyncClient:
         Returns:
             Raw bytes read from the data block
         """
+        if self._use_legacy_data and self._legacy_client is not None:
+            client = self._legacy_client
+            loop = asyncio.get_event_loop()
+            data = await loop.run_in_executor(None, lambda: client.db_read(db_number, start, size))
+            return bytes(data)
+
         payload = _build_read_payload([(db_number, start, size)])
         response = await self._send_request(FunctionCode.GET_MULTI_VARIABLES, payload)
 
@@ -156,6 +234,12 @@ class S7CommPlusAsyncClient:
             start: Start byte offset
             data: Bytes to write
         """
+        if self._use_legacy_data and self._legacy_client is not None:
+            client = self._legacy_client
+            loop = asyncio.get_event_loop()
+            await loop.run_in_executor(None, lambda: client.db_write(db_number, start, bytearray(data)))
+            return
+
         payload = _build_write_payload([(db_number, start, data)])
         response = await self._send_request(FunctionCode.SET_MULTI_VARIABLES, payload)
         _parse_write_response(response)
@@ -169,11 +253,24 @@ class S7CommPlusAsyncClient:
         Returns:
             List of raw bytes for each item
         """
+        if self._use_legacy_data and self._legacy_client is not None:
+            client = self._legacy_client
+            loop = asyncio.get_event_loop()
+            multi_results: list[bytes] = []
+            for db_number, start, size in items:
+
+                def _read(db: int = db_number, s: int = start, sz: int = size) -> bytearray:
+                    return bytearray(client.db_read(db, s, sz))
+
+                data = await loop.run_in_executor(None, _read)
+                multi_results.append(bytes(data))
+            return multi_results
+
         payload = _build_read_payload(items)
         response = await self._send_request(FunctionCode.GET_MULTI_VARIABLES, payload)
 
-        results = _parse_read_response(response)
-        return [r if r is not None else b"" for r in results]
+        parsed = _parse_read_response(response)
+        return [r if r is not None else b"" for r in parsed]
 
     async def explore(self) -> bytes:
         """Browse the PLC object tree.

--- a/snap7/s7commplus/async_client.py
+++ b/snap7/s7commplus/async_client.py
@@ -1,0 +1,385 @@
+"""
+Async S7CommPlus client for S7-1200/1500 PLCs.
+
+Provides the same API as S7CommPlusClient but using asyncio for
+non-blocking I/O. Uses asyncio.Lock for concurrent safety.
+
+Example::
+
+    async with S7CommPlusAsyncClient() as client:
+        await client.connect("192.168.1.10")
+        data = await client.db_read(1, 0, 4)
+        await client.db_write(1, 0, struct.pack(">f", 23.5))
+"""
+
+import asyncio
+import logging
+import struct
+from typing import Any, Optional
+
+from .protocol import FunctionCode, Opcode, ProtocolVersion
+from .codec import encode_header, decode_header
+from .vlq import encode_uint32_vlq, decode_uint32_vlq
+
+logger = logging.getLogger(__name__)
+
+# COTP constants
+_COTP_CR = 0xE0
+_COTP_CC = 0xD0
+_COTP_DT = 0xF0
+
+
+class S7CommPlusAsyncClient:
+    """Async S7CommPlus client for S7-1200/1500 PLCs.
+
+    Supports V1 protocol. V2/V3/TLS planned for future.
+
+    Uses asyncio for all I/O operations and asyncio.Lock for
+    concurrent safety when shared between multiple coroutines.
+    """
+
+    def __init__(self) -> None:
+        self._reader: Optional[asyncio.StreamReader] = None
+        self._writer: Optional[asyncio.StreamWriter] = None
+        self._session_id: int = 0
+        self._sequence_number: int = 0
+        self._protocol_version: int = 0
+        self._connected = False
+        self._lock = asyncio.Lock()
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    @property
+    def protocol_version(self) -> int:
+        return self._protocol_version
+
+    @property
+    def session_id(self) -> int:
+        return self._session_id
+
+    async def connect(
+        self,
+        host: str,
+        port: int = 102,
+        rack: int = 0,
+        slot: int = 1,
+    ) -> None:
+        """Connect to an S7-1200/1500 PLC.
+
+        Args:
+            host: PLC IP address or hostname
+            port: TCP port (default 102)
+            rack: PLC rack number
+            slot: PLC slot number
+        """
+        local_tsap = 0x0100
+        remote_tsap = 0x0100 | (rack << 5) | slot
+
+        # TCP connect
+        self._reader, self._writer = await asyncio.open_connection(host, port)
+
+        try:
+            # COTP handshake
+            await self._cotp_connect(local_tsap, remote_tsap)
+
+            # S7CommPlus session setup
+            await self._create_session()
+
+            self._connected = True
+            logger.info(
+                f"Async S7CommPlus connected to {host}:{port}, "
+                f"version=V{self._protocol_version}, session={self._session_id}"
+            )
+        except Exception:
+            await self.disconnect()
+            raise
+
+    async def disconnect(self) -> None:
+        """Disconnect from PLC."""
+        if self._connected and self._session_id:
+            try:
+                await self._delete_session()
+            except Exception:
+                pass
+
+        self._connected = False
+        self._session_id = 0
+        self._sequence_number = 0
+        self._protocol_version = 0
+
+        if self._writer:
+            try:
+                self._writer.close()
+                await self._writer.wait_closed()
+            except Exception:
+                pass
+            self._writer = None
+            self._reader = None
+
+    async def db_read(self, db_number: int, start: int, size: int) -> bytes:
+        """Read raw bytes from a data block.
+
+        Args:
+            db_number: Data block number
+            start: Start byte offset
+            size: Number of bytes to read
+
+        Returns:
+            Raw bytes read from the data block
+        """
+        object_id = 0x00010000 | (db_number & 0xFFFF)
+        payload = bytearray()
+        payload += encode_uint32_vlq(1)
+        payload += encode_uint32_vlq(object_id)
+        payload += encode_uint32_vlq(start)
+        payload += encode_uint32_vlq(size)
+
+        response = await self._send_request(
+            FunctionCode.GET_MULTI_VARIABLES, bytes(payload)
+        )
+
+        offset = 0
+        _, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+        item_count, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+
+        if item_count == 0:
+            return b""
+
+        status, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+        data_length, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+
+        if status != 0:
+            raise RuntimeError(f"Read failed with status {status}")
+
+        return response[offset : offset + data_length]
+
+    async def db_write(self, db_number: int, start: int, data: bytes) -> None:
+        """Write raw bytes to a data block.
+
+        Args:
+            db_number: Data block number
+            start: Start byte offset
+            data: Bytes to write
+        """
+        object_id = 0x00010000 | (db_number & 0xFFFF)
+        payload = bytearray()
+        payload += encode_uint32_vlq(1)
+        payload += encode_uint32_vlq(object_id)
+        payload += encode_uint32_vlq(start)
+        payload += encode_uint32_vlq(len(data))
+        payload += data
+
+        response = await self._send_request(
+            FunctionCode.SET_MULTI_VARIABLES, bytes(payload)
+        )
+
+        offset = 0
+        return_code, consumed = decode_uint32_vlq(response, offset)
+        if return_code != 0:
+            raise RuntimeError(f"Write failed with return code {return_code}")
+
+    async def db_read_multi(
+        self, items: list[tuple[int, int, int]]
+    ) -> list[bytes]:
+        """Read multiple data block regions in a single request.
+
+        Args:
+            items: List of (db_number, start_offset, size) tuples
+
+        Returns:
+            List of raw bytes for each item
+        """
+        payload = bytearray()
+        payload += encode_uint32_vlq(len(items))
+        for db_number, start, size in items:
+            object_id = 0x00010000 | (db_number & 0xFFFF)
+            payload += encode_uint32_vlq(object_id)
+            payload += encode_uint32_vlq(start)
+            payload += encode_uint32_vlq(size)
+
+        response = await self._send_request(
+            FunctionCode.GET_MULTI_VARIABLES, bytes(payload)
+        )
+
+        offset = 0
+        _, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+        item_count, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+
+        results: list[bytes] = []
+        for _ in range(item_count):
+            status, consumed = decode_uint32_vlq(response, offset)
+            offset += consumed
+            data_length, consumed = decode_uint32_vlq(response, offset)
+            offset += consumed
+            if status == 0 and data_length > 0:
+                results.append(response[offset : offset + data_length])
+                offset += data_length
+            else:
+                results.append(b"")
+
+        return results
+
+    async def explore(self) -> bytes:
+        """Browse the PLC object tree.
+
+        Returns:
+            Raw response payload
+        """
+        return await self._send_request(FunctionCode.EXPLORE, b"")
+
+    # -- Internal methods --
+
+    async def _send_request(self, function_code: int, payload: bytes) -> bytes:
+        """Send an S7CommPlus request and receive the response."""
+        async with self._lock:
+            if not self._connected or self._writer is None or self._reader is None:
+                raise RuntimeError("Not connected")
+
+            seq_num = self._next_sequence_number()
+
+            request = struct.pack(
+                ">BHHHHIB",
+                Opcode.REQUEST,
+                0x0000,
+                function_code,
+                0x0000,
+                seq_num,
+                self._session_id,
+                0x36,
+            ) + payload
+
+            frame = encode_header(self._protocol_version, len(request)) + request
+            await self._send_cotp_dt(frame)
+
+            response_data = await self._recv_cotp_dt()
+
+            version, data_length, consumed = decode_header(response_data)
+            response = response_data[consumed:]
+
+            if len(response) < 14:
+                raise RuntimeError("Response too short")
+
+            return response[14:]
+
+    async def _cotp_connect(self, local_tsap: int, remote_tsap: int) -> None:
+        """Perform COTP Connection Request / Confirm handshake."""
+        if self._writer is None or self._reader is None:
+            raise RuntimeError("Not connected")
+
+        # Build COTP CR
+        base_pdu = struct.pack(">BBHHB", 6, _COTP_CR, 0x0000, 0x0001, 0x00)
+        calling_tsap = struct.pack(">BBH", 0xC1, 2, local_tsap)
+        called_tsap = struct.pack(">BBH", 0xC2, 2, remote_tsap)
+        pdu_size_param = struct.pack(">BBB", 0xC0, 1, 0x0A)
+
+        params = calling_tsap + called_tsap + pdu_size_param
+        cr_pdu = struct.pack(">B", 6 + len(params)) + base_pdu[1:] + params
+
+        # Send TPKT + CR
+        tpkt = struct.pack(">BBH", 3, 0, 4 + len(cr_pdu)) + cr_pdu
+        self._writer.write(tpkt)
+        await self._writer.drain()
+
+        # Receive TPKT + CC
+        tpkt_header = await self._reader.readexactly(4)
+        _, _, length = struct.unpack(">BBH", tpkt_header)
+        payload = await self._reader.readexactly(length - 4)
+
+        if len(payload) < 7 or payload[1] != _COTP_CC:
+            raise RuntimeError(f"Expected COTP CC, got {payload[1]:#04x}")
+
+    async def _create_session(self) -> None:
+        """Send CreateObject to establish S7CommPlus session."""
+        seq_num = self._next_sequence_number()
+
+        request = struct.pack(
+            ">BHHHHIB",
+            Opcode.REQUEST,
+            0x0000,
+            FunctionCode.CREATE_OBJECT,
+            0x0000,
+            seq_num,
+            0x00000000,
+            0x36,
+        )
+        request += struct.pack(">I", 0)
+
+        frame = encode_header(ProtocolVersion.V1, len(request)) + request
+        await self._send_cotp_dt(frame)
+
+        response_data = await self._recv_cotp_dt()
+        version, data_length, consumed = decode_header(response_data)
+        response = response_data[consumed:]
+
+        if len(response) < 14:
+            raise RuntimeError("CreateObject response too short")
+
+        self._session_id = struct.unpack_from(">I", response, 9)[0]
+        self._protocol_version = version
+
+    async def _delete_session(self) -> None:
+        """Send DeleteObject to close the session."""
+        seq_num = self._next_sequence_number()
+
+        request = struct.pack(
+            ">BHHHHIB",
+            Opcode.REQUEST,
+            0x0000,
+            FunctionCode.DELETE_OBJECT,
+            0x0000,
+            seq_num,
+            self._session_id,
+            0x36,
+        )
+        request += struct.pack(">I", 0)
+
+        frame = encode_header(self._protocol_version, len(request)) + request
+        await self._send_cotp_dt(frame)
+
+        try:
+            await asyncio.wait_for(self._recv_cotp_dt(), timeout=1.0)
+        except Exception:
+            pass
+
+    async def _send_cotp_dt(self, data: bytes) -> None:
+        """Send data wrapped in COTP DT + TPKT."""
+        if self._writer is None:
+            raise RuntimeError("Not connected")
+
+        cotp_dt = struct.pack(">BBB", 2, _COTP_DT, 0x80) + data
+        tpkt = struct.pack(">BBH", 3, 0, 4 + len(cotp_dt)) + cotp_dt
+        self._writer.write(tpkt)
+        await self._writer.drain()
+
+    async def _recv_cotp_dt(self) -> bytes:
+        """Receive TPKT + COTP DT and return the payload."""
+        if self._reader is None:
+            raise RuntimeError("Not connected")
+
+        tpkt_header = await self._reader.readexactly(4)
+        _, _, length = struct.unpack(">BBH", tpkt_header)
+        payload = await self._reader.readexactly(length - 4)
+
+        if len(payload) < 3 or payload[1] != _COTP_DT:
+            raise RuntimeError(f"Expected COTP DT, got {payload[1]:#04x}")
+
+        return payload[3:]
+
+    def _next_sequence_number(self) -> int:
+        seq = self._sequence_number
+        self._sequence_number = (self._sequence_number + 1) & 0xFFFF
+        return seq
+
+    async def __aenter__(self) -> "S7CommPlusAsyncClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        await self.disconnect()

--- a/snap7/s7commplus/client.py
+++ b/snap7/s7commplus/client.py
@@ -9,6 +9,11 @@ Supports all S7CommPlus protocol versions (V1/V2/V3/TLS). The protocol
 version is auto-detected from the PLC's CreateObject response during
 connection setup.
 
+When a PLC does not support S7CommPlus data operations (e.g. PLCs that
+accept S7CommPlus sessions but return ERROR2 for GetMultiVariables),
+the client transparently falls back to the legacy S7 protocol for
+data block read/write operations.
+
 Status: V1 connection is functional. V2/V3/TLS authentication planned.
 
 Reference: thomas-v2/S7CommPlusDriver (C#, LGPL-3.0)
@@ -42,6 +47,9 @@ class S7CommPlusClient:
 
     The protocol version is auto-detected during connection.
 
+    When the PLC does not support S7CommPlus data operations, the client
+    automatically falls back to legacy S7 protocol for db_read/db_write.
+
     Example::
 
         client = S7CommPlusClient()
@@ -58,9 +66,17 @@ class S7CommPlusClient:
 
     def __init__(self) -> None:
         self._connection: Optional[S7CommPlusConnection] = None
+        self._legacy_client: Optional[Any] = None
+        self._use_legacy_data: bool = False
+        self._host: str = ""
+        self._port: int = 102
+        self._rack: int = 0
+        self._slot: int = 1
 
     @property
     def connected(self) -> bool:
+        if self._use_legacy_data and self._legacy_client is not None:
+            return bool(self._legacy_client.connected)
         return self._connection is not None and self._connection.connected
 
     @property
@@ -77,6 +93,11 @@ class S7CommPlusClient:
             return 0
         return self._connection.session_id
 
+    @property
+    def using_legacy_fallback(self) -> bool:
+        """Whether the client is using legacy S7 protocol for data operations."""
+        return self._use_legacy_data
+
     def connect(
         self,
         host: str,
@@ -90,6 +111,9 @@ class S7CommPlusClient:
     ) -> None:
         """Connect to an S7-1200/1500 PLC using S7CommPlus.
 
+        If the PLC does not support S7CommPlus data operations, a secondary
+        legacy S7 connection is established transparently for data access.
+
         Args:
             host: PLC IP address or hostname
             port: TCP port (default 102)
@@ -100,6 +124,11 @@ class S7CommPlusClient:
             tls_key: Path to client private key (PEM)
             tls_ca: Path to CA certificate for PLC verification (PEM)
         """
+        self._host = host
+        self._port = port
+        self._rack = rack
+        self._slot = slot
+
         self._connection = S7CommPlusConnection(
             host=host,
             port=port,
@@ -112,8 +141,63 @@ class S7CommPlusClient:
             tls_ca=tls_ca,
         )
 
+        # Probe S7CommPlus data operations with a minimal request
+        if not self._probe_s7commplus_data():
+            logger.info("S7CommPlus data operations not supported, falling back to legacy S7 protocol")
+            self._setup_legacy_fallback()
+
+    def _probe_s7commplus_data(self) -> bool:
+        """Test if the PLC supports S7CommPlus data operations.
+
+        Sends a minimal GetMultiVariables request with zero items. If the PLC
+        responds with ERROR2 or a non-zero return code, data operations are
+        not supported.
+
+        Returns:
+            True if S7CommPlus data operations work.
+        """
+        if self._connection is None:
+            return False
+
+        try:
+            # Send a minimal GetMultiVariables with 0 items
+            payload = struct.pack(">I", 0) + encode_uint32_vlq(0) + encode_uint32_vlq(0)
+            payload += encode_object_qualifier()
+            payload += struct.pack(">I", 0)
+
+            response = self._connection.send_request(FunctionCode.GET_MULTI_VARIABLES, payload)
+
+            # Check if we got a valid response (return value = 0)
+            if len(response) < 1:
+                return False
+            return_value, _ = decode_uint64_vlq(response, 0)
+            if return_value != 0:
+                logger.debug(f"S7CommPlus probe: PLC returned error {return_value}")
+                return False
+            return True
+        except Exception as e:
+            logger.debug(f"S7CommPlus probe failed: {e}")
+            return False
+
+    def _setup_legacy_fallback(self) -> None:
+        """Establish a secondary legacy S7 connection for data operations."""
+        from ..client import Client
+
+        self._legacy_client = Client()
+        self._legacy_client.connect(self._host, self._rack, self._slot, self._port)
+        self._use_legacy_data = True
+        logger.info(f"Legacy S7 fallback connected to {self._host}:{self._port}")
+
     def disconnect(self) -> None:
         """Disconnect from PLC."""
+        if self._legacy_client is not None:
+            try:
+                self._legacy_client.disconnect()
+            except Exception:
+                pass
+            self._legacy_client = None
+            self._use_legacy_data = False
+
         if self._connection:
             self._connection.disconnect()
             self._connection = None
@@ -123,6 +207,9 @@ class S7CommPlusClient:
     def db_read(self, db_number: int, start: int, size: int) -> bytes:
         """Read raw bytes from a data block.
 
+        Uses S7CommPlus protocol when supported, otherwise falls back to
+        legacy S7 protocol transparently.
+
         Args:
             db_number: Data block number
             start: Start byte offset
@@ -131,6 +218,9 @@ class S7CommPlusClient:
         Returns:
             Raw bytes read from the data block
         """
+        if self._use_legacy_data and self._legacy_client is not None:
+            return bytes(self._legacy_client.db_read(db_number, start, size))
+
         if self._connection is None:
             raise RuntimeError("Not connected")
 
@@ -150,11 +240,18 @@ class S7CommPlusClient:
     def db_write(self, db_number: int, start: int, data: bytes) -> None:
         """Write raw bytes to a data block.
 
+        Uses S7CommPlus protocol when supported, otherwise falls back to
+        legacy S7 protocol transparently.
+
         Args:
             db_number: Data block number
             start: Start byte offset
             data: Bytes to write
         """
+        if self._use_legacy_data and self._legacy_client is not None:
+            self._legacy_client.db_write(db_number, start, bytearray(data))
+            return
+
         if self._connection is None:
             raise RuntimeError("Not connected")
 
@@ -171,12 +268,22 @@ class S7CommPlusClient:
     def db_read_multi(self, items: list[tuple[int, int, int]]) -> list[bytes]:
         """Read multiple data block regions in a single request.
 
+        Uses S7CommPlus protocol when supported, otherwise falls back to
+        legacy S7 protocol (individual reads) transparently.
+
         Args:
             items: List of (db_number, start_offset, size) tuples
 
         Returns:
             List of raw bytes for each item
         """
+        if self._use_legacy_data and self._legacy_client is not None:
+            results = []
+            for db_number, start, size in items:
+                data = self._legacy_client.db_read(db_number, start, size)
+                results.append(bytes(data))
+            return results
+
         if self._connection is None:
             raise RuntimeError("Not connected")
 
@@ -186,8 +293,8 @@ class S7CommPlusClient:
         response = self._connection.send_request(FunctionCode.GET_MULTI_VARIABLES, payload)
         logger.debug(f"db_read_multi: response ({len(response)} bytes): {response.hex(' ')}")
 
-        results = _parse_read_response(response)
-        return [r if r is not None else b"" for r in results]
+        parsed = _parse_read_response(response)
+        return [r if r is not None else b"" for r in parsed]
 
     # -- Explore (browse PLC object tree) --
 

--- a/snap7/s7commplus/client.py
+++ b/snap7/s7commplus/client.py
@@ -93,14 +93,9 @@ class S7CommPlusClient:
             tls_key: Path to client private key (PEM)
             tls_ca: Path to CA certificate for PLC verification (PEM)
         """
-        local_tsap = 0x0100
-        remote_tsap = 0x0100 | (rack << 5) | slot
-
         self._connection = S7CommPlusConnection(
             host=host,
             port=port,
-            local_tsap=local_tsap,
-            remote_tsap=remote_tsap,
         )
 
         self._connection.connect(

--- a/snap7/s7commplus/client.py
+++ b/snap7/s7commplus/client.py
@@ -9,8 +9,7 @@ Supports all S7CommPlus protocol versions (V1/V2/V3/TLS). The protocol
 version is auto-detected from the PLC's CreateObject response during
 connection setup.
 
-Status: experimental scaffolding -- not yet functional.
-All methods raise NotImplementedError with guidance on what needs to be done.
+Status: V1 connection is functional. V2/V3/TLS authentication planned.
 
 Reference: thomas-v2/S7CommPlusDriver (C#, LGPL-3.0)
 """
@@ -19,6 +18,8 @@ import logging
 from typing import Any, Optional
 
 from .connection import S7CommPlusConnection
+from .protocol import FunctionCode
+from .vlq import encode_uint32_vlq, decode_uint32_vlq
 
 logger = logging.getLogger(__name__)
 
@@ -34,11 +35,17 @@ class S7CommPlusClient:
 
     The protocol version is auto-detected during connection.
 
-    Example (future, once implemented)::
+    Example::
 
         client = S7CommPlusClient()
         client.connect("192.168.1.10")
-        value = client.read_variable("DB1.myVariable")
+
+        # Read raw bytes from DB1
+        data = client.db_read(1, 0, 4)
+
+        # Write raw bytes to DB1
+        client.db_write(1, 0, struct.pack(">f", 23.5))
+
         client.disconnect()
     """
 
@@ -49,12 +56,27 @@ class S7CommPlusClient:
     def connected(self) -> bool:
         return self._connection is not None and self._connection.connected
 
+    @property
+    def protocol_version(self) -> int:
+        """Protocol version negotiated with the PLC."""
+        if self._connection is None:
+            return 0
+        return self._connection.protocol_version
+
+    @property
+    def session_id(self) -> int:
+        """Session ID assigned by the PLC."""
+        if self._connection is None:
+            return 0
+        return self._connection.session_id
+
     def connect(
         self,
         host: str,
         port: int = 102,
         rack: int = 0,
         slot: int = 1,
+        use_tls: bool = False,
         tls_cert: Optional[str] = None,
         tls_key: Optional[str] = None,
         tls_ca: Optional[str] = None,
@@ -66,12 +88,10 @@ class S7CommPlusClient:
             port: TCP port (default 102)
             rack: PLC rack number
             slot: PLC slot number
+            use_tls: Whether to attempt TLS (requires V3 PLC + certs)
             tls_cert: Path to client TLS certificate (PEM)
             tls_key: Path to client private key (PEM)
             tls_ca: Path to CA certificate for PLC verification (PEM)
-
-        Raises:
-            NotImplementedError: S7CommPlus connection is not yet implemented
         """
         local_tsap = 0x0100
         remote_tsap = 0x0100 | (rack << 5) | slot
@@ -84,6 +104,7 @@ class S7CommPlusClient:
         )
 
         self._connection.connect(
+            use_tls=use_tls,
             tls_cert=tls_cert,
             tls_key=tls_key,
             tls_ca=tls_ca,
@@ -95,158 +116,155 @@ class S7CommPlusClient:
             self._connection.disconnect()
             self._connection = None
 
+    # -- Data block read/write --
+
+    def db_read(self, db_number: int, start: int, size: int) -> bytes:
+        """Read raw bytes from a data block.
+
+        Args:
+            db_number: Data block number
+            start: Start byte offset
+            size: Number of bytes to read
+
+        Returns:
+            Raw bytes read from the data block
+        """
+        if self._connection is None:
+            raise RuntimeError("Not connected")
+
+        # Build GetMultiVariables request payload
+        object_id = 0x00010000 | (db_number & 0xFFFF)
+        payload = bytearray()
+        payload += encode_uint32_vlq(1)  # 1 item
+        payload += encode_uint32_vlq(object_id)
+        payload += encode_uint32_vlq(start)
+        payload += encode_uint32_vlq(size)
+
+        response = self._connection.send_request(
+            FunctionCode.GET_MULTI_VARIABLES, bytes(payload)
+        )
+
+        # Parse response
+        offset = 0
+        # Skip return code
+        _, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+
+        # Item count
+        item_count, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+
+        if item_count == 0:
+            return b""
+
+        # First item: status + data_length + data
+        status, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+
+        data_length, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+
+        if status != 0:
+            raise RuntimeError(f"Read failed with status {status}")
+
+        return response[offset : offset + data_length]
+
+    def db_write(self, db_number: int, start: int, data: bytes) -> None:
+        """Write raw bytes to a data block.
+
+        Args:
+            db_number: Data block number
+            start: Start byte offset
+            data: Bytes to write
+        """
+        if self._connection is None:
+            raise RuntimeError("Not connected")
+
+        object_id = 0x00010000 | (db_number & 0xFFFF)
+        payload = bytearray()
+        payload += encode_uint32_vlq(1)  # 1 item
+        payload += encode_uint32_vlq(object_id)
+        payload += encode_uint32_vlq(start)
+        payload += encode_uint32_vlq(len(data))
+        payload += data
+
+        response = self._connection.send_request(
+            FunctionCode.SET_MULTI_VARIABLES, bytes(payload)
+        )
+
+        # Parse response - check return code
+        offset = 0
+        return_code, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+
+        if return_code != 0:
+            raise RuntimeError(f"Write failed with return code {return_code}")
+
+    def db_read_multi(
+        self, items: list[tuple[int, int, int]]
+    ) -> list[bytes]:
+        """Read multiple data block regions in a single request.
+
+        Args:
+            items: List of (db_number, start_offset, size) tuples
+
+        Returns:
+            List of raw bytes for each item
+        """
+        if self._connection is None:
+            raise RuntimeError("Not connected")
+
+        payload = bytearray()
+        payload += encode_uint32_vlq(len(items))
+        for db_number, start, size in items:
+            object_id = 0x00010000 | (db_number & 0xFFFF)
+            payload += encode_uint32_vlq(object_id)
+            payload += encode_uint32_vlq(start)
+            payload += encode_uint32_vlq(size)
+
+        response = self._connection.send_request(
+            FunctionCode.GET_MULTI_VARIABLES, bytes(payload)
+        )
+
+        # Parse response
+        offset = 0
+        _, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+
+        item_count, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+
+        results: list[bytes] = []
+        for _ in range(item_count):
+            status, consumed = decode_uint32_vlq(response, offset)
+            offset += consumed
+
+            data_length, consumed = decode_uint32_vlq(response, offset)
+            offset += consumed
+
+            if status == 0 and data_length > 0:
+                results.append(response[offset : offset + data_length])
+                offset += data_length
+            else:
+                results.append(b"")
+
+        return results
+
     # -- Explore (browse PLC object tree) --
 
-    def explore(self, object_id: int = 0) -> dict[str, Any]:
+    def explore(self) -> bytes:
         """Browse the PLC object tree.
 
-        The Explore function is used to discover the structure of data
-        blocks, variable names, types, and addresses in the PLC.
-
-        Args:
-            object_id: Root object ID to start exploring from.
-                       0 = root of the PLC object tree.
+        Returns the raw Explore response payload for parsing.
+        Full symbolic exploration will be implemented in a future version.
 
         Returns:
-            Dictionary describing the object tree structure.
-
-        Raises:
-            NotImplementedError: Not yet implemented
+            Raw response payload
         """
-        # TODO: Build ExploreRequest, send, parse ExploreResponse
-        # This is the key operation for discovering symbolic addresses.
-        raise NotImplementedError("explore() is not yet implemented")
+        if self._connection is None:
+            raise RuntimeError("Not connected")
 
-    # -- Variable read/write --
-
-    def read_variable(self, address: str) -> Any:
-        """Read a single PLC variable by symbolic address.
-
-        S7CommPlus supports symbolic access to variables in optimized
-        data blocks, e.g. "DB1.myStruct.myField".
-
-        Args:
-            address: Symbolic variable address
-
-        Returns:
-            Variable value (type depends on PLC variable type)
-
-        Raises:
-            NotImplementedError: Not yet implemented
-        """
-        # TODO: Resolve symbolic address -> numeric address via Explore
-        # TODO: Build GetMultiVariables request
-        raise NotImplementedError("read_variable() is not yet implemented")
-
-    def write_variable(self, address: str, value: Any) -> None:
-        """Write a single PLC variable by symbolic address.
-
-        Args:
-            address: Symbolic variable address
-            value: Value to write
-
-        Raises:
-            NotImplementedError: Not yet implemented
-        """
-        # TODO: Resolve address, build SetMultiVariables request
-        raise NotImplementedError("write_variable() is not yet implemented")
-
-    def read_variables(self, addresses: list[str]) -> dict[str, Any]:
-        """Read multiple PLC variables in a single request.
-
-        Args:
-            addresses: List of symbolic variable addresses
-
-        Returns:
-            Dictionary mapping address -> value
-
-        Raises:
-            NotImplementedError: Not yet implemented
-        """
-        # TODO: Build GetMultiVariables with multiple items
-        raise NotImplementedError("read_variables() is not yet implemented")
-
-    def write_variables(self, values: dict[str, Any]) -> None:
-        """Write multiple PLC variables in a single request.
-
-        Args:
-            values: Dictionary mapping address -> value
-
-        Raises:
-            NotImplementedError: Not yet implemented
-        """
-        # TODO: Build SetMultiVariables with multiple items
-        raise NotImplementedError("write_variables() is not yet implemented")
-
-    # -- PLC control --
-
-    def get_cpu_state(self) -> str:
-        """Get the current CPU operational state.
-
-        Returns:
-            CPU state string (e.g. "Run", "Stop")
-
-        Raises:
-            NotImplementedError: Not yet implemented
-        """
-        raise NotImplementedError("get_cpu_state() is not yet implemented")
-
-    def plc_start(self) -> None:
-        """Start PLC execution.
-
-        Raises:
-            NotImplementedError: Not yet implemented
-        """
-        raise NotImplementedError("plc_start() is not yet implemented")
-
-    def plc_stop(self) -> None:
-        """Stop PLC execution.
-
-        Raises:
-            NotImplementedError: Not yet implemented
-        """
-        raise NotImplementedError("plc_stop() is not yet implemented")
-
-    # -- Block operations --
-
-    def list_blocks(self) -> dict[str, list[int]]:
-        """List all blocks in the PLC.
-
-        Returns:
-            Dictionary mapping block type -> list of block numbers
-
-        Raises:
-            NotImplementedError: Not yet implemented
-        """
-        raise NotImplementedError("list_blocks() is not yet implemented")
-
-    def upload_block(self, block_type: str, block_number: int) -> bytes:
-        """Upload (read) a block from the PLC.
-
-        Args:
-            block_type: Block type ("OB", "FB", "FC", "DB")
-            block_number: Block number
-
-        Returns:
-            Block data
-
-        Raises:
-            NotImplementedError: Not yet implemented
-        """
-        raise NotImplementedError("upload_block() is not yet implemented")
-
-    def download_block(self, block_type: str, block_number: int, data: bytes) -> None:
-        """Download (write) a block to the PLC.
-
-        Args:
-            block_type: Block type ("OB", "FB", "FC", "DB")
-            block_number: Block number
-            data: Block data to download
-
-        Raises:
-            NotImplementedError: Not yet implemented
-        """
-        raise NotImplementedError("download_block() is not yet implemented")
+        return self._connection.send_request(FunctionCode.EXPLORE, b"")
 
     # -- Context manager --
 

--- a/snap7/s7commplus/client.py
+++ b/snap7/s7commplus/client.py
@@ -160,8 +160,7 @@ class S7CommPlusClient:
 
         payload = _build_write_payload([(db_number, start, data)])
         logger.debug(
-            f"db_write: db={db_number} start={start} data_len={len(data)} "
-            f"data={data.hex(' ')} payload={payload.hex(' ')}"
+            f"db_write: db={db_number} start={start} data_len={len(data)} data={data.hex(' ')} payload={payload.hex(' ')}"
         )
 
         response = self._connection.send_request(FunctionCode.SET_MULTI_VARIABLES, payload)
@@ -239,7 +238,7 @@ def _build_read_payload(items: list[tuple[int, int, int]]) -> bytes:
         addr_bytes, field_count = encode_item_address(
             access_area=access_area,
             access_sub_area=Ids.DB_VALUE_ACTUAL,
-            lids=[start, size],
+            lids=[start + 1, size],  # LID byte offsets are 1-based in S7CommPlus
         )
         addresses.append(addr_bytes)
         total_field_count += field_count
@@ -338,7 +337,7 @@ def _build_write_payload(items: list[tuple[int, int, bytes]]) -> bytes:
         addr_bytes, field_count = encode_item_address(
             access_area=access_area,
             access_sub_area=Ids.DB_VALUE_ACTUAL,
-            lids=[start, len(data)],
+            lids=[start + 1, len(data)],  # LID byte offsets are 1-based in S7CommPlus
         )
         addresses.append(addr_bytes)
         total_field_count += field_count

--- a/snap7/s7commplus/client.py
+++ b/snap7/s7commplus/client.py
@@ -140,9 +140,7 @@ class S7CommPlusClient:
         payload += encode_uint32_vlq(start)
         payload += encode_uint32_vlq(size)
 
-        response = self._connection.send_request(
-            FunctionCode.GET_MULTI_VARIABLES, bytes(payload)
-        )
+        response = self._connection.send_request(FunctionCode.GET_MULTI_VARIABLES, bytes(payload))
 
         # Parse response
         offset = 0
@@ -188,9 +186,7 @@ class S7CommPlusClient:
         payload += encode_uint32_vlq(len(data))
         payload += data
 
-        response = self._connection.send_request(
-            FunctionCode.SET_MULTI_VARIABLES, bytes(payload)
-        )
+        response = self._connection.send_request(FunctionCode.SET_MULTI_VARIABLES, bytes(payload))
 
         # Parse response - check return code
         offset = 0
@@ -200,9 +196,7 @@ class S7CommPlusClient:
         if return_code != 0:
             raise RuntimeError(f"Write failed with return code {return_code}")
 
-    def db_read_multi(
-        self, items: list[tuple[int, int, int]]
-    ) -> list[bytes]:
+    def db_read_multi(self, items: list[tuple[int, int, int]]) -> list[bytes]:
         """Read multiple data block regions in a single request.
 
         Args:
@@ -222,9 +216,7 @@ class S7CommPlusClient:
             payload += encode_uint32_vlq(start)
             payload += encode_uint32_vlq(size)
 
-        response = self._connection.send_request(
-            FunctionCode.GET_MULTI_VARIABLES, bytes(payload)
-        )
+        response = self._connection.send_request(FunctionCode.GET_MULTI_VARIABLES, bytes(payload))
 
         # Parse response
         offset = 0

--- a/snap7/s7commplus/client.py
+++ b/snap7/s7commplus/client.py
@@ -1,0 +1,257 @@
+"""
+S7CommPlus client for S7-1200/1500 PLCs.
+
+Provides high-level operations over the S7CommPlus protocol, similar to
+the existing snap7.Client but targeting S7-1200/1500 PLCs with full
+engineering access (symbolic addressing, optimized data blocks, etc.).
+
+Supports all S7CommPlus protocol versions (V1/V2/V3/TLS). The protocol
+version is auto-detected from the PLC's CreateObject response during
+connection setup.
+
+Status: experimental scaffolding -- not yet functional.
+All methods raise NotImplementedError with guidance on what needs to be done.
+
+Reference: thomas-v2/S7CommPlusDriver (C#, LGPL-3.0)
+"""
+
+import logging
+from typing import Any, Optional
+
+from .connection import S7CommPlusConnection
+
+logger = logging.getLogger(__name__)
+
+
+class S7CommPlusClient:
+    """S7CommPlus client for S7-1200/1500 PLCs.
+
+    Supports all S7CommPlus protocol versions:
+    - V1: S7-1200 FW V4.0+
+    - V2: S7-1200/1500 with older firmware
+    - V3: S7-1200/1500 pre-TIA Portal V17
+    - V3 + TLS: TIA Portal V17+ (recommended)
+
+    The protocol version is auto-detected during connection.
+
+    Example (future, once implemented)::
+
+        client = S7CommPlusClient()
+        client.connect("192.168.1.10")
+        value = client.read_variable("DB1.myVariable")
+        client.disconnect()
+    """
+
+    def __init__(self) -> None:
+        self._connection: Optional[S7CommPlusConnection] = None
+
+    @property
+    def connected(self) -> bool:
+        return self._connection is not None and self._connection.connected
+
+    def connect(
+        self,
+        host: str,
+        port: int = 102,
+        rack: int = 0,
+        slot: int = 1,
+        tls_cert: Optional[str] = None,
+        tls_key: Optional[str] = None,
+        tls_ca: Optional[str] = None,
+    ) -> None:
+        """Connect to an S7-1200/1500 PLC using S7CommPlus.
+
+        Args:
+            host: PLC IP address or hostname
+            port: TCP port (default 102)
+            rack: PLC rack number
+            slot: PLC slot number
+            tls_cert: Path to client TLS certificate (PEM)
+            tls_key: Path to client private key (PEM)
+            tls_ca: Path to CA certificate for PLC verification (PEM)
+
+        Raises:
+            NotImplementedError: S7CommPlus connection is not yet implemented
+        """
+        local_tsap = 0x0100
+        remote_tsap = 0x0100 | (rack << 5) | slot
+
+        self._connection = S7CommPlusConnection(
+            host=host,
+            port=port,
+            local_tsap=local_tsap,
+            remote_tsap=remote_tsap,
+        )
+
+        self._connection.connect(
+            tls_cert=tls_cert,
+            tls_key=tls_key,
+            tls_ca=tls_ca,
+        )
+
+    def disconnect(self) -> None:
+        """Disconnect from PLC."""
+        if self._connection:
+            self._connection.disconnect()
+            self._connection = None
+
+    # -- Explore (browse PLC object tree) --
+
+    def explore(self, object_id: int = 0) -> dict[str, Any]:
+        """Browse the PLC object tree.
+
+        The Explore function is used to discover the structure of data
+        blocks, variable names, types, and addresses in the PLC.
+
+        Args:
+            object_id: Root object ID to start exploring from.
+                       0 = root of the PLC object tree.
+
+        Returns:
+            Dictionary describing the object tree structure.
+
+        Raises:
+            NotImplementedError: Not yet implemented
+        """
+        # TODO: Build ExploreRequest, send, parse ExploreResponse
+        # This is the key operation for discovering symbolic addresses.
+        raise NotImplementedError("explore() is not yet implemented")
+
+    # -- Variable read/write --
+
+    def read_variable(self, address: str) -> Any:
+        """Read a single PLC variable by symbolic address.
+
+        S7CommPlus supports symbolic access to variables in optimized
+        data blocks, e.g. "DB1.myStruct.myField".
+
+        Args:
+            address: Symbolic variable address
+
+        Returns:
+            Variable value (type depends on PLC variable type)
+
+        Raises:
+            NotImplementedError: Not yet implemented
+        """
+        # TODO: Resolve symbolic address -> numeric address via Explore
+        # TODO: Build GetMultiVariables request
+        raise NotImplementedError("read_variable() is not yet implemented")
+
+    def write_variable(self, address: str, value: Any) -> None:
+        """Write a single PLC variable by symbolic address.
+
+        Args:
+            address: Symbolic variable address
+            value: Value to write
+
+        Raises:
+            NotImplementedError: Not yet implemented
+        """
+        # TODO: Resolve address, build SetMultiVariables request
+        raise NotImplementedError("write_variable() is not yet implemented")
+
+    def read_variables(self, addresses: list[str]) -> dict[str, Any]:
+        """Read multiple PLC variables in a single request.
+
+        Args:
+            addresses: List of symbolic variable addresses
+
+        Returns:
+            Dictionary mapping address -> value
+
+        Raises:
+            NotImplementedError: Not yet implemented
+        """
+        # TODO: Build GetMultiVariables with multiple items
+        raise NotImplementedError("read_variables() is not yet implemented")
+
+    def write_variables(self, values: dict[str, Any]) -> None:
+        """Write multiple PLC variables in a single request.
+
+        Args:
+            values: Dictionary mapping address -> value
+
+        Raises:
+            NotImplementedError: Not yet implemented
+        """
+        # TODO: Build SetMultiVariables with multiple items
+        raise NotImplementedError("write_variables() is not yet implemented")
+
+    # -- PLC control --
+
+    def get_cpu_state(self) -> str:
+        """Get the current CPU operational state.
+
+        Returns:
+            CPU state string (e.g. "Run", "Stop")
+
+        Raises:
+            NotImplementedError: Not yet implemented
+        """
+        raise NotImplementedError("get_cpu_state() is not yet implemented")
+
+    def plc_start(self) -> None:
+        """Start PLC execution.
+
+        Raises:
+            NotImplementedError: Not yet implemented
+        """
+        raise NotImplementedError("plc_start() is not yet implemented")
+
+    def plc_stop(self) -> None:
+        """Stop PLC execution.
+
+        Raises:
+            NotImplementedError: Not yet implemented
+        """
+        raise NotImplementedError("plc_stop() is not yet implemented")
+
+    # -- Block operations --
+
+    def list_blocks(self) -> dict[str, list[int]]:
+        """List all blocks in the PLC.
+
+        Returns:
+            Dictionary mapping block type -> list of block numbers
+
+        Raises:
+            NotImplementedError: Not yet implemented
+        """
+        raise NotImplementedError("list_blocks() is not yet implemented")
+
+    def upload_block(self, block_type: str, block_number: int) -> bytes:
+        """Upload (read) a block from the PLC.
+
+        Args:
+            block_type: Block type ("OB", "FB", "FC", "DB")
+            block_number: Block number
+
+        Returns:
+            Block data
+
+        Raises:
+            NotImplementedError: Not yet implemented
+        """
+        raise NotImplementedError("upload_block() is not yet implemented")
+
+    def download_block(self, block_type: str, block_number: int, data: bytes) -> None:
+        """Download (write) a block to the PLC.
+
+        Args:
+            block_type: Block type ("OB", "FB", "FC", "DB")
+            block_number: Block number
+            data: Block data to download
+
+        Raises:
+            NotImplementedError: Not yet implemented
+        """
+        raise NotImplementedError("download_block() is not yet implemented")
+
+    # -- Context manager --
+
+    def __enter__(self) -> "S7CommPlusClient":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.disconnect()

--- a/snap7/s7commplus/client.py
+++ b/snap7/s7commplus/client.py
@@ -15,11 +15,18 @@ Reference: thomas-v2/S7CommPlusDriver (C#, LGPL-3.0)
 """
 
 import logging
+import struct
 from typing import Any, Optional
 
 from .connection import S7CommPlusConnection
-from .protocol import FunctionCode
-from .vlq import encode_uint32_vlq, decode_uint32_vlq
+from .protocol import FunctionCode, Ids
+from .vlq import encode_uint32_vlq, decode_uint32_vlq, decode_uint64_vlq
+from .codec import (
+    encode_item_address,
+    encode_object_qualifier,
+    encode_pvalue_blob,
+    decode_pvalue_to_bytes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -127,61 +134,18 @@ class S7CommPlusClient:
         if self._connection is None:
             raise RuntimeError("Not connected")
 
-        # Build GetMultiVariables request payload
-        object_id = 0x00010000 | (db_number & 0xFFFF)
-        payload = bytearray()
-        payload += encode_uint32_vlq(1)  # 1 item
-        payload += encode_uint32_vlq(object_id)
-        payload += encode_uint32_vlq(start)
-        payload += encode_uint32_vlq(size)
+        payload = _build_read_payload([(db_number, start, size)])
+        logger.debug(f"db_read: db={db_number} start={start} size={size} payload={payload.hex(' ')}")
 
-        logger.debug(
-            f"db_read: db={db_number} start={start} size={size} "
-            f"object_id=0x{object_id:08X} payload={bytes(payload).hex(' ')}"
-        )
-
-        response = self._connection.send_request(FunctionCode.GET_MULTI_VARIABLES, bytes(payload))
-
+        response = self._connection.send_request(FunctionCode.GET_MULTI_VARIABLES, payload)
         logger.debug(f"db_read: response ({len(response)} bytes): {response.hex(' ')}")
 
-        # Parse response
-        offset = 0
-        # Skip return code
-        return_code, consumed = decode_uint32_vlq(response, offset)
-        logger.debug(f"db_read: return_code={return_code} (consumed {consumed} bytes)")
-        offset += consumed
-
-        # Item count
-        item_count, consumed = decode_uint32_vlq(response, offset)
-        logger.debug(f"db_read: item_count={item_count} (consumed {consumed} bytes)")
-        offset += consumed
-
-        if item_count == 0:
-            logger.debug("db_read: no items returned")
-            return b""
-
-        # First item: status + data_length + data
-        status, consumed = decode_uint32_vlq(response, offset)
-        logger.debug(f"db_read: item status={status} (consumed {consumed} bytes)")
-        offset += consumed
-
-        data_length, consumed = decode_uint32_vlq(response, offset)
-        logger.debug(f"db_read: data_length={data_length} (consumed {consumed} bytes)")
-        offset += consumed
-
-        if status != 0:
-            logger.error(
-                f"db_read: FAILED status={status}, remaining bytes: {response[offset:].hex(' ')}"
-            )
-            raise RuntimeError(f"Read failed with status {status}")
-
-        result = response[offset : offset + data_length]
-        logger.debug(f"db_read: result ({len(result)} bytes): {result.hex(' ')}")
-        remaining = response[offset + data_length :]
-        if remaining:
-            logger.debug(f"db_read: remaining after data ({len(remaining)} bytes): {remaining.hex(' ')}")
-
-        return result
+        results = _parse_read_response(response)
+        if not results:
+            raise RuntimeError("Read returned no data")
+        if results[0] is None:
+            raise RuntimeError("Read failed: PLC returned error for item")
+        return results[0]
 
     def db_write(self, db_number: int, start: int, data: bytes) -> None:
         """Write raw bytes to a data block.
@@ -194,34 +158,16 @@ class S7CommPlusClient:
         if self._connection is None:
             raise RuntimeError("Not connected")
 
-        object_id = 0x00010000 | (db_number & 0xFFFF)
-        payload = bytearray()
-        payload += encode_uint32_vlq(1)  # 1 item
-        payload += encode_uint32_vlq(object_id)
-        payload += encode_uint32_vlq(start)
-        payload += encode_uint32_vlq(len(data))
-        payload += data
-
+        payload = _build_write_payload([(db_number, start, data)])
         logger.debug(
             f"db_write: db={db_number} start={start} data_len={len(data)} "
-            f"object_id=0x{object_id:08X} data={data.hex(' ')} payload={bytes(payload).hex(' ')}"
+            f"data={data.hex(' ')} payload={payload.hex(' ')}"
         )
 
-        response = self._connection.send_request(FunctionCode.SET_MULTI_VARIABLES, bytes(payload))
-
+        response = self._connection.send_request(FunctionCode.SET_MULTI_VARIABLES, payload)
         logger.debug(f"db_write: response ({len(response)} bytes): {response.hex(' ')}")
 
-        # Parse response - check return code
-        offset = 0
-        return_code, consumed = decode_uint32_vlq(response, offset)
-        logger.debug(f"db_write: return_code={return_code} (consumed {consumed} bytes)")
-        offset += consumed
-
-        if return_code != 0:
-            logger.error(
-                f"db_write: FAILED return_code={return_code}, remaining: {response[offset:].hex(' ')}"
-            )
-            raise RuntimeError(f"Write failed with return code {return_code}")
+        _parse_write_response(response)
 
     def db_read_multi(self, items: list[tuple[int, int, int]]) -> list[bytes]:
         """Read multiple data block regions in a single request.
@@ -235,50 +181,14 @@ class S7CommPlusClient:
         if self._connection is None:
             raise RuntimeError("Not connected")
 
-        payload = bytearray()
-        payload += encode_uint32_vlq(len(items))
-        for db_number, start, size in items:
-            object_id = 0x00010000 | (db_number & 0xFFFF)
-            payload += encode_uint32_vlq(object_id)
-            payload += encode_uint32_vlq(start)
-            payload += encode_uint32_vlq(size)
+        payload = _build_read_payload(items)
+        logger.debug(f"db_read_multi: {len(items)} items: {items} payload={payload.hex(' ')}")
 
-        logger.debug(f"db_read_multi: {len(items)} items: {items} payload={bytes(payload).hex(' ')}")
-
-        response = self._connection.send_request(FunctionCode.GET_MULTI_VARIABLES, bytes(payload))
-
+        response = self._connection.send_request(FunctionCode.GET_MULTI_VARIABLES, payload)
         logger.debug(f"db_read_multi: response ({len(response)} bytes): {response.hex(' ')}")
 
-        # Parse response
-        offset = 0
-        return_code, consumed = decode_uint32_vlq(response, offset)
-        logger.debug(f"db_read_multi: return_code={return_code} (consumed {consumed} bytes)")
-        offset += consumed
-
-        item_count, consumed = decode_uint32_vlq(response, offset)
-        logger.debug(f"db_read_multi: item_count={item_count} (consumed {consumed} bytes)")
-        offset += consumed
-
-        results: list[bytes] = []
-        for i in range(item_count):
-            status, consumed = decode_uint32_vlq(response, offset)
-            offset += consumed
-
-            data_length, consumed = decode_uint32_vlq(response, offset)
-            offset += consumed
-
-            logger.debug(f"db_read_multi: item[{i}] status={status} data_length={data_length}")
-
-            if status == 0 and data_length > 0:
-                item_data = response[offset : offset + data_length]
-                logger.debug(f"db_read_multi: item[{i}] data: {item_data.hex(' ')}")
-                results.append(item_data)
-                offset += data_length
-            else:
-                logger.debug(f"db_read_multi: item[{i}] empty/error")
-                results.append(b"")
-
-        return results
+        results = _parse_read_response(response)
+        return [r if r is not None else b"" for r in results]
 
     # -- Explore (browse PLC object tree) --
 
@@ -305,3 +215,190 @@ class S7CommPlusClient:
 
     def __exit__(self, *args: Any) -> None:
         self.disconnect()
+
+
+# -- Request/response builders (module-level for reuse by async client) --
+
+
+def _build_read_payload(items: list[tuple[int, int, int]]) -> bytes:
+    """Build a GetMultiVariables request payload.
+
+    Args:
+        items: List of (db_number, start_offset, size) tuples
+
+    Returns:
+        Encoded payload bytes (after the 14-byte request header)
+
+    Reference: thomas-v2/S7CommPlusDriver/Core/GetMultiVariablesRequest.cs
+    """
+    # Encode all item addresses and compute total field count
+    addresses: list[bytes] = []
+    total_field_count = 0
+    for db_number, start, size in items:
+        access_area = Ids.DB_ACCESS_AREA_BASE + (db_number & 0xFFFF)
+        addr_bytes, field_count = encode_item_address(
+            access_area=access_area,
+            access_sub_area=Ids.DB_VALUE_ACTUAL,
+            lids=[start, size],
+        )
+        addresses.append(addr_bytes)
+        total_field_count += field_count
+
+    payload = bytearray()
+    # LinkId (UInt32 fixed = 0, for reading variables)
+    payload += struct.pack(">I", 0)
+    # Item count
+    payload += encode_uint32_vlq(len(items))
+    # Total field count across all items
+    payload += encode_uint32_vlq(total_field_count)
+    # Item addresses
+    for addr in addresses:
+        payload += addr
+    # ObjectQualifier
+    payload += encode_object_qualifier()
+    # Padding
+    payload += struct.pack(">I", 0)
+
+    return bytes(payload)
+
+
+def _parse_read_response(response: bytes) -> list[Optional[bytes]]:
+    """Parse a GetMultiVariables response payload.
+
+    Args:
+        response: Response payload (after the 14-byte response header)
+
+    Returns:
+        List of raw bytes per item (None for errored items)
+
+    Reference: thomas-v2/S7CommPlusDriver/Core/GetMultiVariablesResponse.cs
+    """
+    offset = 0
+
+    # ReturnValue (UInt64 VLQ)
+    return_value, consumed = decode_uint64_vlq(response, offset)
+    offset += consumed
+    logger.debug(f"_parse_read_response: return_value={return_value}")
+
+    if return_value != 0:
+        logger.error(f"_parse_read_response: PLC returned error: {return_value}")
+        return []
+
+    # Value list: ItemNumber (VLQ) + PValue, terminated by ItemNumber=0
+    values: dict[int, bytes] = {}
+    while offset < len(response):
+        item_nr, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+        if item_nr == 0:
+            break
+        raw_bytes, consumed = decode_pvalue_to_bytes(response, offset)
+        offset += consumed
+        values[item_nr] = raw_bytes
+
+    # Error list: ErrorItemNumber (VLQ) + ErrorReturnValue (UInt64 VLQ), terminated by 0
+    errors: dict[int, int] = {}
+    while offset < len(response):
+        err_item_nr, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+        if err_item_nr == 0:
+            break
+        err_value, consumed = decode_uint64_vlq(response, offset)
+        offset += consumed
+        errors[err_item_nr] = err_value
+        logger.debug(f"_parse_read_response: error item {err_item_nr}: {err_value}")
+
+    # Build result list (1-based item numbers)
+    max_item = max(max(values.keys(), default=0), max(errors.keys(), default=0))
+    results: list[Optional[bytes]] = []
+    for i in range(1, max_item + 1):
+        if i in values:
+            results.append(values[i])
+        else:
+            results.append(None)
+
+    return results
+
+
+def _build_write_payload(items: list[tuple[int, int, bytes]]) -> bytes:
+    """Build a SetMultiVariables request payload.
+
+    Args:
+        items: List of (db_number, start_offset, data) tuples
+
+    Returns:
+        Encoded payload bytes
+
+    Reference: thomas-v2/S7CommPlusDriver/Core/SetMultiVariablesRequest.cs
+    """
+    # Encode all item addresses and compute total field count
+    addresses: list[bytes] = []
+    total_field_count = 0
+    for db_number, start, data in items:
+        access_area = Ids.DB_ACCESS_AREA_BASE + (db_number & 0xFFFF)
+        addr_bytes, field_count = encode_item_address(
+            access_area=access_area,
+            access_sub_area=Ids.DB_VALUE_ACTUAL,
+            lids=[start, len(data)],
+        )
+        addresses.append(addr_bytes)
+        total_field_count += field_count
+
+    payload = bytearray()
+    # InObjectId (UInt32 fixed = 0, for plain variable writes)
+    payload += struct.pack(">I", 0)
+    # Item count
+    payload += encode_uint32_vlq(len(items))
+    # Total field count
+    payload += encode_uint32_vlq(total_field_count)
+    # Item addresses
+    for addr in addresses:
+        payload += addr
+    # Value list: ItemNumber (1-based) + PValue
+    for i, (_, _, data) in enumerate(items, 1):
+        payload += encode_uint32_vlq(i)
+        payload += encode_pvalue_blob(data)
+    # Fill byte
+    payload += bytes([0x00])
+    # ObjectQualifier
+    payload += encode_object_qualifier()
+    # Padding
+    payload += struct.pack(">I", 0)
+
+    return bytes(payload)
+
+
+def _parse_write_response(response: bytes) -> None:
+    """Parse a SetMultiVariables response payload.
+
+    Args:
+        response: Response payload (after the 14-byte response header)
+
+    Raises:
+        RuntimeError: If the write failed
+
+    Reference: thomas-v2/S7CommPlusDriver/Core/SetMultiVariablesResponse.cs
+    """
+    offset = 0
+
+    # ReturnValue (UInt64 VLQ)
+    return_value, consumed = decode_uint64_vlq(response, offset)
+    offset += consumed
+    logger.debug(f"_parse_write_response: return_value={return_value}")
+
+    if return_value != 0:
+        raise RuntimeError(f"Write failed with return value {return_value}")
+
+    # Error list: ErrorItemNumber (VLQ) + ErrorReturnValue (UInt64 VLQ)
+    errors: list[tuple[int, int]] = []
+    while offset < len(response):
+        err_item_nr, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+        if err_item_nr == 0:
+            break
+        err_value, consumed = decode_uint64_vlq(response, offset)
+        offset += consumed
+        errors.append((err_item_nr, err_value))
+
+    if errors:
+        err_str = ", ".join(f"item {nr}: error {val}" for nr, val in errors)
+        raise RuntimeError(f"Write failed: {err_str}")

--- a/snap7/s7commplus/client.py
+++ b/snap7/s7commplus/client.py
@@ -135,32 +135,53 @@ class S7CommPlusClient:
         payload += encode_uint32_vlq(start)
         payload += encode_uint32_vlq(size)
 
+        logger.debug(
+            f"db_read: db={db_number} start={start} size={size} "
+            f"object_id=0x{object_id:08X} payload={bytes(payload).hex(' ')}"
+        )
+
         response = self._connection.send_request(FunctionCode.GET_MULTI_VARIABLES, bytes(payload))
+
+        logger.debug(f"db_read: response ({len(response)} bytes): {response.hex(' ')}")
 
         # Parse response
         offset = 0
         # Skip return code
-        _, consumed = decode_uint32_vlq(response, offset)
+        return_code, consumed = decode_uint32_vlq(response, offset)
+        logger.debug(f"db_read: return_code={return_code} (consumed {consumed} bytes)")
         offset += consumed
 
         # Item count
         item_count, consumed = decode_uint32_vlq(response, offset)
+        logger.debug(f"db_read: item_count={item_count} (consumed {consumed} bytes)")
         offset += consumed
 
         if item_count == 0:
+            logger.debug("db_read: no items returned")
             return b""
 
         # First item: status + data_length + data
         status, consumed = decode_uint32_vlq(response, offset)
+        logger.debug(f"db_read: item status={status} (consumed {consumed} bytes)")
         offset += consumed
 
         data_length, consumed = decode_uint32_vlq(response, offset)
+        logger.debug(f"db_read: data_length={data_length} (consumed {consumed} bytes)")
         offset += consumed
 
         if status != 0:
+            logger.error(
+                f"db_read: FAILED status={status}, remaining bytes: {response[offset:].hex(' ')}"
+            )
             raise RuntimeError(f"Read failed with status {status}")
 
-        return response[offset : offset + data_length]
+        result = response[offset : offset + data_length]
+        logger.debug(f"db_read: result ({len(result)} bytes): {result.hex(' ')}")
+        remaining = response[offset + data_length :]
+        if remaining:
+            logger.debug(f"db_read: remaining after data ({len(remaining)} bytes): {remaining.hex(' ')}")
+
+        return result
 
     def db_write(self, db_number: int, start: int, data: bytes) -> None:
         """Write raw bytes to a data block.
@@ -181,14 +202,25 @@ class S7CommPlusClient:
         payload += encode_uint32_vlq(len(data))
         payload += data
 
+        logger.debug(
+            f"db_write: db={db_number} start={start} data_len={len(data)} "
+            f"object_id=0x{object_id:08X} data={data.hex(' ')} payload={bytes(payload).hex(' ')}"
+        )
+
         response = self._connection.send_request(FunctionCode.SET_MULTI_VARIABLES, bytes(payload))
+
+        logger.debug(f"db_write: response ({len(response)} bytes): {response.hex(' ')}")
 
         # Parse response - check return code
         offset = 0
         return_code, consumed = decode_uint32_vlq(response, offset)
+        logger.debug(f"db_write: return_code={return_code} (consumed {consumed} bytes)")
         offset += consumed
 
         if return_code != 0:
+            logger.error(
+                f"db_write: FAILED return_code={return_code}, remaining: {response[offset:].hex(' ')}"
+            )
             raise RuntimeError(f"Write failed with return code {return_code}")
 
     def db_read_multi(self, items: list[tuple[int, int, int]]) -> list[bytes]:
@@ -211,28 +243,39 @@ class S7CommPlusClient:
             payload += encode_uint32_vlq(start)
             payload += encode_uint32_vlq(size)
 
+        logger.debug(f"db_read_multi: {len(items)} items: {items} payload={bytes(payload).hex(' ')}")
+
         response = self._connection.send_request(FunctionCode.GET_MULTI_VARIABLES, bytes(payload))
+
+        logger.debug(f"db_read_multi: response ({len(response)} bytes): {response.hex(' ')}")
 
         # Parse response
         offset = 0
-        _, consumed = decode_uint32_vlq(response, offset)
+        return_code, consumed = decode_uint32_vlq(response, offset)
+        logger.debug(f"db_read_multi: return_code={return_code} (consumed {consumed} bytes)")
         offset += consumed
 
         item_count, consumed = decode_uint32_vlq(response, offset)
+        logger.debug(f"db_read_multi: item_count={item_count} (consumed {consumed} bytes)")
         offset += consumed
 
         results: list[bytes] = []
-        for _ in range(item_count):
+        for i in range(item_count):
             status, consumed = decode_uint32_vlq(response, offset)
             offset += consumed
 
             data_length, consumed = decode_uint32_vlq(response, offset)
             offset += consumed
 
+            logger.debug(f"db_read_multi: item[{i}] status={status} data_length={data_length}")
+
             if status == 0 and data_length > 0:
-                results.append(response[offset : offset + data_length])
+                item_data = response[offset : offset + data_length]
+                logger.debug(f"db_read_multi: item[{i}] data: {item_data.hex(' ')}")
+                results.append(item_data)
                 offset += data_length
             else:
+                logger.debug(f"db_read_multi: item[{i}] empty/error")
                 results.append(b"")
 
         return results
@@ -251,7 +294,9 @@ class S7CommPlusClient:
         if self._connection is None:
             raise RuntimeError("Not connected")
 
-        return self._connection.send_request(FunctionCode.EXPLORE, b"")
+        response = self._connection.send_request(FunctionCode.EXPLORE, b"")
+        logger.debug(f"explore: response ({len(response)} bytes): {response.hex(' ')}")
+        return response
 
     # -- Context manager --
 

--- a/snap7/s7commplus/codec.py
+++ b/snap7/s7commplus/codec.py
@@ -1,0 +1,292 @@
+"""
+S7CommPlus data encoding and decoding.
+
+Provides serialization for the S7CommPlus wire format including:
+- Fixed-width integers (big-endian)
+- VLQ-encoded integers
+- Floating point values
+- Strings (UTF-8 encoded WStrings)
+- Blobs (raw byte arrays)
+- S7CommPlus frame header
+
+Reference: thomas-v2/S7CommPlusDriver/Core/S7p.cs
+"""
+
+import struct
+from typing import Any
+
+from .protocol import PROTOCOL_ID, DataType
+from .vlq import (
+    encode_uint32_vlq,
+    encode_int32_vlq,
+    encode_uint64_vlq,
+    encode_int64_vlq,
+)
+
+
+def encode_header(version: int, data_length: int) -> bytes:
+    """Encode an S7CommPlus frame header.
+
+    Header format (4 bytes)::
+
+        [0]   Protocol ID: 0x72
+        [1]   Protocol version
+        [2-3] Data length (big-endian uint16)
+
+    Args:
+        version: Protocol version byte
+        data_length: Length of data following the header
+
+    Returns:
+        4-byte header
+    """
+    return struct.pack(">BBH", PROTOCOL_ID, version, data_length)
+
+
+def decode_header(data: bytes, offset: int = 0) -> tuple[int, int, int]:
+    """Decode an S7CommPlus frame header.
+
+    Args:
+        data: Buffer containing the header
+        offset: Starting position
+
+    Returns:
+        Tuple of (protocol_version, data_length, bytes_consumed)
+
+    Raises:
+        ValueError: If protocol ID is not 0x72
+    """
+    if len(data) - offset < 4:
+        raise ValueError("Not enough data for S7CommPlus header")
+
+    proto_id, version, length = struct.unpack_from(">BBH", data, offset)
+
+    if proto_id != PROTOCOL_ID:
+        raise ValueError(f"Invalid protocol ID: {proto_id:#04x}, expected {PROTOCOL_ID:#04x}")
+
+    return version, length, 4
+
+
+def encode_request_header(
+    function_code: int,
+    sequence_number: int,
+    session_id: int = 0,
+    transport_flags: int = 0x36,
+) -> bytes:
+    """Encode an S7CommPlus request header (after the frame header).
+
+    Request header format::
+
+        [0]     Opcode: 0x31 (Request)
+        [1-2]   Reserved: 0x0000
+        [3-4]   Function code (big-endian uint16)
+        [5-6]   Reserved: 0x0000
+        [7-8]   Sequence number (big-endian uint16)
+        [9-12]  Session ID (big-endian uint32)
+        [13]    Transport flags
+
+    Args:
+        function_code: S7CommPlus function code
+        sequence_number: Request sequence number
+        session_id: Session identifier (0 for initial connection)
+        transport_flags: Transport flags byte
+
+    Returns:
+        14-byte request header
+    """
+    from .protocol import Opcode
+
+    return struct.pack(
+        ">BHHHHIB",
+        Opcode.REQUEST,
+        0x0000,  # Reserved
+        function_code,
+        0x0000,  # Reserved
+        sequence_number,
+        session_id,
+        transport_flags,
+    )
+
+
+def decode_response_header(data: bytes, offset: int = 0) -> dict[str, Any]:
+    """Decode an S7CommPlus response header.
+
+    Args:
+        data: Buffer containing the response
+        offset: Starting position
+
+    Returns:
+        Dictionary with opcode, function_code, sequence_number, session_id,
+        transport_flags, and bytes_consumed
+    """
+    if len(data) - offset < 14:
+        raise ValueError("Not enough data for S7CommPlus response header")
+
+    opcode, reserved1, function_code, reserved2, seq_num, session_id, transport_flags = struct.unpack_from(
+        ">BHHHHIB", data, offset
+    )
+
+    return {
+        "opcode": opcode,
+        "function_code": function_code,
+        "sequence_number": seq_num,
+        "session_id": session_id,
+        "transport_flags": transport_flags,
+        "bytes_consumed": 14,
+    }
+
+
+# -- Fixed-width encoding (big-endian) --
+
+
+def encode_uint8(value: int) -> bytes:
+    return struct.pack(">B", value)
+
+
+def decode_uint8(data: bytes, offset: int = 0) -> tuple[int, int]:
+    return struct.unpack_from(">B", data, offset)[0], 1
+
+
+def encode_uint16(value: int) -> bytes:
+    return struct.pack(">H", value)
+
+
+def decode_uint16(data: bytes, offset: int = 0) -> tuple[int, int]:
+    return struct.unpack_from(">H", data, offset)[0], 2
+
+
+def encode_uint32(value: int) -> bytes:
+    return struct.pack(">I", value)
+
+
+def decode_uint32(data: bytes, offset: int = 0) -> tuple[int, int]:
+    return struct.unpack_from(">I", data, offset)[0], 4
+
+
+def encode_uint64(value: int) -> bytes:
+    return struct.pack(">Q", value)
+
+
+def decode_uint64(data: bytes, offset: int = 0) -> tuple[int, int]:
+    return struct.unpack_from(">Q", data, offset)[0], 8
+
+
+def encode_int16(value: int) -> bytes:
+    return struct.pack(">h", value)
+
+
+def decode_int16(data: bytes, offset: int = 0) -> tuple[int, int]:
+    return struct.unpack_from(">h", data, offset)[0], 2
+
+
+def encode_int32(value: int) -> bytes:
+    return struct.pack(">i", value)
+
+
+def decode_int32(data: bytes, offset: int = 0) -> tuple[int, int]:
+    return struct.unpack_from(">i", data, offset)[0], 4
+
+
+def encode_int64(value: int) -> bytes:
+    return struct.pack(">q", value)
+
+
+def decode_int64(data: bytes, offset: int = 0) -> tuple[int, int]:
+    return struct.unpack_from(">q", data, offset)[0], 8
+
+
+def encode_float32(value: float) -> bytes:
+    return struct.pack(">f", value)
+
+
+def decode_float32(data: bytes, offset: int = 0) -> tuple[float, int]:
+    return struct.unpack_from(">f", data, offset)[0], 4
+
+
+def encode_float64(value: float) -> bytes:
+    return struct.pack(">d", value)
+
+
+def decode_float64(data: bytes, offset: int = 0) -> tuple[float, int]:
+    return struct.unpack_from(">d", data, offset)[0], 8
+
+
+# -- String encoding --
+
+
+def encode_wstring(value: str) -> bytes:
+    """Encode a string as UTF-8 (S7CommPlus WString wire format)."""
+    return value.encode("utf-8")
+
+
+def decode_wstring(data: bytes, offset: int, length: int) -> tuple[str, int]:
+    """Decode a UTF-8 string.
+
+    Args:
+        data: Buffer
+        offset: Start position
+        length: Number of bytes to decode
+
+    Returns:
+        Tuple of (decoded_string, bytes_consumed)
+    """
+    return data[offset : offset + length].decode("utf-8"), length
+
+
+# -- Typed value encoding --
+
+
+def encode_typed_value(datatype: int, value: Any) -> bytes:
+    """Encode a value with its type tag.
+
+    This prepends the DataType byte before the encoded value, which is how
+    attribute values are serialized in the S7CommPlus object model.
+
+    Args:
+        datatype: DataType enum value
+        value: Value to encode
+
+    Returns:
+        Type-tagged encoded value
+    """
+    tag = struct.pack(">B", datatype)
+
+    if datatype == DataType.NULL:
+        return tag
+    elif datatype == DataType.BOOL:
+        return tag + struct.pack(">B", 1 if value else 0)
+    elif datatype == DataType.USINT or datatype == DataType.BYTE:
+        return tag + struct.pack(">B", value)
+    elif datatype == DataType.UINT or datatype == DataType.WORD:
+        return tag + struct.pack(">H", value)
+    elif datatype == DataType.UDINT or datatype == DataType.DWORD:
+        return tag + encode_uint32_vlq(value)
+    elif datatype == DataType.ULINT or datatype == DataType.LWORD:
+        return tag + encode_uint64_vlq(value)
+    elif datatype == DataType.SINT:
+        return tag + struct.pack(">b", value)
+    elif datatype == DataType.INT:
+        return tag + struct.pack(">h", value)
+    elif datatype == DataType.DINT:
+        return tag + encode_int32_vlq(value)
+    elif datatype == DataType.LINT:
+        return tag + encode_int64_vlq(value)
+    elif datatype == DataType.REAL:
+        return tag + struct.pack(">f", value)
+    elif datatype == DataType.LREAL:
+        return tag + struct.pack(">d", value)
+    elif datatype == DataType.TIMESTAMP:
+        return tag + struct.pack(">Q", value)
+    elif datatype == DataType.TIMESPAN:
+        return tag + encode_int64_vlq(value)
+    elif datatype == DataType.RID:
+        return tag + struct.pack(">I", value)
+    elif datatype == DataType.AID:
+        return tag + encode_uint32_vlq(value)
+    elif datatype == DataType.WSTRING:
+        encoded = value.encode("utf-8")
+        return tag + encode_uint32_vlq(len(encoded)) + encoded
+    elif datatype == DataType.BLOB:
+        return tag + encode_uint32_vlq(len(value)) + value
+    else:
+        raise ValueError(f"Unsupported DataType for encoding: {datatype:#04x}")

--- a/snap7/s7commplus/codec.py
+++ b/snap7/s7commplus/codec.py
@@ -284,9 +284,9 @@ def encode_typed_value(datatype: int, value: Any) -> bytes:
     elif datatype == DataType.AID:
         return tag + encode_uint32_vlq(value)
     elif datatype == DataType.WSTRING:
-        encoded = value.encode("utf-8")
+        encoded: bytes = value.encode("utf-8")
         return tag + encode_uint32_vlq(len(encoded)) + encoded
     elif datatype == DataType.BLOB:
-        return tag + encode_uint32_vlq(len(value)) + value
+        return bytes(tag + encode_uint32_vlq(len(value)) + value)
     else:
         raise ValueError(f"Unsupported DataType for encoding: {datatype:#04x}")

--- a/snap7/s7commplus/codec.py
+++ b/snap7/s7commplus/codec.py
@@ -15,11 +15,13 @@ Reference: thomas-v2/S7CommPlusDriver/Core/S7p.cs
 import struct
 from typing import Any
 
-from .protocol import PROTOCOL_ID, DataType
+from .protocol import PROTOCOL_ID, DataType, Ids
 from .vlq import (
     encode_uint32_vlq,
+    decode_uint32_vlq,
     encode_int32_vlq,
     encode_uint64_vlq,
+    decode_uint64_vlq,
     encode_int64_vlq,
 )
 
@@ -290,3 +292,204 @@ def encode_typed_value(datatype: int, value: Any) -> bytes:
         return bytes(tag + encode_uint32_vlq(len(value)) + value)
     else:
         raise ValueError(f"Unsupported DataType for encoding: {datatype:#04x}")
+
+
+# -- S7CommPlus request/response payload helpers --
+
+
+def encode_object_qualifier() -> bytes:
+    """Encode the S7CommPlus ObjectQualifier structure.
+
+    This fixed structure is appended to GetMultiVariables and
+    SetMultiVariables requests.
+
+    Reference: thomas-v2/S7CommPlusDriver/Core/S7p.cs EncodeObjectQualifier
+    """
+    result = bytearray()
+    result += struct.pack(">I", Ids.OBJECT_QUALIFIER)
+    # ParentRID = RID(0)
+    result += encode_uint32_vlq(Ids.PARENT_RID)
+    result += bytes([0x00, DataType.RID]) + struct.pack(">I", 0)
+    # CompositionAID = AID(0)
+    result += encode_uint32_vlq(Ids.COMPOSITION_AID)
+    result += bytes([0x00, DataType.AID]) + encode_uint32_vlq(0)
+    # KeyQualifier = UDInt(0)
+    result += encode_uint32_vlq(Ids.KEY_QUALIFIER)
+    result += bytes([0x00, DataType.UDINT]) + encode_uint32_vlq(0)
+    # Terminator
+    result += bytes([0x00])
+    return bytes(result)
+
+
+def encode_item_address(
+    access_area: int,
+    access_sub_area: int,
+    lids: list[int] | None = None,
+    symbol_crc: int = 0,
+) -> tuple[bytes, int]:
+    """Encode an S7CommPlus ItemAddress for variable access.
+
+    Args:
+        access_area: Access area ID (e.g., 0x8A0E0001 for DB1)
+        access_sub_area: Sub-area ID (e.g., Ids.DB_VALUE_ACTUAL)
+        lids: Additional LID values for sub-addressing
+        symbol_crc: Symbol CRC (0 for no CRC check)
+
+    Returns:
+        Tuple of (encoded_bytes, field_count)
+
+    Reference: thomas-v2/S7CommPlusDriver/ClientApi/ItemAddress.cs
+    """
+    if lids is None:
+        lids = []
+    result = bytearray()
+    result += encode_uint32_vlq(symbol_crc)
+    result += encode_uint32_vlq(access_area)
+    result += encode_uint32_vlq(len(lids) + 1)  # +1 for AccessSubArea
+    result += encode_uint32_vlq(access_sub_area)
+    for lid in lids:
+        result += encode_uint32_vlq(lid)
+    field_count = 4 + len(lids)  # SymbolCrc + AccessArea + NumLIDs + AccessSubArea + LIDs
+    return bytes(result), field_count
+
+
+def encode_pvalue_blob(data: bytes) -> bytes:
+    """Encode raw bytes as a BLOB PValue.
+
+    PValue format: [flags:1][datatype:1][length:VLQ][data]
+    """
+    result = bytearray()
+    result += bytes([0x00, DataType.BLOB])
+    result += encode_uint32_vlq(len(data))
+    result += data
+    return bytes(result)
+
+
+def decode_pvalue_to_bytes(data: bytes, offset: int) -> tuple[bytes, int]:
+    """Decode a PValue from S7CommPlus response to raw bytes.
+
+    Supports scalar types and BLOBs. Returns the raw big-endian bytes
+    of the value regardless of type.
+
+    Args:
+        data: Response buffer
+        offset: Position of the PValue
+
+    Returns:
+        Tuple of (raw_bytes, bytes_consumed)
+    """
+    if offset + 2 > len(data):
+        raise ValueError("Not enough data for PValue header")
+
+    flags = data[offset]
+    datatype = data[offset + 1]
+    consumed = 2
+
+    is_array = bool(flags & 0x10)
+
+    if is_array:
+        # Array: read count then elements
+        count, c = decode_uint32_vlq(data, offset + consumed)
+        consumed += c
+        elem_size = _pvalue_element_size(datatype)
+        if elem_size > 0:
+            raw = data[offset + consumed : offset + consumed + count * elem_size]
+            consumed += count * elem_size
+            return bytes(raw), consumed
+        else:
+            # Variable-length elements (VLQ encoded)
+            result = bytearray()
+            for _ in range(count):
+                val, c = decode_uint32_vlq(data, offset + consumed)
+                consumed += c
+                result += encode_uint32_vlq(val)
+            return bytes(result), consumed
+
+    # Scalar types
+    if datatype == DataType.NULL:
+        return b"", consumed
+    elif datatype == DataType.BOOL:
+        return data[offset + consumed : offset + consumed + 1], consumed + 1
+    elif datatype in (DataType.USINT, DataType.BYTE, DataType.SINT):
+        return data[offset + consumed : offset + consumed + 1], consumed + 1
+    elif datatype in (DataType.UINT, DataType.WORD, DataType.INT):
+        return data[offset + consumed : offset + consumed + 2], consumed + 2
+    elif datatype in (DataType.UDINT, DataType.DWORD):
+        val, c = decode_uint32_vlq(data, offset + consumed)
+        consumed += c
+        return struct.pack(">I", val), consumed
+    elif datatype in (DataType.DINT,):
+        # Signed VLQ
+        from .vlq import decode_int32_vlq
+
+        val, c = decode_int32_vlq(data, offset + consumed)
+        consumed += c
+        return struct.pack(">i", val), consumed
+    elif datatype == DataType.REAL:
+        return data[offset + consumed : offset + consumed + 4], consumed + 4
+    elif datatype == DataType.LREAL:
+        return data[offset + consumed : offset + consumed + 8], consumed + 8
+    elif datatype in (DataType.ULINT, DataType.LWORD):
+        val, c = decode_uint64_vlq(data, offset + consumed)
+        consumed += c
+        return struct.pack(">Q", val), consumed
+    elif datatype in (DataType.LINT,):
+        from .vlq import decode_int64_vlq
+
+        val, c = decode_int64_vlq(data, offset + consumed)
+        consumed += c
+        return struct.pack(">q", val), consumed
+    elif datatype == DataType.TIMESTAMP:
+        return data[offset + consumed : offset + consumed + 8], consumed + 8
+    elif datatype == DataType.TIMESPAN:
+        from .vlq import decode_int64_vlq
+
+        val, c = decode_int64_vlq(data, offset + consumed)
+        consumed += c
+        return struct.pack(">q", val), consumed
+    elif datatype == DataType.RID:
+        return data[offset + consumed : offset + consumed + 4], consumed + 4
+    elif datatype == DataType.AID:
+        val, c = decode_uint32_vlq(data, offset + consumed)
+        consumed += c
+        return struct.pack(">I", val), consumed
+    elif datatype == DataType.BLOB:
+        length, c = decode_uint32_vlq(data, offset + consumed)
+        consumed += c
+        raw = data[offset + consumed : offset + consumed + length]
+        consumed += length
+        return bytes(raw), consumed
+    elif datatype == DataType.WSTRING:
+        length, c = decode_uint32_vlq(data, offset + consumed)
+        consumed += c
+        raw = data[offset + consumed : offset + consumed + length]
+        consumed += length
+        return bytes(raw), consumed
+    elif datatype == DataType.STRUCT:
+        # Struct: read count, then nested PValues
+        count, c = decode_uint32_vlq(data, offset + consumed)
+        consumed += c
+        result = bytearray()
+        for _ in range(count):
+            val_bytes, c = decode_pvalue_to_bytes(data, offset + consumed)
+            consumed += c
+            result += val_bytes
+        return bytes(result), consumed
+    else:
+        raise ValueError(f"Unsupported PValue datatype: {datatype:#04x}")
+
+
+def _pvalue_element_size(datatype: int) -> int:
+    """Return the fixed byte size for a PValue array element, or 0 for variable-length."""
+    if datatype in (DataType.BOOL, DataType.USINT, DataType.BYTE, DataType.SINT):
+        return 1
+    elif datatype in (DataType.UINT, DataType.WORD, DataType.INT):
+        return 2
+    elif datatype in (DataType.REAL,):
+        return 4
+    elif datatype in (DataType.LREAL, DataType.TIMESTAMP):
+        return 8
+    elif datatype in (DataType.RID,):
+        return 4
+    else:
+        return 0  # Variable-length (VLQ encoded)

--- a/snap7/s7commplus/connection.py
+++ b/snap7/s7commplus/connection.py
@@ -136,21 +136,15 @@ class S7CommPlusConnection:
             # Step 3: Version-specific authentication
             if use_tls and self._protocol_version >= ProtocolVersion.V3:
                 # TODO: Send InitSsl request and perform TLS handshake
-                raise NotImplementedError(
-                    "TLS authentication is not yet implemented. "
-                    "Use use_tls=False for V1 connections."
-                )
+                raise NotImplementedError("TLS authentication is not yet implemented. Use use_tls=False for V1 connections.")
             elif self._protocol_version == ProtocolVersion.V2:
                 # TODO: Proprietary HMAC-SHA256/AES session auth
-                raise NotImplementedError(
-                    "V2 authentication is not yet implemented."
-                )
+                raise NotImplementedError("V2 authentication is not yet implemented.")
 
             # V1: No further authentication needed
             self._connected = True
             logger.info(
-                f"S7CommPlus connected to {self.host}:{self.port}, "
-                f"version=V{self._protocol_version}, session={self._session_id}"
+                f"S7CommPlus connected to {self.host}:{self.port}, version=V{self._protocol_version}, session={self._session_id}"
             )
 
         except Exception:
@@ -172,9 +166,7 @@ class S7CommPlusConnection:
         self._protocol_version = 0
         self._iso_conn.disconnect()
 
-    def send_request(
-        self, function_code: int, payload: bytes = b""
-    ) -> bytes:
+    def send_request(self, function_code: int, payload: bytes = b"") -> bytes:
         """Send an S7CommPlus request and receive the response.
 
         Args:
@@ -186,21 +178,25 @@ class S7CommPlusConnection:
         """
         if not self._connected:
             from ..error import S7ConnectionError
+
             raise S7ConnectionError("Not connected")
 
         seq_num = self._next_sequence_number()
 
         # Build request header
-        request = struct.pack(
-            ">BHHHHIB",
-            Opcode.REQUEST,
-            0x0000,  # Reserved
-            function_code,
-            0x0000,  # Reserved
-            seq_num,
-            self._session_id,
-            0x36,  # Transport flags
-        ) + payload
+        request = (
+            struct.pack(
+                ">BHHHHIB",
+                Opcode.REQUEST,
+                0x0000,  # Reserved
+                function_code,
+                0x0000,  # Reserved
+                seq_num,
+                self._session_id,
+                0x36,  # Transport flags
+            )
+            + payload
+        )
 
         # Add S7CommPlus frame header and send
         frame = encode_header(self._protocol_version, len(request)) + request
@@ -215,6 +211,7 @@ class S7CommPlusConnection:
 
         if len(response) < 14:
             from ..error import S7ConnectionError
+
             raise S7ConnectionError("Response too short")
 
         return response[14:]
@@ -252,6 +249,7 @@ class S7CommPlusConnection:
 
         if len(response) < 14:
             from ..error import S7ConnectionError
+
             raise S7ConnectionError("CreateObject response too short")
 
         # Extract session ID from response header

--- a/snap7/s7commplus/connection.py
+++ b/snap7/s7commplus/connection.py
@@ -34,10 +34,13 @@ Reference: thomas-v2/S7CommPlusDriver (C#, LGPL-3.0)
 
 import logging
 import ssl
+import struct
 from typing import Optional, Type
 from types import TracebackType
 
 from ..connection import ISOTCPConnection
+from .protocol import FunctionCode, Opcode, ProtocolVersion
+from .codec import encode_header, decode_header
 
 logger = logging.getLogger(__name__)
 
@@ -51,7 +54,8 @@ class S7CommPlusConnection:
     - Version-appropriate authentication (V1/V2/V3/TLS)
     - Frame send/receive (TLS-encrypted when using V17+ firmware)
 
-    Status: scaffolding -- connection logic is not yet implemented.
+    Currently implements V1 authentication. V2/V3/TLS authentication
+    layers are planned for future development.
     """
 
     def __init__(
@@ -90,6 +94,11 @@ class S7CommPlusConnection:
         return self._protocol_version
 
     @property
+    def session_id(self) -> int:
+        """Session ID assigned by the PLC."""
+        return self._session_id
+
+    @property
     def tls_active(self) -> bool:
         """Whether TLS encryption is active on this connection."""
         return self._tls_active
@@ -97,7 +106,7 @@ class S7CommPlusConnection:
     def connect(
         self,
         timeout: float = 5.0,
-        use_tls: bool = True,
+        use_tls: bool = False,
         tls_cert: Optional[str] = None,
         tls_key: Optional[str] = None,
         tls_ca: Optional[str] = None,
@@ -109,55 +118,53 @@ class S7CommPlusConnection:
         2. CreateObject to establish S7CommPlus session
         3. Protocol version is detected from PLC response
         4. If use_tls=True and PLC supports it, TLS is negotiated
-        5. If use_tls=False, falls back to version-appropriate auth
 
         Args:
             timeout: Connection timeout in seconds
-            use_tls: Whether to attempt TLS negotiation (default True).
-                     If the PLC does not support TLS, falls back to the
-                     protocol version's native authentication.
+            use_tls: Whether to attempt TLS negotiation.
             tls_cert: Path to client TLS certificate (PEM)
-            tls_key: Path to client TLS private key (PEM)
+            tls_key: Path to client private key (PEM)
             tls_ca: Path to CA certificate for PLC verification (PEM)
-
-        Raises:
-            S7ConnectionError: If connection fails
-            NotImplementedError: Until connection logic is implemented
         """
-        # TODO: Implementation roadmap:
-        #
-        # Phase 1 - COTP connection (reuse existing ISOTCPConnection):
-        #   self._iso_conn.connect(timeout)
-        #
-        # Phase 2 - CreateObject (session setup):
-        #   Build CreateObject request with NullServerSession data
-        #   Send via self._iso_conn.send_data()
-        #   Parse CreateObject response to get:
-        #     - self._protocol_version (V1/V2/V3)
-        #     - self._session_id
-        #     - server_session_challenge (for V2/V3)
-        #
-        # Phase 3 - Authentication (version-dependent):
-        #   if V1:
-        #     Simple: send challenge + 0x80
-        #   elif V3 and use_tls:
-        #     Send InitSsl request
-        #     Perform TLS handshake over the TPKT/COTP tunnel
-        #     self._tls_active = True
-        #   elif V2 or V3 (no TLS):
-        #     Proprietary key derivation (HMAC-SHA256, AES, ECC)
-        #     Compute integrity ID for subsequent packets
-        #
-        # Phase 4 - Session is ready for data exchange
+        try:
+            # Step 1: COTP connection
+            self._iso_conn.connect(timeout)
 
-        raise NotImplementedError(
-            "S7CommPlus connection is not yet implemented. "
-            "This module is scaffolding for future development. "
-            "See https://github.com/thomas-v2/S7CommPlusDriver for reference."
-        )
+            # Step 2: CreateObject (S7CommPlus session setup)
+            self._create_session()
+
+            # Step 3: Version-specific authentication
+            if use_tls and self._protocol_version >= ProtocolVersion.V3:
+                # TODO: Send InitSsl request and perform TLS handshake
+                raise NotImplementedError(
+                    "TLS authentication is not yet implemented. "
+                    "Use use_tls=False for V1 connections."
+                )
+            elif self._protocol_version == ProtocolVersion.V2:
+                # TODO: Proprietary HMAC-SHA256/AES session auth
+                raise NotImplementedError(
+                    "V2 authentication is not yet implemented."
+                )
+
+            # V1: No further authentication needed
+            self._connected = True
+            logger.info(
+                f"S7CommPlus connected to {self.host}:{self.port}, "
+                f"version=V{self._protocol_version}, session={self._session_id}"
+            )
+
+        except Exception:
+            self.disconnect()
+            raise
 
     def disconnect(self) -> None:
         """Disconnect from PLC."""
+        if self._connected and self._session_id:
+            try:
+                self._delete_session()
+            except Exception:
+                pass
+
         self._connected = False
         self._tls_active = False
         self._session_id = 0
@@ -165,32 +172,118 @@ class S7CommPlusConnection:
         self._protocol_version = 0
         self._iso_conn.disconnect()
 
-    def send(self, data: bytes) -> None:
-        """Send an S7CommPlus frame.
-
-        Adds the S7CommPlus frame header and sends over the ISO connection.
-        If TLS is active, data is encrypted before sending.
+    def send_request(
+        self, function_code: int, payload: bytes = b""
+    ) -> bytes:
+        """Send an S7CommPlus request and receive the response.
 
         Args:
-            data: S7CommPlus PDU payload (without frame header)
-
-        Raises:
-            S7ConnectionError: If not connected
-            NotImplementedError: Until send logic is implemented
-        """
-        raise NotImplementedError("S7CommPlus send is not yet implemented.")
-
-    def receive(self) -> bytes:
-        """Receive an S7CommPlus frame.
+            function_code: S7CommPlus function code
+            payload: Request payload (after the 14-byte request header)
 
         Returns:
-            S7CommPlus PDU payload (without frame header)
-
-        Raises:
-            S7ConnectionError: If not connected
-            NotImplementedError: Until receive logic is implemented
+            Response payload (after the 14-byte response header)
         """
-        raise NotImplementedError("S7CommPlus receive is not yet implemented.")
+        if not self._connected:
+            from ..error import S7ConnectionError
+            raise S7ConnectionError("Not connected")
+
+        seq_num = self._next_sequence_number()
+
+        # Build request header
+        request = struct.pack(
+            ">BHHHHIB",
+            Opcode.REQUEST,
+            0x0000,  # Reserved
+            function_code,
+            0x0000,  # Reserved
+            seq_num,
+            self._session_id,
+            0x36,  # Transport flags
+        ) + payload
+
+        # Add S7CommPlus frame header and send
+        frame = encode_header(self._protocol_version, len(request)) + request
+        self._iso_conn.send_data(frame)
+
+        # Receive response
+        response_frame = self._iso_conn.receive_data()
+
+        # Parse frame header
+        version, data_length, consumed = decode_header(response_frame)
+        response = response_frame[consumed:]
+
+        if len(response) < 14:
+            from ..error import S7ConnectionError
+            raise S7ConnectionError("Response too short")
+
+        return response[14:]
+
+    def _create_session(self) -> None:
+        """Send CreateObject request to establish an S7CommPlus session."""
+        seq_num = self._next_sequence_number()
+
+        # Build CreateObject request with NullServer session data
+        request = struct.pack(
+            ">BHHHHIB",
+            Opcode.REQUEST,
+            0x0000,
+            FunctionCode.CREATE_OBJECT,
+            0x0000,
+            seq_num,
+            0x00000000,  # No session yet
+            0x36,
+        )
+
+        # Add empty request data (minimal CreateObject)
+        request += struct.pack(">I", 0)
+
+        # Wrap in S7CommPlus frame header
+        frame = encode_header(ProtocolVersion.V1, len(request)) + request
+
+        self._iso_conn.send_data(frame)
+
+        # Receive response
+        response_frame = self._iso_conn.receive_data()
+
+        # Parse S7CommPlus frame header
+        version, data_length, consumed = decode_header(response_frame)
+        response = response_frame[consumed:]
+
+        if len(response) < 14:
+            from ..error import S7ConnectionError
+            raise S7ConnectionError("CreateObject response too short")
+
+        # Extract session ID from response header
+        self._session_id = struct.unpack_from(">I", response, 9)[0]
+        self._protocol_version = version
+
+        logger.debug(f"Session created: id={self._session_id}, version=V{version}")
+
+    def _delete_session(self) -> None:
+        """Send DeleteObject to close the session."""
+        seq_num = self._next_sequence_number()
+
+        request = struct.pack(
+            ">BHHHHIB",
+            Opcode.REQUEST,
+            0x0000,
+            FunctionCode.DELETE_OBJECT,
+            0x0000,
+            seq_num,
+            self._session_id,
+            0x36,
+        )
+        request += struct.pack(">I", 0)
+
+        frame = encode_header(self._protocol_version, len(request)) + request
+        self._iso_conn.send_data(frame)
+
+        # Best-effort receive
+        try:
+            self._iso_conn.receive_data()
+        except Exception:
+            pass
 
     def _next_sequence_number(self) -> int:
         """Get next sequence number and increment."""
@@ -205,13 +298,6 @@ class S7CommPlusConnection:
         ca_path: Optional[str] = None,
     ) -> ssl.SSLContext:
         """Create TLS context for S7CommPlus.
-
-        For TIA Portal V17+ PLCs, TLS 1.3 with per-device certificates is
-        used. The PLC's certificate is generated in TIA Portal and must be
-        exported and provided as the CA certificate.
-
-        For older PLCs, TLS is not used (the proprietary auth layer handles
-        session security).
 
         Args:
             cert_path: Client certificate path (PEM)
@@ -230,8 +316,6 @@ class S7CommPlusConnection:
         if ca_path:
             ctx.load_verify_locations(ca_path)
         else:
-            # For development/testing: disable certificate verification
-            # In production, always provide proper certificates
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
 

--- a/snap7/s7commplus/connection.py
+++ b/snap7/s7commplus/connection.py
@@ -218,9 +218,7 @@ class S7CommPlusConnection:
         )
         request = request_header + payload
 
-        logger.debug(
-            f"=== SEND REQUEST === function_code=0x{function_code:04X} seq={seq_num} session=0x{self._session_id:08X}"
-        )
+        logger.debug(f"=== SEND REQUEST === function_code=0x{function_code:04X} seq={seq_num} session=0x{self._session_id:08X}")
         logger.debug(f"  Request header (14 bytes): {request_header.hex(' ')}")
         logger.debug(f"  Request payload ({len(payload)} bytes): {payload.hex(' ')}")
 

--- a/snap7/s7commplus/connection.py
+++ b/snap7/s7commplus/connection.py
@@ -206,38 +206,67 @@ class S7CommPlusConnection:
         seq_num = self._next_sequence_number()
 
         # Build request header
-        request = (
-            struct.pack(
-                ">BHHHHIB",
-                Opcode.REQUEST,
-                0x0000,  # Reserved
-                function_code,
-                0x0000,  # Reserved
-                seq_num,
-                self._session_id,
-                0x36,  # Transport flags
-            )
-            + payload
+        request_header = struct.pack(
+            ">BHHHHIB",
+            Opcode.REQUEST,
+            0x0000,  # Reserved
+            function_code,
+            0x0000,  # Reserved
+            seq_num,
+            self._session_id,
+            0x36,  # Transport flags
         )
+        request = request_header + payload
+
+        logger.debug(
+            f"=== SEND REQUEST === function_code=0x{function_code:04X} seq={seq_num} session=0x{self._session_id:08X}"
+        )
+        logger.debug(f"  Request header (14 bytes): {request_header.hex(' ')}")
+        logger.debug(f"  Request payload ({len(payload)} bytes): {payload.hex(' ')}")
 
         # Add S7CommPlus frame header and trailer, then send
         frame = encode_header(self._protocol_version, len(request)) + request
         frame += struct.pack(">BBH", 0x72, self._protocol_version, 0x0000)
+
+        logger.debug(f"  Full frame ({len(frame)} bytes): {frame.hex(' ')}")
         self._iso_conn.send_data(frame)
 
         # Receive response
         response_frame = self._iso_conn.receive_data()
+        logger.debug(f"=== RECV RESPONSE === raw frame ({len(response_frame)} bytes): {response_frame.hex(' ')}")
 
         # Parse frame header, use data_length to exclude trailer
         version, data_length, consumed = decode_header(response_frame)
+        logger.debug(f"  Frame header: version=V{version}, data_length={data_length}, header_size={consumed}")
+
         response = response_frame[consumed : consumed + data_length]
+        logger.debug(f"  Response data ({len(response)} bytes): {response.hex(' ')}")
 
         if len(response) < 14:
             from ..error import S7ConnectionError
 
             raise S7ConnectionError("Response too short")
 
-        return response[14:]
+        # Parse response header for debug
+        resp_opcode = response[0]
+        resp_func = struct.unpack_from(">H", response, 3)[0]
+        resp_seq = struct.unpack_from(">H", response, 7)[0]
+        resp_session = struct.unpack_from(">I", response, 9)[0]
+        resp_transport = response[13]
+        logger.debug(
+            f"  Response header: opcode=0x{resp_opcode:02X} function=0x{resp_func:04X} "
+            f"seq={resp_seq} session=0x{resp_session:08X} transport=0x{resp_transport:02X}"
+        )
+
+        resp_payload = response[14:]
+        logger.debug(f"  Response payload ({len(resp_payload)} bytes): {resp_payload.hex(' ')}")
+
+        # Check for trailer bytes after data_length
+        trailer = response_frame[consumed + data_length :]
+        if trailer:
+            logger.debug(f"  Trailer ({len(trailer)} bytes): {trailer.hex(' ')}")
+
+        return resp_payload
 
     def _init_ssl(self) -> None:
         """Send InitSSL request to prepare the connection.
@@ -270,10 +299,12 @@ class S7CommPlusConnection:
         frame = encode_header(ProtocolVersion.V1, len(request)) + request
         frame += struct.pack(">BBH", 0x72, ProtocolVersion.V1, 0x0000)
 
+        logger.debug(f"=== InitSSL === sending ({len(frame)} bytes): {frame.hex(' ')}")
         self._iso_conn.send_data(frame)
 
         # Receive InitSSL response
         response_frame = self._iso_conn.receive_data()
+        logger.debug(f"=== InitSSL === received ({len(response_frame)} bytes): {response_frame.hex(' ')}")
 
         # Parse S7CommPlus frame header
         version, data_length, consumed = decode_header(response_frame)
@@ -284,7 +315,8 @@ class S7CommPlusConnection:
 
             raise S7ConnectionError("InitSSL response too short")
 
-        logger.debug(f"InitSSL response received, version=V{version}")
+        logger.debug(f"InitSSL response: version=V{version}, data_length={data_length}")
+        logger.debug(f"InitSSL response body ({len(response)} bytes): {response.hex(' ')}")
 
     def _create_session(self) -> None:
         """Send CreateObject request to establish an S7CommPlus session.
@@ -353,14 +385,19 @@ class S7CommPlusConnection:
         # S7CommPlus trailer (end-of-frame marker)
         frame += struct.pack(">BBH", 0x72, ProtocolVersion.V1, 0x0000)
 
+        logger.debug(f"=== CreateObject === sending ({len(frame)} bytes): {frame.hex(' ')}")
         self._iso_conn.send_data(frame)
 
         # Receive response
         response_frame = self._iso_conn.receive_data()
+        logger.debug(f"=== CreateObject === received ({len(response_frame)} bytes): {response_frame.hex(' ')}")
 
         # Parse S7CommPlus frame header
         version, data_length, consumed = decode_header(response_frame)
         response = response_frame[consumed:]
+
+        logger.debug(f"CreateObject response: version=V{version}, data_length={data_length}")
+        logger.debug(f"CreateObject response body ({len(response)} bytes): {response.hex(' ')}")
 
         if len(response) < 14:
             from ..error import S7ConnectionError
@@ -371,7 +408,17 @@ class S7CommPlusConnection:
         self._session_id = struct.unpack_from(">I", response, 9)[0]
         self._protocol_version = version
 
-        logger.debug(f"Session created: id={self._session_id}, version=V{version}")
+        # Parse and log the full response header
+        resp_opcode = response[0]
+        resp_func = struct.unpack_from(">H", response, 3)[0]
+        resp_seq = struct.unpack_from(">H", response, 7)[0]
+        resp_transport = response[13]
+        logger.debug(
+            f"CreateObject response header: opcode=0x{resp_opcode:02X} function=0x{resp_func:04X} "
+            f"seq={resp_seq} session=0x{self._session_id:08X} transport=0x{resp_transport:02X}"
+        )
+        logger.debug(f"CreateObject response payload: {response[14:].hex(' ')}")
+        logger.debug(f"Session created: id=0x{self._session_id:08X} ({self._session_id}), version=V{version}")
 
     def _delete_session(self) -> None:
         """Send DeleteObject to close the session."""

--- a/snap7/s7commplus/connection.py
+++ b/snap7/s7commplus/connection.py
@@ -15,19 +15,25 @@ the same across all versions -- only the session authentication layer differs.
 Connection sequence (all versions)::
 
     1. TCP connect to port 102
-    2. COTP Connection Request / Confirm (same as legacy S7comm)
-    3. S7CommPlus CreateObject request (NullServer session setup)
-    4. PLC responds with CreateObject response containing:
+    2. COTP Connection Request / Confirm
+       - Local TSAP: 0x0600
+       - Remote TSAP: "SIMATIC-ROOT-HMI" (16-byte ASCII string)
+    3. InitSSL request / response (unencrypted)
+    4. TLS activation (for V3/TLS PLCs)
+    5. S7CommPlus CreateObject request (NullServer session setup)
+       - SessionId = ObjectNullServerSession (288)
+       - Proper PObject tree with ServerSession class
+    6. PLC responds with CreateObject response containing:
        - Protocol version (V1/V2/V3)
        - Session ID
        - Server session challenge (V2/V3)
 
-Version-specific authentication after step 4::
+Version-specific authentication after step 6::
 
-    V1: Simple challenge-response handshake
+    V1: No further authentication needed
     V2: Session key derivation and integrity checking
     V3 (no TLS): Public-key key exchange
-    V3 (TLS): InitSsl request -> TLS 1.3 handshake over TPKT/COTP tunnel
+    V3 (TLS): TLS 1.3 handshake is already done in step 4
 
 Reference: thomas-v2/S7CommPlusDriver (C#, LGPL-3.0)
 """
@@ -39,8 +45,18 @@ from typing import Optional, Type
 from types import TracebackType
 
 from ..connection import ISOTCPConnection
-from .protocol import FunctionCode, Opcode, ProtocolVersion
-from .codec import encode_header, decode_header
+from .protocol import (
+    FunctionCode,
+    Opcode,
+    ProtocolVersion,
+    ElementID,
+    ObjectId,
+    S7COMMPLUS_LOCAL_TSAP,
+    S7COMMPLUS_REMOTE_TSAP,
+)
+from .codec import encode_header, decode_header, encode_typed_value
+from .vlq import encode_uint32_vlq
+from .protocol import DataType
 
 logger = logging.getLogger(__name__)
 
@@ -62,19 +78,15 @@ class S7CommPlusConnection:
         self,
         host: str,
         port: int = 102,
-        local_tsap: int = 0x0100,
-        remote_tsap: int = 0x0102,
     ):
         self.host = host
         self.port = port
-        self.local_tsap = local_tsap
-        self.remote_tsap = remote_tsap
 
         self._iso_conn = ISOTCPConnection(
             host=host,
             port=port,
-            local_tsap=local_tsap,
-            remote_tsap=remote_tsap,
+            local_tsap=S7COMMPLUS_LOCAL_TSAP,
+            remote_tsap=S7COMMPLUS_REMOTE_TSAP,
         )
 
         self._ssl_context: Optional[ssl.SSLContext] = None
@@ -127,21 +139,31 @@ class S7CommPlusConnection:
             tls_ca: Path to CA certificate for PLC verification (PEM)
         """
         try:
-            # Step 1: COTP connection
+            # Step 1: COTP connection (same TSAP for all S7CommPlus versions)
             self._iso_conn.connect(timeout)
 
-            # Step 2: CreateObject (S7CommPlus session setup)
+            # Step 2: InitSSL handshake (required before CreateObject)
+            self._init_ssl()
+
+            # Step 3: TLS activation (required for modern firmware)
+            if use_tls:
+                # TODO: Perform TLS 1.3 handshake over the existing COTP connection
+                raise NotImplementedError("TLS activation is not yet implemented. Use use_tls=False for V1 connections.")
+
+            # Step 4: CreateObject (S7CommPlus session setup)
             self._create_session()
 
-            # Step 3: Version-specific authentication
-            if use_tls and self._protocol_version >= ProtocolVersion.V3:
-                # TODO: Send InitSsl request and perform TLS handshake
-                raise NotImplementedError("TLS authentication is not yet implemented. Use use_tls=False for V1 connections.")
+            # Step 5: Version-specific authentication
+            if self._protocol_version >= ProtocolVersion.V3:
+                if not use_tls:
+                    logger.warning(
+                        "PLC reports V3 protocol but TLS is not enabled. Connection may not work without use_tls=True."
+                    )
             elif self._protocol_version == ProtocolVersion.V2:
                 # TODO: Proprietary HMAC-SHA256/AES session auth
                 raise NotImplementedError("V2 authentication is not yet implemented.")
 
-            # V1: No further authentication needed
+            # V1: No further authentication needed after CreateObject
             self._connected = True
             logger.info(
                 f"S7CommPlus connected to {self.host}:{self.port}, version=V{self._protocol_version}, session={self._session_id}"
@@ -198,16 +220,17 @@ class S7CommPlusConnection:
             + payload
         )
 
-        # Add S7CommPlus frame header and send
+        # Add S7CommPlus frame header and trailer, then send
         frame = encode_header(self._protocol_version, len(request)) + request
+        frame += struct.pack(">BBH", 0x72, self._protocol_version, 0x0000)
         self._iso_conn.send_data(frame)
 
         # Receive response
         response_frame = self._iso_conn.receive_data()
 
-        # Parse frame header
+        # Parse frame header, use data_length to exclude trailer
         version, data_length, consumed = decode_header(response_frame)
-        response = response_frame[consumed:]
+        response = response_frame[consumed : consumed + data_length]
 
         if len(response) < 14:
             from ..error import S7ConnectionError
@@ -216,11 +239,64 @@ class S7CommPlusConnection:
 
         return response[14:]
 
-    def _create_session(self) -> None:
-        """Send CreateObject request to establish an S7CommPlus session."""
+    def _init_ssl(self) -> None:
+        """Send InitSSL request to prepare the connection.
+
+        This is the first S7CommPlus message sent after COTP connect.
+        The PLC responds with an InitSSL response. For PLCs that support
+        TLS, the caller should then activate TLS before sending CreateObject.
+        For V1 PLCs without TLS, the response may indicate that TLS is
+        not supported, but the connection can continue without it.
+
+        Reference: thomas-v2/S7CommPlusDriver InitSslRequest
+        """
         seq_num = self._next_sequence_number()
 
-        # Build CreateObject request with NullServer session data
+        # InitSSL request: header + padding
+        request = struct.pack(
+            ">BHHHHIB",
+            Opcode.REQUEST,
+            0x0000,  # Reserved
+            FunctionCode.INIT_SSL,
+            0x0000,  # Reserved
+            seq_num,
+            0x00000000,  # No session yet
+            0x30,  # Transport flags (0x30 for InitSSL)
+        )
+        # Trailing padding
+        request += struct.pack(">I", 0)
+
+        # Wrap in S7CommPlus frame header + trailer
+        frame = encode_header(ProtocolVersion.V1, len(request)) + request
+        frame += struct.pack(">BBH", 0x72, ProtocolVersion.V1, 0x0000)
+
+        self._iso_conn.send_data(frame)
+
+        # Receive InitSSL response
+        response_frame = self._iso_conn.receive_data()
+
+        # Parse S7CommPlus frame header
+        version, data_length, consumed = decode_header(response_frame)
+        response = response_frame[consumed:]
+
+        if len(response) < 14:
+            from ..error import S7ConnectionError
+
+            raise S7ConnectionError("InitSSL response too short")
+
+        logger.debug(f"InitSSL response received, version=V{version}")
+
+    def _create_session(self) -> None:
+        """Send CreateObject request to establish an S7CommPlus session.
+
+        Builds a NullServerSession CreateObject request matching the
+        structure expected by S7-1200/1500 PLCs:
+
+        Reference: thomas-v2/S7CommPlusDriver CreateObjectRequest.SetNullServerSessionData()
+        """
+        seq_num = self._next_sequence_number()
+
+        # Build CreateObject request header
         request = struct.pack(
             ">BHHHHIB",
             Opcode.REQUEST,
@@ -228,15 +304,54 @@ class S7CommPlusConnection:
             FunctionCode.CREATE_OBJECT,
             0x0000,
             seq_num,
-            0x00000000,  # No session yet
-            0x36,
+            ObjectId.OBJECT_NULL_SERVER_SESSION,  # SessionId = 288 for initial setup
+            0x36,  # Transport flags
         )
 
-        # Add empty request data (minimal CreateObject)
+        # RequestId: ObjectServerSessionContainer (285)
+        request += struct.pack(">I", ObjectId.OBJECT_SERVER_SESSION_CONTAINER)
+
+        # RequestValue: ValueUDInt(0) = DatatypeFlags(0x00) + Datatype.UDInt(0x04) + VLQ(0)
+        request += bytes([0x00, DataType.UDINT]) + encode_uint32_vlq(0)
+
+        # Unknown padding (always 0)
         request += struct.pack(">I", 0)
 
-        # Wrap in S7CommPlus frame header
+        # RequestObject: PObject for NullServerSession
+        # StartOfObject
+        request += bytes([ElementID.START_OF_OBJECT])
+        # RelationId: GetNewRIDOnServer (211)
+        request += struct.pack(">I", ObjectId.GET_NEW_RID_ON_SERVER)
+        # ClassId: ClassServerSession (287), VLQ encoded
+        request += encode_uint32_vlq(ObjectId.CLASS_SERVER_SESSION)
+        # ClassFlags: 0
+        request += encode_uint32_vlq(0)
+        # AttributeId: None (0)
+        request += encode_uint32_vlq(0)
+
+        # Attribute: ServerSessionClientRID (300) = RID 0x80c3c901
+        request += bytes([ElementID.ATTRIBUTE])
+        request += encode_uint32_vlq(ObjectId.SERVER_SESSION_CLIENT_RID)
+        request += encode_typed_value(DataType.RID, 0x80C3C901)
+
+        # Nested object: ClassSubscriptions
+        request += bytes([ElementID.START_OF_OBJECT])
+        request += struct.pack(">I", ObjectId.GET_NEW_RID_ON_SERVER)
+        request += encode_uint32_vlq(ObjectId.CLASS_SUBSCRIPTIONS)
+        request += encode_uint32_vlq(0)  # ClassFlags
+        request += encode_uint32_vlq(0)  # AttributeId
+        request += bytes([ElementID.TERMINATING_OBJECT])
+
+        # End outer object
+        request += bytes([ElementID.TERMINATING_OBJECT])
+
+        # Trailing padding
+        request += struct.pack(">I", 0)
+
+        # Wrap in S7CommPlus frame header + trailer
         frame = encode_header(ProtocolVersion.V1, len(request)) + request
+        # S7CommPlus trailer (end-of-frame marker)
+        frame += struct.pack(">BBH", 0x72, ProtocolVersion.V1, 0x0000)
 
         self._iso_conn.send_data(frame)
 
@@ -275,6 +390,7 @@ class S7CommPlusConnection:
         request += struct.pack(">I", 0)
 
         frame = encode_header(self._protocol_version, len(request)) + request
+        frame += struct.pack(">BBH", 0x72, self._protocol_version, 0x0000)
         self._iso_conn.send_data(frame)
 
         # Best-effort receive

--- a/snap7/s7commplus/connection.py
+++ b/snap7/s7commplus/connection.py
@@ -54,11 +54,25 @@ from .protocol import (
     S7COMMPLUS_LOCAL_TSAP,
     S7COMMPLUS_REMOTE_TSAP,
 )
-from .codec import encode_header, decode_header, encode_typed_value
-from .vlq import encode_uint32_vlq
+from .codec import encode_header, decode_header, encode_typed_value, encode_object_qualifier
+from .vlq import encode_uint32_vlq, decode_uint32_vlq, decode_uint64_vlq
 from .protocol import DataType
 
 logger = logging.getLogger(__name__)
+
+
+def _element_size(datatype: int) -> int:
+    """Return the fixed byte size for an array element, or 0 for variable-length."""
+    if datatype in (DataType.BOOL, DataType.USINT, DataType.BYTE, DataType.SINT):
+        return 1
+    elif datatype in (DataType.UINT, DataType.WORD, DataType.INT):
+        return 2
+    elif datatype in (DataType.REAL, DataType.RID):
+        return 4
+    elif datatype in (DataType.LREAL, DataType.TIMESTAMP):
+        return 8
+    else:
+        return 0
 
 
 class S7CommPlusConnection:
@@ -95,6 +109,7 @@ class S7CommPlusConnection:
         self._protocol_version: int = 0  # Detected from PLC response
         self._tls_active: bool = False
         self._connected = False
+        self._server_session_version: Optional[int] = None
 
     @property
     def connected(self) -> bool:
@@ -153,7 +168,13 @@ class S7CommPlusConnection:
             # Step 4: CreateObject (S7CommPlus session setup)
             self._create_session()
 
-            # Step 5: Version-specific authentication
+            # Step 5: Session setup - echo ServerSessionVersion back to PLC
+            if self._server_session_version is not None:
+                self._setup_session()
+            else:
+                logger.warning("PLC did not provide ServerSessionVersion - session setup incomplete")
+
+            # Step 6: Version-specific authentication
             if self._protocol_version >= ProtocolVersion.V3:
                 if not use_tls:
                     logger.warning(
@@ -186,6 +207,7 @@ class S7CommPlusConnection:
         self._session_id = 0
         self._sequence_number = 0
         self._protocol_version = 0
+        self._server_session_version = None
         self._iso_conn.disconnect()
 
     def send_request(self, function_code: int, payload: bytes = b"") -> bytes:
@@ -417,6 +439,235 @@ class S7CommPlusConnection:
         )
         logger.debug(f"CreateObject response payload: {response[14:].hex(' ')}")
         logger.debug(f"Session created: id=0x{self._session_id:08X} ({self._session_id}), version=V{version}")
+
+        # Parse response payload to extract ServerSessionVersion
+        self._parse_create_object_response(response[14:])
+
+    def _parse_create_object_response(self, payload: bytes) -> None:
+        """Parse CreateObject response payload to extract ServerSessionVersion.
+
+        The response contains a PObject tree with attributes. We scan for
+        attribute 306 (ServerSessionVersion) which must be echoed back to
+        complete the session handshake.
+
+        Args:
+            payload: Response payload after the 14-byte response header
+        """
+        offset = 0
+        while offset < len(payload):
+            tag = payload[offset]
+
+            if tag == ElementID.ATTRIBUTE:
+                offset += 1
+                if offset >= len(payload):
+                    break
+                attr_id, consumed = decode_uint32_vlq(payload, offset)
+                offset += consumed
+
+                if attr_id == ObjectId.SERVER_SESSION_VERSION:
+                    # Next bytes are the typed value: flags + datatype + VLQ value
+                    if offset + 2 > len(payload):
+                        break
+                    _flags = payload[offset]
+                    datatype = payload[offset + 1]
+                    offset += 2
+                    if datatype == DataType.UDINT:
+                        value, consumed = decode_uint32_vlq(payload, offset)
+                        offset += consumed
+                        self._server_session_version = value
+                        logger.info(f"ServerSessionVersion = {value}")
+                        return
+                    elif datatype == DataType.DWORD:
+                        value, consumed = decode_uint32_vlq(payload, offset)
+                        offset += consumed
+                        self._server_session_version = value
+                        logger.info(f"ServerSessionVersion = {value}")
+                        return
+                    else:
+                        # Skip unknown type - try to continue scanning
+                        logger.debug(f"ServerSessionVersion has unexpected type {datatype:#04x}")
+                else:
+                    # Skip this attribute's value - we don't parse it, just advance
+                    # Try to skip the typed value (flags + datatype + value)
+                    if offset + 2 > len(payload):
+                        break
+                    _flags = payload[offset]
+                    datatype = payload[offset + 1]
+                    offset += 2
+                    offset = self._skip_typed_value(payload, offset, datatype, _flags)
+
+            elif tag == ElementID.START_OF_OBJECT:
+                offset += 1
+                # Skip RelationId (4 bytes fixed) + ClassId (VLQ) + ClassFlags (VLQ) + AttributeId (VLQ)
+                if offset + 4 > len(payload):
+                    break
+                offset += 4  # RelationId
+                _, consumed = decode_uint32_vlq(payload, offset)
+                offset += consumed  # ClassId
+                _, consumed = decode_uint32_vlq(payload, offset)
+                offset += consumed  # ClassFlags
+                _, consumed = decode_uint32_vlq(payload, offset)
+                offset += consumed  # AttributeId
+
+            elif tag == ElementID.TERMINATING_OBJECT:
+                offset += 1
+
+            elif tag == 0x00:
+                # Null terminator / padding
+                offset += 1
+
+            else:
+                # Unknown tag - try to skip
+                offset += 1
+
+        logger.debug("ServerSessionVersion not found in CreateObject response")
+
+    def _skip_typed_value(self, data: bytes, offset: int, datatype: int, flags: int) -> int:
+        """Skip over a typed value in the PObject tree.
+
+        Best-effort: advances offset past common value types.
+        Returns new offset.
+        """
+        is_array = bool(flags & 0x10)
+
+        if is_array:
+            if offset >= len(data):
+                return offset
+            count, consumed = decode_uint32_vlq(data, offset)
+            offset += consumed
+            # For fixed-size types, skip count * size
+            elem_size = _element_size(datatype)
+            if elem_size > 0:
+                offset += count * elem_size
+            else:
+                # Variable-length: skip each VLQ element
+                for _ in range(count):
+                    if offset >= len(data):
+                        break
+                    _, consumed = decode_uint32_vlq(data, offset)
+                    offset += consumed
+            return offset
+
+        if datatype == DataType.NULL:
+            return offset
+        elif datatype in (DataType.BOOL, DataType.USINT, DataType.BYTE, DataType.SINT):
+            return offset + 1
+        elif datatype in (DataType.UINT, DataType.WORD, DataType.INT):
+            return offset + 2
+        elif datatype in (DataType.UDINT, DataType.DWORD, DataType.AID, DataType.DINT):
+            _, consumed = decode_uint32_vlq(data, offset)
+            return offset + consumed
+        elif datatype in (DataType.ULINT, DataType.LWORD, DataType.LINT):
+            _, consumed = decode_uint64_vlq(data, offset)
+            return offset + consumed
+        elif datatype == DataType.REAL:
+            return offset + 4
+        elif datatype == DataType.LREAL:
+            return offset + 8
+        elif datatype == DataType.TIMESTAMP:
+            return offset + 8
+        elif datatype == DataType.TIMESPAN:
+            _, consumed = decode_uint64_vlq(data, offset)  # int64 VLQ
+            return offset + consumed
+        elif datatype == DataType.RID:
+            return offset + 4
+        elif datatype in (DataType.BLOB, DataType.WSTRING):
+            length, consumed = decode_uint32_vlq(data, offset)
+            return offset + consumed + length
+        elif datatype == DataType.STRUCT:
+            count, consumed = decode_uint32_vlq(data, offset)
+            offset += consumed
+            for _ in range(count):
+                if offset + 2 > len(data):
+                    break
+                sub_flags = data[offset]
+                sub_type = data[offset + 1]
+                offset += 2
+                offset = self._skip_typed_value(data, offset, sub_type, sub_flags)
+            return offset
+        else:
+            # Unknown type - can't skip reliably
+            return offset
+
+    def _setup_session(self) -> None:
+        """Send SetMultiVariables to echo ServerSessionVersion back to the PLC.
+
+        This completes the session handshake by writing the ServerSessionVersion
+        attribute back to the session object. Without this step, the PLC rejects
+        all subsequent data operations with ERROR2 (0x05A9).
+
+        Reference: thomas-v2/S7CommPlusDriver SetSessionSetupData
+        """
+        if self._server_session_version is None:
+            return
+
+        seq_num = self._next_sequence_number()
+
+        # Build SetMultiVariables request
+        request = struct.pack(
+            ">BHHHHIB",
+            Opcode.REQUEST,
+            0x0000,
+            FunctionCode.SET_MULTI_VARIABLES,
+            0x0000,
+            seq_num,
+            self._session_id,
+            0x36,  # Transport flags
+        )
+
+        payload = bytearray()
+        # InObjectId = session ID (tells PLC which object we're writing to)
+        payload += struct.pack(">I", self._session_id)
+        # Item count = 1
+        payload += encode_uint32_vlq(1)
+        # Total address field count = 1 (just the attribute ID)
+        payload += encode_uint32_vlq(1)
+        # Address: attribute ID = ServerSessionVersion (306) as VLQ
+        payload += encode_uint32_vlq(ObjectId.SERVER_SESSION_VERSION)
+        # Value: ItemNumber = 1 (VLQ)
+        payload += encode_uint32_vlq(1)
+        # PValue: flags=0x00, type=UDInt, VLQ-encoded value
+        payload += bytes([0x00, DataType.UDINT])
+        payload += encode_uint32_vlq(self._server_session_version)
+        # Fill byte
+        payload += bytes([0x00])
+        # ObjectQualifier
+        payload += encode_object_qualifier()
+        # Trailing padding
+        payload += struct.pack(">I", 0)
+
+        request += bytes(payload)
+
+        # Wrap in S7CommPlus frame
+        frame = encode_header(self._protocol_version, len(request)) + request
+        frame += struct.pack(">BBH", 0x72, self._protocol_version, 0x0000)
+
+        logger.debug(f"=== SetupSession === sending ({len(frame)} bytes): {frame.hex(' ')}")
+        self._iso_conn.send_data(frame)
+
+        # Receive response
+        response_frame = self._iso_conn.receive_data()
+        logger.debug(f"=== SetupSession === received ({len(response_frame)} bytes): {response_frame.hex(' ')}")
+
+        version, data_length, consumed = decode_header(response_frame)
+        response = response_frame[consumed : consumed + data_length]
+
+        if len(response) < 14:
+            from ..error import S7ConnectionError
+
+            raise S7ConnectionError("SetupSession response too short")
+
+        resp_func = struct.unpack_from(">H", response, 3)[0]
+        logger.debug(f"SetupSession response: function=0x{resp_func:04X}")
+
+        # Parse return value from payload
+        resp_payload = response[14:]
+        if len(resp_payload) >= 1:
+            return_value, _ = decode_uint64_vlq(resp_payload, 0)
+            if return_value != 0:
+                logger.warning(f"SetupSession: PLC returned error {return_value}")
+            else:
+                logger.info("Session setup completed successfully")
 
     def _delete_session(self) -> None:
         """Send DeleteObject to close the session."""

--- a/snap7/s7commplus/connection.py
+++ b/snap7/s7commplus/connection.py
@@ -1,0 +1,249 @@
+"""
+S7CommPlus connection management.
+
+Establishes an ISO-on-TCP connection to S7-1200/1500 PLCs using the
+S7CommPlus protocol, with support for all protocol versions:
+
+- V1: Early S7-1200 (FW >= V4.0). Trivial anti-replay (challenge + 0x80).
+- V2: Adds integrity checking and proprietary session authentication.
+- V3: Adds ECC-based key exchange.
+- V3 + TLS: TIA Portal V17+. Standard TLS 1.3 with per-device certificates.
+
+The wire protocol (VLQ encoding, data types, function codes, object model) is
+the same across all versions -- only the session authentication layer differs.
+
+Connection sequence (all versions)::
+
+    1. TCP connect to port 102
+    2. COTP Connection Request / Confirm (same as legacy S7comm)
+    3. S7CommPlus CreateObject request (NullServer session setup)
+    4. PLC responds with CreateObject response containing:
+       - Protocol version (V1/V2/V3)
+       - Session ID
+       - Server session challenge (V2/V3)
+
+Version-specific authentication after step 4::
+
+    V1: session_response = challenge_byte + 0x80
+    V2: Proprietary HMAC-SHA256 / AES session key derivation
+    V3 (no TLS): ECC-based key exchange (requires product-family keys)
+    V3 (TLS): InitSsl request -> TLS 1.3 handshake over TPKT/COTP tunnel
+
+Reference: thomas-v2/S7CommPlusDriver (C#, LGPL-3.0)
+"""
+
+import logging
+import ssl
+from typing import Optional, Type
+from types import TracebackType
+
+from ..connection import ISOTCPConnection
+
+logger = logging.getLogger(__name__)
+
+
+class S7CommPlusConnection:
+    """S7CommPlus connection with multi-version support.
+
+    Wraps an ISOTCPConnection and adds:
+    - S7CommPlus session establishment (CreateObject)
+    - Protocol version detection from PLC response
+    - Version-appropriate authentication (V1/V2/V3/TLS)
+    - Frame send/receive (TLS-encrypted when using V17+ firmware)
+
+    Status: scaffolding -- connection logic is not yet implemented.
+    """
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 102,
+        local_tsap: int = 0x0100,
+        remote_tsap: int = 0x0102,
+    ):
+        self.host = host
+        self.port = port
+        self.local_tsap = local_tsap
+        self.remote_tsap = remote_tsap
+
+        self._iso_conn = ISOTCPConnection(
+            host=host,
+            port=port,
+            local_tsap=local_tsap,
+            remote_tsap=remote_tsap,
+        )
+
+        self._ssl_context: Optional[ssl.SSLContext] = None
+        self._session_id: int = 0
+        self._sequence_number: int = 0
+        self._protocol_version: int = 0  # Detected from PLC response
+        self._tls_active: bool = False
+        self._connected = False
+
+    @property
+    def connected(self) -> bool:
+        return self._connected
+
+    @property
+    def protocol_version(self) -> int:
+        """Protocol version negotiated with the PLC."""
+        return self._protocol_version
+
+    @property
+    def tls_active(self) -> bool:
+        """Whether TLS encryption is active on this connection."""
+        return self._tls_active
+
+    def connect(
+        self,
+        timeout: float = 5.0,
+        use_tls: bool = True,
+        tls_cert: Optional[str] = None,
+        tls_key: Optional[str] = None,
+        tls_ca: Optional[str] = None,
+    ) -> None:
+        """Establish S7CommPlus connection.
+
+        The connection sequence:
+        1. COTP connection (same as legacy S7comm)
+        2. CreateObject to establish S7CommPlus session
+        3. Protocol version is detected from PLC response
+        4. If use_tls=True and PLC supports it, TLS is negotiated
+        5. If use_tls=False, falls back to version-appropriate auth
+
+        Args:
+            timeout: Connection timeout in seconds
+            use_tls: Whether to attempt TLS negotiation (default True).
+                     If the PLC does not support TLS, falls back to the
+                     protocol version's native authentication.
+            tls_cert: Path to client TLS certificate (PEM)
+            tls_key: Path to client TLS private key (PEM)
+            tls_ca: Path to CA certificate for PLC verification (PEM)
+
+        Raises:
+            S7ConnectionError: If connection fails
+            NotImplementedError: Until connection logic is implemented
+        """
+        # TODO: Implementation roadmap:
+        #
+        # Phase 1 - COTP connection (reuse existing ISOTCPConnection):
+        #   self._iso_conn.connect(timeout)
+        #
+        # Phase 2 - CreateObject (session setup):
+        #   Build CreateObject request with NullServerSession data
+        #   Send via self._iso_conn.send_data()
+        #   Parse CreateObject response to get:
+        #     - self._protocol_version (V1/V2/V3)
+        #     - self._session_id
+        #     - server_session_challenge (for V2/V3)
+        #
+        # Phase 3 - Authentication (version-dependent):
+        #   if V1:
+        #     Simple: send challenge + 0x80
+        #   elif V3 and use_tls:
+        #     Send InitSsl request
+        #     Perform TLS handshake over the TPKT/COTP tunnel
+        #     self._tls_active = True
+        #   elif V2 or V3 (no TLS):
+        #     Proprietary key derivation (HMAC-SHA256, AES, ECC)
+        #     Compute integrity ID for subsequent packets
+        #
+        # Phase 4 - Session is ready for data exchange
+
+        raise NotImplementedError(
+            "S7CommPlus connection is not yet implemented. "
+            "This module is scaffolding for future development. "
+            "See https://github.com/thomas-v2/S7CommPlusDriver for reference."
+        )
+
+    def disconnect(self) -> None:
+        """Disconnect from PLC."""
+        self._connected = False
+        self._tls_active = False
+        self._session_id = 0
+        self._sequence_number = 0
+        self._protocol_version = 0
+        self._iso_conn.disconnect()
+
+    def send(self, data: bytes) -> None:
+        """Send an S7CommPlus frame.
+
+        Adds the S7CommPlus frame header and sends over the ISO connection.
+        If TLS is active, data is encrypted before sending.
+
+        Args:
+            data: S7CommPlus PDU payload (without frame header)
+
+        Raises:
+            S7ConnectionError: If not connected
+            NotImplementedError: Until send logic is implemented
+        """
+        raise NotImplementedError("S7CommPlus send is not yet implemented.")
+
+    def receive(self) -> bytes:
+        """Receive an S7CommPlus frame.
+
+        Returns:
+            S7CommPlus PDU payload (without frame header)
+
+        Raises:
+            S7ConnectionError: If not connected
+            NotImplementedError: Until receive logic is implemented
+        """
+        raise NotImplementedError("S7CommPlus receive is not yet implemented.")
+
+    def _next_sequence_number(self) -> int:
+        """Get next sequence number and increment."""
+        seq = self._sequence_number
+        self._sequence_number = (self._sequence_number + 1) & 0xFFFF
+        return seq
+
+    def _setup_ssl_context(
+        self,
+        cert_path: Optional[str] = None,
+        key_path: Optional[str] = None,
+        ca_path: Optional[str] = None,
+    ) -> ssl.SSLContext:
+        """Create TLS context for S7CommPlus.
+
+        For TIA Portal V17+ PLCs, TLS 1.3 with per-device certificates is
+        used. The PLC's certificate is generated in TIA Portal and must be
+        exported and provided as the CA certificate.
+
+        For older PLCs, TLS is not used (the proprietary auth layer handles
+        session security).
+
+        Args:
+            cert_path: Client certificate path (PEM)
+            key_path: Client private key path (PEM)
+            ca_path: PLC CA certificate path (PEM)
+
+        Returns:
+            Configured SSLContext
+        """
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+
+        if cert_path and key_path:
+            ctx.load_cert_chain(cert_path, key_path)
+
+        if ca_path:
+            ctx.load_verify_locations(ca_path)
+        else:
+            # For development/testing: disable certificate verification
+            # In production, always provide proper certificates
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+
+        return ctx
+
+    def __enter__(self) -> "S7CommPlusConnection":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_val: Optional[BaseException],
+        exc_tb: Optional[TracebackType],
+    ) -> None:
+        self.disconnect()

--- a/snap7/s7commplus/connection.py
+++ b/snap7/s7commplus/connection.py
@@ -4,9 +4,9 @@ S7CommPlus connection management.
 Establishes an ISO-on-TCP connection to S7-1200/1500 PLCs using the
 S7CommPlus protocol, with support for all protocol versions:
 
-- V1: Early S7-1200 (FW >= V4.0). Trivial anti-replay (challenge + 0x80).
-- V2: Adds integrity checking and proprietary session authentication.
-- V3: Adds ECC-based key exchange.
+- V1: Early S7-1200 (FW >= V4.0). Simple session handshake.
+- V2: Adds integrity checking and session authentication.
+- V3: Adds public-key-based key exchange.
 - V3 + TLS: TIA Portal V17+. Standard TLS 1.3 with per-device certificates.
 
 The wire protocol (VLQ encoding, data types, function codes, object model) is
@@ -24,9 +24,9 @@ Connection sequence (all versions)::
 
 Version-specific authentication after step 4::
 
-    V1: session_response = challenge_byte + 0x80
-    V2: Proprietary HMAC-SHA256 / AES session key derivation
-    V3 (no TLS): ECC-based key exchange (requires product-family keys)
+    V1: Simple challenge-response handshake
+    V2: Session key derivation and integrity checking
+    V3 (no TLS): Public-key key exchange
     V3 (TLS): InitSsl request -> TLS 1.3 handshake over TPKT/COTP tunnel
 
 Reference: thomas-v2/S7CommPlusDriver (C#, LGPL-3.0)

--- a/snap7/s7commplus/protocol.py
+++ b/snap7/s7commplus/protocol.py
@@ -18,12 +18,12 @@ PROTOCOL_ID = 0x72
 class ProtocolVersion(IntEnum):
     """S7CommPlus protocol versions.
 
-    V1: Early S7-1200 FW V4.0 -- trivial anti-replay (challenge + 0x80)
-    V2: Adds integrity checking and proprietary session authentication
-    V3: Adds ECC-based key exchange (broken via CVE-2022-38465)
+    V1: Early S7-1200 FW V4.0 -- simple session handshake
+    V2: Adds integrity checking and session authentication
+    V3: Adds public-key-based key exchange
     TLS: TIA Portal V17+ -- standard TLS 1.3 with per-device certificates
 
-    For new implementations, only TLS (V3 + InitSsl) should be targeted.
+    For new implementations, TLS (V3 + InitSsl) is the recommended target.
     """
 
     V1 = 0x01

--- a/snap7/s7commplus/protocol.py
+++ b/snap7/s7commplus/protocol.py
@@ -100,6 +100,7 @@ class ObjectId(IntEnum):
     CLASS_SERVER_SESSION = 287
     OBJECT_NULL_SERVER_SESSION = 288
     SERVER_SESSION_CLIENT_RID = 300
+    SERVER_SESSION_VERSION = 306
 
 
 # Default TSAP for S7CommPlus connections

--- a/snap7/s7commplus/protocol.py
+++ b/snap7/s7commplus/protocol.py
@@ -1,0 +1,176 @@
+"""
+S7CommPlus protocol constants and types.
+
+Defines the protocol framing, opcodes, function codes, data types,
+element IDs, and other constants needed for S7CommPlus communication.
+
+Reference: thomas-v2/S7CommPlusDriver (C#, LGPL-3.0)
+Reference: Wireshark S7CommPlus dissector
+"""
+
+from enum import IntEnum
+
+
+# Protocol identification byte (vs 0x32 for legacy S7comm)
+PROTOCOL_ID = 0x72
+
+
+class ProtocolVersion(IntEnum):
+    """S7CommPlus protocol versions.
+
+    V1: Early S7-1200 FW V4.0 -- trivial anti-replay (challenge + 0x80)
+    V2: Adds integrity checking and proprietary session authentication
+    V3: Adds ECC-based key exchange (broken via CVE-2022-38465)
+    TLS: TIA Portal V17+ -- standard TLS 1.3 with per-device certificates
+
+    For new implementations, only TLS (V3 + InitSsl) should be targeted.
+    """
+
+    V1 = 0x01
+    V2 = 0x02
+    V3 = 0x03
+    SYSTEM_EVENT = 0xFE
+
+
+class Opcode(IntEnum):
+    """S7CommPlus opcodes (first byte after header)."""
+
+    REQUEST = 0x31
+    RESPONSE = 0x32
+    NOTIFICATION = 0x33
+    RESPONSE2 = 0x02  # Seen in some older firmware
+
+
+class FunctionCode(IntEnum):
+    """S7CommPlus function codes.
+
+    These identify the type of operation in a request/response pair.
+    """
+
+    ERROR = 0x04B1
+    EXPLORE = 0x04BB
+    CREATE_OBJECT = 0x04CA
+    DELETE_OBJECT = 0x04D4
+    SET_VARIABLE = 0x04F2
+    GET_VARIABLE = 0x04FC  # Only in old S7-1200 firmware
+    ADD_LINK = 0x0506
+    REMOVE_LINK = 0x051A
+    GET_LINK = 0x0524
+    SET_MULTI_VARIABLES = 0x0542
+    GET_MULTI_VARIABLES = 0x054C
+    BEGIN_SEQUENCE = 0x0556
+    END_SEQUENCE = 0x0560
+    INVOKE = 0x056B
+    SET_VAR_SUBSTREAMED = 0x057C
+    GET_VAR_SUBSTREAMED = 0x0586
+    GET_VARIABLES_ADDRESS = 0x0590
+    ABORT = 0x059A
+    ERROR2 = 0x05A9
+    INIT_SSL = 0x05B3
+
+
+class ElementID(IntEnum):
+    """Tag IDs used in the object serialization format.
+
+    S7CommPlus uses a tagged object model where data is structured as
+    nested objects with attributes, similar to TLV encoding.
+    """
+
+    START_OF_OBJECT = 0xA1
+    TERMINATING_OBJECT = 0xA2
+    ATTRIBUTE = 0xA3
+    RELATION = 0xA4
+    START_OF_TAG_DESCRIPTION = 0xA7
+    TERMINATING_TAG_DESCRIPTION = 0xA8
+    VARTYPE_LIST = 0xAB
+    VARNAME_LIST = 0xAC
+
+
+class DataType(IntEnum):
+    """S7CommPlus wire data types.
+
+    These identify how values are encoded on the wire in the S7CommPlus
+    protocol. Note: these differ from the Softdatatype IDs used for
+    PLC variable type metadata.
+    """
+
+    NULL = 0x00
+    BOOL = 0x01
+    USINT = 0x02
+    UINT = 0x03
+    UDINT = 0x04
+    ULINT = 0x05
+    SINT = 0x06
+    INT = 0x07
+    DINT = 0x08
+    LINT = 0x09
+    BYTE = 0x0A
+    WORD = 0x0B
+    DWORD = 0x0C
+    LWORD = 0x0D
+    REAL = 0x0E
+    LREAL = 0x0F
+    TIMESTAMP = 0x10
+    TIMESPAN = 0x11
+    RID = 0x12
+    AID = 0x13
+    BLOB = 0x14
+    WSTRING = 0x15
+    VARIANT = 0x16
+    STRUCT = 0x17
+    S7STRING = 0x19
+
+
+class SoftDataType(IntEnum):
+    """PLC soft data types (used in variable metadata / tag descriptions).
+
+    These correspond to the data types as they appear in the PLC's symbol
+    table and are used for symbolic access to optimized data blocks.
+    """
+
+    VOID = 0
+    BOOL = 1
+    BYTE = 2
+    CHAR = 3
+    WORD = 4
+    INT = 5
+    DWORD = 6
+    DINT = 7
+    REAL = 8
+    DATE = 9
+    TIME_OF_DAY = 10
+    TIME = 11
+    S5TIME = 12
+    DATE_AND_TIME = 14
+    ARRAY = 16
+    STRUCT = 17
+    STRING = 19
+    POINTER = 20
+    ANY = 22
+    BLOCK_FB = 23
+    BLOCK_FC = 24
+    BLOCK_DB = 25
+    BLOCK_SDB = 26
+    COUNTER = 28
+    TIMER = 29
+    IEC_COUNTER = 30
+    IEC_TIMER = 31
+    BLOCK_SFB = 32
+    BLOCK_SFC = 33
+    BLOCK_OB = 36
+    BLOCK_UDT = 37
+    LREAL = 48
+    ULINT = 49
+    LINT = 50
+    LWORD = 51
+    USINT = 52
+    UINT = 53
+    UDINT = 54
+    SINT = 55
+    WCHAR = 61
+    WSTRING = 62
+    VARIANT = 63
+    LTIME = 64
+    LTOD = 65
+    LDT = 66
+    DTL = 67

--- a/snap7/s7commplus/protocol.py
+++ b/snap7/s7commplus/protocol.py
@@ -86,6 +86,28 @@ class ElementID(IntEnum):
     VARNAME_LIST = 0xAC
 
 
+class ObjectId(IntEnum):
+    """Well-known object IDs used in session establishment.
+
+    Reference: thomas-v2/S7CommPlusDriver/Core/Ids.cs
+    """
+
+    NONE = 0
+    GET_NEW_RID_ON_SERVER = 211
+    CLASS_SUBSCRIPTIONS = 255
+    CLASS_SERVER_SESSION_CONTAINER = 284
+    OBJECT_SERVER_SESSION_CONTAINER = 285
+    CLASS_SERVER_SESSION = 287
+    OBJECT_NULL_SERVER_SESSION = 288
+    SERVER_SESSION_CLIENT_RID = 300
+
+
+# Default TSAP for S7CommPlus connections
+# The remote TSAP is the ASCII string "SIMATIC-ROOT-HMI" (16 bytes)
+S7COMMPLUS_LOCAL_TSAP = 0x0600
+S7COMMPLUS_REMOTE_TSAP = b"SIMATIC-ROOT-HMI"
+
+
 class DataType(IntEnum):
     """S7CommPlus wire data types.
 

--- a/snap7/s7commplus/protocol.py
+++ b/snap7/s7commplus/protocol.py
@@ -143,6 +143,33 @@ class DataType(IntEnum):
     S7STRING = 0x19
 
 
+class Ids(IntEnum):
+    """Well-known IDs for S7CommPlus protocol structures.
+
+    Reference: thomas-v2/S7CommPlusDriver/Core/Ids.cs
+    """
+
+    # Data block access sub-areas
+    DB_VALUE_ACTUAL = 2550
+    CONTROLLER_AREA_VALUE_ACTUAL = 2551
+
+    # ObjectQualifier structure IDs
+    OBJECT_QUALIFIER = 1256
+    PARENT_RID = 1257
+    COMPOSITION_AID = 1258
+    KEY_QUALIFIER = 1259
+
+    # Native object RIDs for memory areas
+    NATIVE_THE_I_AREA_RID = 80
+    NATIVE_THE_Q_AREA_RID = 81
+    NATIVE_THE_M_AREA_RID = 82
+    NATIVE_THE_S7_COUNTERS_RID = 83
+    NATIVE_THE_S7_TIMERS_RID = 84
+
+    # DB AccessArea base (add DB number to get area ID)
+    DB_ACCESS_AREA_BASE = 0x8A0E0000
+
+
 class SoftDataType(IntEnum):
     """PLC soft data types (used in variable metadata / tag descriptions).
 

--- a/snap7/s7commplus/server.py
+++ b/snap7/s7commplus/server.py
@@ -428,8 +428,9 @@ class S7CommPlusServer:
 
     def _send_s7commplus_frame(self, sock: socket.socket, data: bytes) -> None:
         """Send an S7CommPlus frame wrapped in TPKT/COTP."""
-        # S7CommPlus header (4 bytes) + data
+        # S7CommPlus header (4 bytes) + data + trailer (4 bytes)
         s7plus_frame = encode_header(self._protocol_version, len(data)) + data
+        s7plus_frame += struct.pack(">BBH", 0x72, self._protocol_version, 0x0000)
 
         # COTP DT header
         cotp_dt = struct.pack(">BBB", 2, 0xF0, 0x80) + s7plus_frame
@@ -449,7 +450,8 @@ class S7CommPlusServer:
         except ValueError:
             return None
 
-        payload = data[consumed:]
+        # Use data_length to exclude any trailer
+        payload = data[consumed : consumed + data_length]
         if len(payload) < 14:
             return None
 
@@ -463,7 +465,9 @@ class S7CommPlusServer:
         req_session_id = struct.unpack_from(">I", payload, 9)[0]
         request_data = payload[14:]
 
-        if function_code == FunctionCode.CREATE_OBJECT:
+        if function_code == FunctionCode.INIT_SSL:
+            return self._handle_init_ssl(seq_num)
+        elif function_code == FunctionCode.CREATE_OBJECT:
             return self._handle_create_object(seq_num, request_data)
         elif function_code == FunctionCode.DELETE_OBJECT:
             return self._handle_delete_object(seq_num, req_session_id)
@@ -475,6 +479,23 @@ class S7CommPlusServer:
             return self._handle_set_multi_variables(seq_num, req_session_id, request_data)
         else:
             return self._build_error_response(seq_num, req_session_id, function_code)
+
+    def _handle_init_ssl(self, seq_num: int) -> bytes:
+        """Handle InitSSL -- respond to SSL initialization (V1 emulation, no real TLS)."""
+        response = bytearray()
+        response += struct.pack(
+            ">BHHHHIB",
+            Opcode.RESPONSE,
+            0x0000,
+            FunctionCode.INIT_SSL,
+            0x0000,
+            seq_num,
+            0x00000000,
+            0x00,  # Transport flags
+        )
+        response += encode_uint32_vlq(0)  # Return code: success
+        response += struct.pack(">I", 0)
+        return bytes(response)
 
     def _handle_create_object(self, seq_num: int, request_data: bytes) -> bytes:
         """Handle CreateObject -- establish a session."""

--- a/snap7/s7commplus/server.py
+++ b/snap7/s7commplus/server.py
@@ -816,8 +816,8 @@ def _server_parse_read_request(request_data: bytes) -> list[tuple[int, int, int]
         # Extract db_number from AccessArea
         db_num = access_area & 0xFFFF
 
-        # Extract byte offset and size from LIDs
-        byte_offset = lids[0] if len(lids) > 0 else 0
+        # Extract byte offset and size from LIDs (LID offsets are 1-based)
+        byte_offset = (lids[0] - 1) if len(lids) > 0 else 0
         byte_size = lids[1] if len(lids) > 1 else 1
 
         items.append((db_num, byte_offset, byte_size))
@@ -882,7 +882,7 @@ def _server_parse_write_request(request_data: bytes) -> tuple[list[tuple[int, in
             lids.append(lid_val)
 
         db_num = access_area & 0xFFFF
-        byte_offset = lids[0] if len(lids) > 0 else 0
+        byte_offset = (lids[0] - 1) if len(lids) > 0 else 0  # LID offsets are 1-based
         byte_size = lids[1] if len(lids) > 1 else 1
         items.append((db_num, byte_offset, byte_size))
 

--- a/snap7/s7commplus/server.py
+++ b/snap7/s7commplus/server.py
@@ -40,8 +40,14 @@ from .protocol import (
     ProtocolVersion,
     SoftDataType,
 )
-from .vlq import encode_uint32_vlq, decode_uint32_vlq
-from .codec import encode_header, decode_header, encode_typed_value
+from .vlq import encode_uint32_vlq, decode_uint32_vlq, encode_uint64_vlq
+from .codec import (
+    encode_header,
+    decode_header,
+    encode_typed_value,
+    encode_pvalue_blob,
+    decode_pvalue_to_bytes,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -613,7 +619,14 @@ class S7CommPlusServer:
         return bytes(response)
 
     def _handle_get_multi_variables(self, seq_num: int, session_id: int, request_data: bytes) -> bytes:
-        """Handle GetMultiVariables -- read variables from data blocks."""
+        """Handle GetMultiVariables -- read variables from data blocks.
+
+        Parses the S7CommPlus request format with ItemAddress structures.
+        The server extracts db_number from AccessArea and byte offset/size
+        from the LID values.
+
+        Reference: thomas-v2/S7CommPlusDriver/Core/GetMultiVariablesRequest.cs
+        """
         response = bytearray()
         response += struct.pack(
             ">BHHHHIB",
@@ -625,49 +638,45 @@ class S7CommPlusServer:
             session_id,
             0x00,
         )
-        response += encode_uint32_vlq(0)  # Return code: success
 
-        # Parse request: expect object_id + variable addresses
-        offset = 0
-        items: list[tuple[int, int, int]] = []  # (db_num, byte_offset, byte_size)
+        # Parse request payload
+        items = _server_parse_read_request(request_data)
 
-        # Simple request format: VLQ item count, then for each item:
-        #   VLQ object_id, VLQ offset, VLQ size
-        if len(request_data) > 0:
-            count, consumed = decode_uint32_vlq(request_data, offset)
-            offset += consumed
+        # ReturnValue: success
+        response += encode_uint64_vlq(0)
 
-            for _ in range(count):
-                if offset >= len(request_data):
-                    break
-                obj_id, consumed = decode_uint32_vlq(request_data, offset)
-                offset += consumed
-                byte_offset, consumed = decode_uint32_vlq(request_data, offset)
-                offset += consumed
-                byte_size, consumed = decode_uint32_vlq(request_data, offset)
-                offset += consumed
-
-                db_num = obj_id & 0xFFFF
-                items.append((db_num, byte_offset, byte_size))
-
-        # Read data for each item
-        response += encode_uint32_vlq(len(items))
-        for db_num, byte_offset, byte_size in items:
+        # Value list: ItemNumber (1-based) + PValue, terminated by ItemNumber=0
+        for i, (db_num, byte_offset, byte_size) in enumerate(items, 1):
             db = self._data_blocks.get(db_num)
             if db is not None:
                 data = db.read(byte_offset, byte_size)
-                response += encode_uint32_vlq(0)  # Success
-                response += encode_uint32_vlq(len(data))
-                response += data
-            else:
-                response += encode_uint32_vlq(1)  # Error: not found
-                response += encode_uint32_vlq(0)
+                response += encode_uint32_vlq(i)  # ItemNumber
+                response += encode_pvalue_blob(data)  # Value as BLOB
+            # Errors handled in error list below
 
-        response += struct.pack(">I", 0)
+        # Terminate value list
+        response += encode_uint32_vlq(0)
+
+        # Error list
+        for i, (db_num, byte_offset, byte_size) in enumerate(items, 1):
+            db = self._data_blocks.get(db_num)
+            if db is None:
+                response += encode_uint32_vlq(i)  # ErrorItemNumber
+                response += encode_uint64_vlq(0x8104)  # Error: object not found
+
+        # Terminate error list
+        response += encode_uint32_vlq(0)
+
+        # IntegrityId
+        response += encode_uint32_vlq(0)
+
         return bytes(response)
 
     def _handle_set_multi_variables(self, seq_num: int, session_id: int, request_data: bytes) -> bytes:
-        """Handle SetMultiVariables -- write variables to data blocks."""
+        """Handle SetMultiVariables -- write variables to data blocks.
+
+        Reference: thomas-v2/S7CommPlusDriver/Core/SetMultiVariablesRequest.cs
+        """
         response = bytearray()
         response += struct.pack(
             ">BHHHHIB",
@@ -680,42 +689,32 @@ class S7CommPlusServer:
             0x00,
         )
 
-        # Parse request: VLQ item count, then for each item:
-        #   VLQ object_id, VLQ offset, VLQ data_length, data bytes
-        offset = 0
-        results: list[int] = []
+        # Parse request payload
+        items, values = _server_parse_write_request(request_data)
 
-        if len(request_data) > 0:
-            count, consumed = decode_uint32_vlq(request_data, offset)
-            offset += consumed
+        # Write data
+        errors: list[tuple[int, int]] = []
+        for i, ((db_num, byte_offset, _), data) in enumerate(zip(items, values), 1):
+            db = self._data_blocks.get(db_num)
+            if db is not None:
+                db.write(byte_offset, data)
+            else:
+                errors.append((i, 0x8104))  # Object not found
 
-            for _ in range(count):
-                if offset >= len(request_data):
-                    break
-                obj_id, consumed = decode_uint32_vlq(request_data, offset)
-                offset += consumed
-                byte_offset, consumed = decode_uint32_vlq(request_data, offset)
-                offset += consumed
-                data_len, consumed = decode_uint32_vlq(request_data, offset)
-                offset += consumed
+        # ReturnValue: success
+        response += encode_uint64_vlq(0)
 
-                data = request_data[offset : offset + data_len]
-                offset += data_len
+        # Error list
+        for err_item, err_code in errors:
+            response += encode_uint32_vlq(err_item)
+            response += encode_uint64_vlq(err_code)
 
-                db_num = obj_id & 0xFFFF
-                db = self._data_blocks.get(db_num)
-                if db is not None:
-                    db.write(byte_offset, data)
-                    results.append(0)  # Success
-                else:
-                    results.append(1)  # Error: not found
+        # Terminate error list
+        response += encode_uint32_vlq(0)
 
-        response += encode_uint32_vlq(0)  # Return code: success
-        response += encode_uint32_vlq(len(results))
-        for r in results:
-            response += encode_uint32_vlq(r)
+        # IntegrityId
+        response += encode_uint32_vlq(0)
 
-        response += struct.pack(">I", 0)
         return bytes(response)
 
     def _build_error_response(self, seq_num: int, session_id: int, function_code: int) -> bytes:
@@ -751,3 +750,153 @@ class S7CommPlusServer:
 
     def __exit__(self, *args: Any) -> None:
         self.stop()
+
+
+# -- Server-side request parsers --
+
+
+def _server_parse_read_request(request_data: bytes) -> list[tuple[int, int, int]]:
+    """Parse a GetMultiVariables request payload on the server side.
+
+    Extracts (db_number, byte_offset, byte_size) for each item from the
+    S7CommPlus ItemAddress format.
+
+    Returns:
+        List of (db_number, byte_offset, byte_size) tuples
+    """
+    if not request_data:
+        return []
+
+    offset = 0
+    items: list[tuple[int, int, int]] = []
+
+    # LinkId (UInt32 fixed)
+    if offset + 4 > len(request_data):
+        return []
+    offset += 4
+
+    # ItemCount (VLQ)
+    item_count, consumed = decode_uint32_vlq(request_data, offset)
+    offset += consumed
+
+    # FieldCount (VLQ)
+    _field_count, consumed = decode_uint32_vlq(request_data, offset)
+    offset += consumed
+
+    # Parse each ItemAddress
+    for _ in range(item_count):
+        if offset >= len(request_data):
+            break
+
+        # SymbolCrc
+        _symbol_crc, consumed = decode_uint32_vlq(request_data, offset)
+        offset += consumed
+
+        # AccessArea
+        access_area, consumed = decode_uint32_vlq(request_data, offset)
+        offset += consumed
+
+        # NumberOfLIDs
+        num_lids, consumed = decode_uint32_vlq(request_data, offset)
+        offset += consumed
+
+        # AccessSubArea (first LID)
+        _access_sub_area, consumed = decode_uint32_vlq(request_data, offset)
+        offset += consumed
+
+        # Additional LIDs
+        lids: list[int] = []
+        for _ in range(num_lids - 1):  # -1 because AccessSubArea counts as one
+            if offset >= len(request_data):
+                break
+            lid_val, consumed = decode_uint32_vlq(request_data, offset)
+            offset += consumed
+            lids.append(lid_val)
+
+        # Extract db_number from AccessArea
+        db_num = access_area & 0xFFFF
+
+        # Extract byte offset and size from LIDs
+        byte_offset = lids[0] if len(lids) > 0 else 0
+        byte_size = lids[1] if len(lids) > 1 else 1
+
+        items.append((db_num, byte_offset, byte_size))
+
+    return items
+
+
+def _server_parse_write_request(request_data: bytes) -> tuple[list[tuple[int, int, int]], list[bytes]]:
+    """Parse a SetMultiVariables request payload on the server side.
+
+    Returns:
+        Tuple of (items, values) where items is list of (db_number, byte_offset, byte_size)
+        and values is list of raw bytes to write
+    """
+    if not request_data:
+        return [], []
+
+    offset = 0
+
+    # InObjectId (UInt32 fixed)
+    if offset + 4 > len(request_data):
+        return [], []
+    offset += 4
+
+    # ItemCount (VLQ)
+    item_count, consumed = decode_uint32_vlq(request_data, offset)
+    offset += consumed
+
+    # FieldCount (VLQ)
+    _field_count, consumed = decode_uint32_vlq(request_data, offset)
+    offset += consumed
+
+    # Parse each ItemAddress
+    items: list[tuple[int, int, int]] = []
+    for _ in range(item_count):
+        if offset >= len(request_data):
+            break
+
+        # SymbolCrc
+        _symbol_crc, consumed = decode_uint32_vlq(request_data, offset)
+        offset += consumed
+
+        # AccessArea
+        access_area, consumed = decode_uint32_vlq(request_data, offset)
+        offset += consumed
+
+        # NumberOfLIDs
+        num_lids, consumed = decode_uint32_vlq(request_data, offset)
+        offset += consumed
+
+        # AccessSubArea
+        _access_sub_area, consumed = decode_uint32_vlq(request_data, offset)
+        offset += consumed
+
+        # Additional LIDs
+        lids: list[int] = []
+        for _ in range(num_lids - 1):
+            if offset >= len(request_data):
+                break
+            lid_val, consumed = decode_uint32_vlq(request_data, offset)
+            offset += consumed
+            lids.append(lid_val)
+
+        db_num = access_area & 0xFFFF
+        byte_offset = lids[0] if len(lids) > 0 else 0
+        byte_size = lids[1] if len(lids) > 1 else 1
+        items.append((db_num, byte_offset, byte_size))
+
+    # Parse value list: ItemNumber (VLQ, 1-based) + PValue
+    values: list[bytes] = []
+    for _ in range(item_count):
+        if offset >= len(request_data):
+            break
+        item_nr, consumed = decode_uint32_vlq(request_data, offset)
+        offset += consumed
+        if item_nr == 0:
+            break
+        raw_bytes, consumed = decode_pvalue_to_bytes(request_data, offset)
+        offset += consumed
+        values.append(raw_bytes)
+
+    return items, values

--- a/snap7/s7commplus/server.py
+++ b/snap7/s7commplus/server.py
@@ -1,0 +1,744 @@
+"""
+S7CommPlus server emulator for testing.
+
+Emulates an S7-1200/1500 PLC for integration testing without real hardware.
+Handles the S7CommPlus protocol including:
+- COTP connection setup (reuses ISOTCPConnection transport)
+- CreateObject session handshake
+- Explore (browse registered data blocks and variables)
+- GetMultiVariables / SetMultiVariables (read/write by address)
+- Internal PLC memory model with thread-safe access
+
+This server does NOT implement TLS or the proprietary authentication
+layers (V2/V3 crypto). It emulates a V1 PLC for testing purposes,
+which is sufficient for validating protocol framing, data encoding,
+and client logic.
+
+Usage::
+
+    server = S7CommPlusServer()
+    server.register_db(1, {"temperature": ("Real", 0), "pressure": ("Real", 4)})
+    server.start(port=11020)
+
+    # ... run tests against localhost:11020 ...
+
+    server.stop()
+"""
+
+import logging
+import socket
+import struct
+import threading
+from enum import IntEnum
+from typing import Any, Callable, Optional
+
+from .protocol import (
+    DataType,
+    ElementID,
+    FunctionCode,
+    Opcode,
+    ProtocolVersion,
+    SoftDataType,
+)
+from .vlq import encode_uint32_vlq, decode_uint32_vlq
+from .codec import encode_header, decode_header, encode_typed_value
+
+logger = logging.getLogger(__name__)
+
+
+class CPUState(IntEnum):
+    """Emulated CPU operational state."""
+
+    UNKNOWN = 0
+    STOP = 1
+    RUN = 2
+
+
+# Mapping from SoftDataType to wire DataType and byte size
+_SOFT_TO_WIRE: dict[int, tuple[int, int]] = {
+    SoftDataType.BOOL: (DataType.BOOL, 1),
+    SoftDataType.BYTE: (DataType.BYTE, 1),
+    SoftDataType.CHAR: (DataType.BYTE, 1),
+    SoftDataType.WORD: (DataType.WORD, 2),
+    SoftDataType.INT: (DataType.INT, 2),
+    SoftDataType.DWORD: (DataType.DWORD, 4),
+    SoftDataType.DINT: (DataType.DINT, 4),
+    SoftDataType.REAL: (DataType.REAL, 4),
+    SoftDataType.LREAL: (DataType.LREAL, 8),
+    SoftDataType.USINT: (DataType.USINT, 1),
+    SoftDataType.UINT: (DataType.UINT, 2),
+    SoftDataType.UDINT: (DataType.UDINT, 4),
+    SoftDataType.SINT: (DataType.SINT, 1),
+    SoftDataType.ULINT: (DataType.ULINT, 8),
+    SoftDataType.LINT: (DataType.LINT, 8),
+    SoftDataType.LWORD: (DataType.LWORD, 8),
+    SoftDataType.STRING: (DataType.S7STRING, 256),
+    SoftDataType.WSTRING: (DataType.WSTRING, 512),
+}
+
+# Map string type names to SoftDataType values
+_TYPE_NAME_MAP: dict[str, int] = {
+    "Bool": SoftDataType.BOOL,
+    "Byte": SoftDataType.BYTE,
+    "Char": SoftDataType.CHAR,
+    "Word": SoftDataType.WORD,
+    "Int": SoftDataType.INT,
+    "DWord": SoftDataType.DWORD,
+    "DInt": SoftDataType.DINT,
+    "Real": SoftDataType.REAL,
+    "LReal": SoftDataType.LREAL,
+    "USInt": SoftDataType.USINT,
+    "UInt": SoftDataType.UINT,
+    "UDInt": SoftDataType.UDINT,
+    "SInt": SoftDataType.SINT,
+    "ULInt": SoftDataType.ULINT,
+    "LInt": SoftDataType.LINT,
+    "LWord": SoftDataType.LWORD,
+    "String": SoftDataType.STRING,
+    "WString": SoftDataType.WSTRING,
+}
+
+
+class DBVariable:
+    """A variable in a data block."""
+
+    def __init__(self, name: str, soft_datatype: int, byte_offset: int):
+        self.name = name
+        self.soft_datatype = soft_datatype
+        self.byte_offset = byte_offset
+
+        wire_info = _SOFT_TO_WIRE.get(soft_datatype, (DataType.BYTE, 1))
+        self.wire_datatype = wire_info[0]
+        self.byte_size = wire_info[1]
+
+    def __repr__(self) -> str:
+        return f"DBVariable({self.name!r}, type={self.soft_datatype}, offset={self.byte_offset})"
+
+
+class DataBlock:
+    """An emulated PLC data block with named variables."""
+
+    def __init__(self, number: int, size: int = 1024):
+        self.number = number
+        self.data = bytearray(size)
+        self.variables: dict[str, DBVariable] = {}
+        self.lock = threading.Lock()
+        # Assign a unique object ID for the S7CommPlus object tree
+        self.object_id = 0x00010000 | (number & 0xFFFF)
+
+    def add_variable(self, name: str, type_name: str, byte_offset: int) -> None:
+        """Register a named variable in this data block.
+
+        Args:
+            name: Variable name (e.g. "temperature")
+            type_name: PLC type name (e.g. "Real", "Int", "Bool")
+            byte_offset: Byte offset within the data block
+        """
+        soft_type = _TYPE_NAME_MAP.get(type_name)
+        if soft_type is None:
+            raise ValueError(f"Unknown type name: {type_name!r}")
+        self.variables[name] = DBVariable(name, soft_type, byte_offset)
+
+    def read(self, offset: int, size: int) -> bytes:
+        """Read bytes from the data block."""
+        with self.lock:
+            end = min(offset + size, len(self.data))
+            result = bytes(self.data[offset:end])
+            # Pad with zeros if reading past end
+            if len(result) < size:
+                result += b"\x00" * (size - len(result))
+            return result
+
+    def write(self, offset: int, data: bytes) -> None:
+        """Write bytes to the data block."""
+        with self.lock:
+            end = min(offset + len(data), len(self.data))
+            self.data[offset:end] = data[: end - offset]
+
+    def read_variable(self, name: str) -> tuple[int, bytes]:
+        """Read a named variable.
+
+        Returns:
+            Tuple of (wire_datatype, raw_bytes)
+        """
+        var = self.variables.get(name)
+        if var is None:
+            raise KeyError(f"Variable not found: {name!r}")
+        raw = self.read(var.byte_offset, var.byte_size)
+        return var.wire_datatype, raw
+
+    def write_variable(self, name: str, data: bytes) -> None:
+        """Write a named variable."""
+        var = self.variables.get(name)
+        if var is None:
+            raise KeyError(f"Variable not found: {name!r}")
+        self.write(var.byte_offset, data)
+
+
+class S7CommPlusServer:
+    """S7CommPlus PLC emulator for testing.
+
+    Emulates an S7-1200/1500 PLC with:
+    - Internal data block storage with named variables
+    - S7CommPlus protocol handling (V1 level)
+    - Multi-client support (threaded)
+    - CPU state management
+    """
+
+    def __init__(self) -> None:
+        self._data_blocks: dict[int, DataBlock] = {}
+        self._cpu_state = CPUState.RUN
+        self._protocol_version = ProtocolVersion.V1
+        self._next_session_id = 1
+
+        self._server_socket: Optional[socket.socket] = None
+        self._server_thread: Optional[threading.Thread] = None
+        self._client_threads: list[threading.Thread] = []
+        self._running = False
+        self._lock = threading.Lock()
+        self._event_callback: Optional[Callable] = None
+
+    @property
+    def cpu_state(self) -> CPUState:
+        return self._cpu_state
+
+    @cpu_state.setter
+    def cpu_state(self, state: CPUState) -> None:
+        self._cpu_state = state
+
+    def register_db(
+        self, db_number: int, variables: dict[str, tuple[str, int]], size: int = 1024
+    ) -> DataBlock:
+        """Register a data block with named variables.
+
+        Args:
+            db_number: Data block number (e.g. 1 for DB1)
+            variables: Dict mapping variable name to (type_name, byte_offset)
+                       e.g. {"temperature": ("Real", 0), "count": ("Int", 4)}
+            size: Data block size in bytes
+
+        Returns:
+            The created DataBlock
+
+        Example::
+
+            server.register_db(1, {
+                "temperature": ("Real", 0),
+                "pressure": ("Real", 4),
+                "running": ("Bool", 8),
+                "count": ("DInt", 10),
+            })
+        """
+        db = DataBlock(db_number, size)
+        for name, (type_name, offset) in variables.items():
+            db.add_variable(name, type_name, offset)
+        self._data_blocks[db_number] = db
+        return db
+
+    def register_raw_db(self, db_number: int, data: bytearray) -> DataBlock:
+        """Register a data block with raw data (no named variables).
+
+        Args:
+            db_number: Data block number
+            data: Initial data block content
+
+        Returns:
+            The created DataBlock
+        """
+        db = DataBlock(db_number, len(data))
+        db.data = data
+        self._data_blocks[db_number] = db
+        return db
+
+    def get_db(self, db_number: int) -> Optional[DataBlock]:
+        """Get a registered data block."""
+        return self._data_blocks.get(db_number)
+
+    def start(self, host: str = "0.0.0.0", port: int = 11020) -> None:
+        """Start the server.
+
+        Args:
+            host: Bind address
+            port: TCP port to listen on
+        """
+        if self._running:
+            raise RuntimeError("Server is already running")
+
+        self._server_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server_socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server_socket.settimeout(1.0)
+        self._server_socket.bind((host, port))
+        self._server_socket.listen(5)
+
+        self._running = True
+        self._server_thread = threading.Thread(
+            target=self._server_loop, daemon=True, name="s7commplus-server"
+        )
+        self._server_thread.start()
+        logger.info(f"S7CommPlus server started on {host}:{port}")
+
+    def stop(self) -> None:
+        """Stop the server."""
+        self._running = False
+
+        if self._server_socket:
+            try:
+                self._server_socket.close()
+            except Exception:
+                pass
+            self._server_socket = None
+
+        if self._server_thread:
+            self._server_thread.join(timeout=5.0)
+            self._server_thread = None
+
+        for t in self._client_threads:
+            t.join(timeout=2.0)
+        self._client_threads.clear()
+
+        logger.info("S7CommPlus server stopped")
+
+    def _server_loop(self) -> None:
+        """Main server accept loop."""
+        while self._running:
+            try:
+                if self._server_socket is None:
+                    break
+                client_sock, address = self._server_socket.accept()
+                logger.info(f"Client connected from {address}")
+                t = threading.Thread(
+                    target=self._handle_client,
+                    args=(client_sock, address),
+                    daemon=True,
+                    name=f"s7commplus-client-{address}",
+                )
+                self._client_threads.append(t)
+                t.start()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+    def _handle_client(self, client_sock: socket.socket, address: tuple) -> None:
+        """Handle a single client connection."""
+        try:
+            client_sock.settimeout(5.0)
+
+            # Step 1: COTP handshake
+            if not self._handle_cotp_connect(client_sock):
+                return
+
+            # Step 2: S7CommPlus session
+            session_id = 0
+
+            while self._running:
+                try:
+                    # Receive TPKT + COTP DT + S7CommPlus data
+                    data = self._recv_s7commplus_frame(client_sock)
+                    if data is None:
+                        break
+
+                    # Process the S7CommPlus request
+                    response = self._process_request(data, session_id)
+
+                    if response is not None:
+                        # Check if session ID was assigned
+                        if session_id == 0 and len(response) >= 14:
+                            # Extract session ID from response for tracking
+                            session_id = struct.unpack_from(">I", response, 9)[0]
+
+                        self._send_s7commplus_frame(client_sock, response)
+
+                except socket.timeout:
+                    continue
+                except (ConnectionError, OSError):
+                    break
+
+        except Exception as e:
+            logger.debug(f"Client handler error: {e}")
+        finally:
+            try:
+                client_sock.close()
+            except Exception:
+                pass
+            logger.info(f"Client disconnected: {address}")
+
+    def _handle_cotp_connect(self, sock: socket.socket) -> bool:
+        """Handle COTP Connection Request / Confirm."""
+        try:
+            # Receive TPKT header
+            tpkt_header = self._recv_exact(sock, 4)
+            version, _, length = struct.unpack(">BBH", tpkt_header)
+            if version != 3:
+                return False
+
+            # Receive COTP CR
+            payload = self._recv_exact(sock, length - 4)
+            if len(payload) < 7:
+                return False
+
+            _pdu_len, pdu_type = payload[0], payload[1]
+            if pdu_type != 0xE0:  # COTP CR
+                return False
+
+            # Parse source ref from CR
+            src_ref = struct.unpack_from(">H", payload, 4)[0]
+
+            # Build COTP CC response
+            cc_pdu = struct.pack(
+                ">BBHHB",
+                6,  # PDU length
+                0xD0,  # COTP CC
+                src_ref,  # Destination ref (client's src ref)
+                0x0001,  # Source ref (our ref)
+                0x00,  # Class 0
+            )
+
+            # Add PDU size parameter
+            pdu_size_param = struct.pack(">BBB", 0xC0, 1, 0x0A)  # 1024 bytes
+            cc_pdu = struct.pack(">B", 6 + len(pdu_size_param)) + cc_pdu[1:] + pdu_size_param
+
+            # Send TPKT + CC
+            tpkt = struct.pack(">BBH", 3, 0, 4 + len(cc_pdu)) + cc_pdu
+            sock.sendall(tpkt)
+
+            logger.debug("COTP connection established")
+            return True
+
+        except Exception as e:
+            logger.debug(f"COTP handshake failed: {e}")
+            return False
+
+    def _recv_s7commplus_frame(self, sock: socket.socket) -> Optional[bytes]:
+        """Receive a TPKT/COTP/S7CommPlus frame, return the S7CommPlus payload."""
+        try:
+            # TPKT header
+            tpkt_header = self._recv_exact(sock, 4)
+            version, _, length = struct.unpack(">BBH", tpkt_header)
+            if version != 3 or length <= 4:
+                return None
+
+            # Remaining data
+            payload = self._recv_exact(sock, length - 4)
+
+            # Skip COTP DT header (3 bytes: length, type 0xF0, EOT)
+            if len(payload) < 3 or payload[1] != 0xF0:
+                return None
+
+            return payload[3:]  # S7CommPlus data
+
+        except Exception:
+            return None
+
+    def _send_s7commplus_frame(self, sock: socket.socket, data: bytes) -> None:
+        """Send an S7CommPlus frame wrapped in TPKT/COTP."""
+        # S7CommPlus header (4 bytes) + data
+        s7plus_frame = encode_header(self._protocol_version, len(data)) + data
+
+        # COTP DT header
+        cotp_dt = struct.pack(">BBB", 2, 0xF0, 0x80) + s7plus_frame
+
+        # TPKT
+        tpkt = struct.pack(">BBH", 3, 0, 4 + len(cotp_dt)) + cotp_dt
+        sock.sendall(tpkt)
+
+    def _process_request(self, data: bytes, session_id: int) -> Optional[bytes]:
+        """Process an S7CommPlus request and return a response."""
+        if len(data) < 4:
+            return None
+
+        # Parse S7CommPlus frame header
+        try:
+            version, data_length, consumed = decode_header(data)
+        except ValueError:
+            return None
+
+        payload = data[consumed:]
+        if len(payload) < 14:
+            return None
+
+        # Parse request header
+        opcode = payload[0]
+        if opcode != Opcode.REQUEST:
+            return None
+
+        function_code = struct.unpack_from(">H", payload, 3)[0]
+        seq_num = struct.unpack_from(">H", payload, 7)[0]
+        req_session_id = struct.unpack_from(">I", payload, 9)[0]
+        request_data = payload[14:]
+
+        if function_code == FunctionCode.CREATE_OBJECT:
+            return self._handle_create_object(seq_num, request_data)
+        elif function_code == FunctionCode.DELETE_OBJECT:
+            return self._handle_delete_object(seq_num, req_session_id)
+        elif function_code == FunctionCode.EXPLORE:
+            return self._handle_explore(seq_num, req_session_id, request_data)
+        elif function_code == FunctionCode.GET_MULTI_VARIABLES:
+            return self._handle_get_multi_variables(seq_num, req_session_id, request_data)
+        elif function_code == FunctionCode.SET_MULTI_VARIABLES:
+            return self._handle_set_multi_variables(seq_num, req_session_id, request_data)
+        else:
+            return self._build_error_response(seq_num, req_session_id, function_code)
+
+    def _handle_create_object(self, seq_num: int, request_data: bytes) -> bytes:
+        """Handle CreateObject -- establish a session."""
+        with self._lock:
+            session_id = self._next_session_id
+            self._next_session_id += 1
+
+        # Build CreateObject response
+        response = bytearray()
+
+        # Response header
+        response += struct.pack(
+            ">BHHHHIB",
+            Opcode.RESPONSE,
+            0x0000,  # Reserved
+            FunctionCode.CREATE_OBJECT,
+            0x0000,  # Reserved
+            seq_num,
+            session_id,
+            0x00,  # Transport flags
+        )
+
+        # Return code: success
+        response += encode_uint32_vlq(0)
+
+        # Object with session info
+        response += bytes([ElementID.START_OF_OBJECT])
+        response += struct.pack(">I", 0x00000001)  # Relation ID
+        response += encode_uint32_vlq(0x00000000)  # Class ID
+        response += encode_uint32_vlq(0x00000000)  # Class flags
+        response += encode_uint32_vlq(0x00000000)  # Attribute ID
+
+        # Session ID attribute
+        response += bytes([ElementID.ATTRIBUTE])
+        response += encode_uint32_vlq(0x0131)  # ServerSession ID attribute
+        response += encode_typed_value(DataType.UDINT, session_id)
+
+        # Protocol version attribute
+        response += bytes([ElementID.ATTRIBUTE])
+        response += encode_uint32_vlq(0x0132)  # Protocol version attribute
+        response += encode_typed_value(DataType.USINT, self._protocol_version)
+
+        response += bytes([ElementID.TERMINATING_OBJECT])
+
+        # Trailing zeros
+        response += struct.pack(">I", 0)
+
+        return bytes(response)
+
+    def _handle_delete_object(self, seq_num: int, session_id: int) -> bytes:
+        """Handle DeleteObject -- close a session."""
+        response = bytearray()
+        response += struct.pack(
+            ">BHHHHIB",
+            Opcode.RESPONSE,
+            0x0000,
+            FunctionCode.DELETE_OBJECT,
+            0x0000,
+            seq_num,
+            session_id,
+            0x00,
+        )
+        response += encode_uint32_vlq(0)  # Return code: success
+        response += struct.pack(">I", 0)
+        return bytes(response)
+
+    def _handle_explore(
+        self, seq_num: int, session_id: int, request_data: bytes
+    ) -> bytes:
+        """Handle Explore -- return the object tree (registered data blocks)."""
+        response = bytearray()
+        response += struct.pack(
+            ">BHHHHIB",
+            Opcode.RESPONSE,
+            0x0000,
+            FunctionCode.EXPLORE,
+            0x0000,
+            seq_num,
+            session_id,
+            0x00,
+        )
+        response += encode_uint32_vlq(0)  # Return code: success
+
+        # Return list of data blocks as objects
+        for db_num, db in sorted(self._data_blocks.items()):
+            response += bytes([ElementID.START_OF_OBJECT])
+            response += struct.pack(">I", db.object_id)  # Relation ID
+            response += encode_uint32_vlq(0x00000100)  # Class: DataBlock
+            response += encode_uint32_vlq(0x00000000)  # Class flags
+            response += encode_uint32_vlq(0x00000000)  # Attribute ID
+
+            # DB number attribute
+            response += bytes([ElementID.ATTRIBUTE])
+            response += encode_uint32_vlq(0x0001)  # DB number attribute ID
+            response += encode_typed_value(DataType.UINT, db_num)
+
+            # DB size attribute
+            response += bytes([ElementID.ATTRIBUTE])
+            response += encode_uint32_vlq(0x0002)  # DB size attribute ID
+            response += encode_typed_value(DataType.UDINT, len(db.data))
+
+            # Variable list
+            if db.variables:
+                response += bytes([ElementID.VARNAME_LIST])
+                response += encode_uint32_vlq(len(db.variables))
+                for var_name, var in db.variables.items():
+                    name_bytes = var_name.encode("utf-8")
+                    response += encode_uint32_vlq(len(name_bytes))
+                    response += name_bytes
+                    response += encode_uint32_vlq(var.soft_datatype)
+                    response += encode_uint32_vlq(var.byte_offset)
+
+            response += bytes([ElementID.TERMINATING_OBJECT])
+
+        # Final terminator
+        response += struct.pack(">I", 0)
+        return bytes(response)
+
+    def _handle_get_multi_variables(
+        self, seq_num: int, session_id: int, request_data: bytes
+    ) -> bytes:
+        """Handle GetMultiVariables -- read variables from data blocks."""
+        response = bytearray()
+        response += struct.pack(
+            ">BHHHHIB",
+            Opcode.RESPONSE,
+            0x0000,
+            FunctionCode.GET_MULTI_VARIABLES,
+            0x0000,
+            seq_num,
+            session_id,
+            0x00,
+        )
+        response += encode_uint32_vlq(0)  # Return code: success
+
+        # Parse request: expect object_id + variable addresses
+        offset = 0
+        items: list[tuple[int, int, int]] = []  # (db_num, byte_offset, byte_size)
+
+        # Simple request format: VLQ item count, then for each item:
+        #   VLQ object_id, VLQ offset, VLQ size
+        if len(request_data) > 0:
+            count, consumed = decode_uint32_vlq(request_data, offset)
+            offset += consumed
+
+            for _ in range(count):
+                if offset >= len(request_data):
+                    break
+                obj_id, consumed = decode_uint32_vlq(request_data, offset)
+                offset += consumed
+                byte_offset, consumed = decode_uint32_vlq(request_data, offset)
+                offset += consumed
+                byte_size, consumed = decode_uint32_vlq(request_data, offset)
+                offset += consumed
+
+                db_num = obj_id & 0xFFFF
+                items.append((db_num, byte_offset, byte_size))
+
+        # Read data for each item
+        response += encode_uint32_vlq(len(items))
+        for db_num, byte_offset, byte_size in items:
+            db = self._data_blocks.get(db_num)
+            if db is not None:
+                data = db.read(byte_offset, byte_size)
+                response += encode_uint32_vlq(0)  # Success
+                response += encode_uint32_vlq(len(data))
+                response += data
+            else:
+                response += encode_uint32_vlq(1)  # Error: not found
+                response += encode_uint32_vlq(0)
+
+        response += struct.pack(">I", 0)
+        return bytes(response)
+
+    def _handle_set_multi_variables(
+        self, seq_num: int, session_id: int, request_data: bytes
+    ) -> bytes:
+        """Handle SetMultiVariables -- write variables to data blocks."""
+        response = bytearray()
+        response += struct.pack(
+            ">BHHHHIB",
+            Opcode.RESPONSE,
+            0x0000,
+            FunctionCode.SET_MULTI_VARIABLES,
+            0x0000,
+            seq_num,
+            session_id,
+            0x00,
+        )
+
+        # Parse request: VLQ item count, then for each item:
+        #   VLQ object_id, VLQ offset, VLQ data_length, data bytes
+        offset = 0
+        results: list[int] = []
+
+        if len(request_data) > 0:
+            count, consumed = decode_uint32_vlq(request_data, offset)
+            offset += consumed
+
+            for _ in range(count):
+                if offset >= len(request_data):
+                    break
+                obj_id, consumed = decode_uint32_vlq(request_data, offset)
+                offset += consumed
+                byte_offset, consumed = decode_uint32_vlq(request_data, offset)
+                offset += consumed
+                data_len, consumed = decode_uint32_vlq(request_data, offset)
+                offset += consumed
+
+                data = request_data[offset : offset + data_len]
+                offset += data_len
+
+                db_num = obj_id & 0xFFFF
+                db = self._data_blocks.get(db_num)
+                if db is not None:
+                    db.write(byte_offset, data)
+                    results.append(0)  # Success
+                else:
+                    results.append(1)  # Error: not found
+
+        response += encode_uint32_vlq(0)  # Return code: success
+        response += encode_uint32_vlq(len(results))
+        for r in results:
+            response += encode_uint32_vlq(r)
+
+        response += struct.pack(">I", 0)
+        return bytes(response)
+
+    def _build_error_response(
+        self, seq_num: int, session_id: int, function_code: int
+    ) -> bytes:
+        """Build a generic error response for unsupported function codes."""
+        response = bytearray()
+        response += struct.pack(
+            ">BHHHHIB",
+            Opcode.RESPONSE,
+            0x0000,
+            FunctionCode.ERROR,
+            0x0000,
+            seq_num,
+            session_id,
+            0x00,
+        )
+        response += encode_uint32_vlq(0x04B1)  # Error function code
+        response += struct.pack(">I", 0)
+        return bytes(response)
+
+    @staticmethod
+    def _recv_exact(sock: socket.socket, size: int) -> bytes:
+        """Receive exactly the specified number of bytes."""
+        data = bytearray()
+        while len(data) < size:
+            chunk = sock.recv(size - len(data))
+            if not chunk:
+                raise ConnectionError("Connection closed")
+            data.extend(chunk)
+        return bytes(data)
+
+    def __enter__(self) -> "S7CommPlusServer":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.stop()

--- a/snap7/s7commplus/server.py
+++ b/snap7/s7commplus/server.py
@@ -258,7 +258,7 @@ class S7CommPlusServer:
         """Get a registered data block."""
         return self._data_blocks.get(db_number)
 
-    def start(self, host: str = "0.0.0.0", port: int = 11020) -> None:
+    def start(self, host: str = "127.0.0.1", port: int = 11020) -> None:
         """Start the server.
 
         Args:

--- a/snap7/s7commplus/server.py
+++ b/snap7/s7commplus/server.py
@@ -196,7 +196,7 @@ class S7CommPlusServer:
         self._client_threads: list[threading.Thread] = []
         self._running = False
         self._lock = threading.Lock()
-        self._event_callback: Optional[Callable] = None
+        self._event_callback: Optional[Callable[..., None]] = None
 
     @property
     def cpu_state(self) -> CPUState:
@@ -206,9 +206,7 @@ class S7CommPlusServer:
     def cpu_state(self, state: CPUState) -> None:
         self._cpu_state = state
 
-    def register_db(
-        self, db_number: int, variables: dict[str, tuple[str, int]], size: int = 1024
-    ) -> DataBlock:
+    def register_db(self, db_number: int, variables: dict[str, tuple[str, int]], size: int = 1024) -> DataBlock:
         """Register a data block with named variables.
 
         Args:
@@ -271,9 +269,7 @@ class S7CommPlusServer:
         self._server_socket.listen(5)
 
         self._running = True
-        self._server_thread = threading.Thread(
-            target=self._server_loop, daemon=True, name="s7commplus-server"
-        )
+        self._server_thread = threading.Thread(target=self._server_loop, daemon=True, name="s7commplus-server")
         self._server_thread.start()
         logger.info(f"S7CommPlus server started on {host}:{port}")
 
@@ -319,7 +315,7 @@ class S7CommPlusServer:
             except OSError:
                 break
 
-    def _handle_client(self, client_sock: socket.socket, address: tuple) -> None:
+    def _handle_client(self, client_sock: socket.socket, address: tuple[str, int]) -> None:
         """Handle a single client connection."""
         try:
             client_sock.settimeout(5.0)
@@ -545,9 +541,7 @@ class S7CommPlusServer:
         response += struct.pack(">I", 0)
         return bytes(response)
 
-    def _handle_explore(
-        self, seq_num: int, session_id: int, request_data: bytes
-    ) -> bytes:
+    def _handle_explore(self, seq_num: int, session_id: int, request_data: bytes) -> bytes:
         """Handle Explore -- return the object tree (registered data blocks)."""
         response = bytearray()
         response += struct.pack(
@@ -597,9 +591,7 @@ class S7CommPlusServer:
         response += struct.pack(">I", 0)
         return bytes(response)
 
-    def _handle_get_multi_variables(
-        self, seq_num: int, session_id: int, request_data: bytes
-    ) -> bytes:
+    def _handle_get_multi_variables(self, seq_num: int, session_id: int, request_data: bytes) -> bytes:
         """Handle GetMultiVariables -- read variables from data blocks."""
         response = bytearray()
         response += struct.pack(
@@ -653,9 +645,7 @@ class S7CommPlusServer:
         response += struct.pack(">I", 0)
         return bytes(response)
 
-    def _handle_set_multi_variables(
-        self, seq_num: int, session_id: int, request_data: bytes
-    ) -> bytes:
+    def _handle_set_multi_variables(self, seq_num: int, session_id: int, request_data: bytes) -> bytes:
         """Handle SetMultiVariables -- write variables to data blocks."""
         response = bytearray()
         response += struct.pack(
@@ -707,9 +697,7 @@ class S7CommPlusServer:
         response += struct.pack(">I", 0)
         return bytes(response)
 
-    def _build_error_response(
-        self, seq_num: int, session_id: int, function_code: int
-    ) -> bytes:
+    def _build_error_response(self, seq_num: int, session_id: int, function_code: int) -> bytes:
         """Build a generic error response for unsupported function codes."""
         response = bytearray()
         response += struct.pack(

--- a/snap7/s7commplus/vlq.py
+++ b/snap7/s7commplus/vlq.py
@@ -1,0 +1,337 @@
+"""
+Variable-Length Quantity (VLQ) encoding for S7CommPlus.
+
+S7CommPlus uses VLQ encoding for integer values in the protocol framing.
+This is similar to MIDI VLQ or protobuf varints, with some S7-specific
+variations for signed values and 64-bit special handling.
+
+Encoding scheme:
+    - Each byte uses 7 data bits + 1 continuation bit (MSB)
+    - continuation bit = 1 means more bytes follow
+    - continuation bit = 0 means this is the last byte
+    - Big-endian byte order (most significant group first)
+    - Signed values use bit 6 of the first byte as a sign flag
+
+64-bit special case:
+    - 8 bytes of 7-bit groups = 56 bits, which is less than 64
+    - The 9th byte uses all 8 bits (no continuation flag)
+    - This avoids needing a 10th byte
+
+Reference: thomas-v2/S7CommPlusDriver/Core/S7p.cs
+"""
+
+def encode_uint32_vlq(value: int) -> bytes:
+    """Encode an unsigned 32-bit integer as VLQ.
+
+    Args:
+        value: Unsigned integer (0 to 2^32-1)
+
+    Returns:
+        VLQ-encoded bytes (1-5 bytes)
+    """
+    if value < 0 or value > 0xFFFFFFFF:
+        raise ValueError(f"Value out of range for uint32 VLQ: {value}")
+
+    result = bytearray()
+
+    # Find the highest non-zero 7-bit group
+    num_groups = 1
+    for i in range(4, 0, -1):
+        if value & (0x7F << (i * 7)):
+            num_groups = i + 1
+            break
+
+    # Encode each group, MSB first
+    for i in range(num_groups - 1, -1, -1):
+        group = (value >> (i * 7)) & 0x7F
+        if i > 0:
+            group |= 0x80  # Set continuation bit
+        result.append(group)
+
+    return bytes(result)
+
+
+def decode_uint32_vlq(data: bytes, offset: int = 0) -> tuple[int, int]:
+    """Decode a VLQ-encoded unsigned 32-bit integer.
+
+    Args:
+        data: Buffer containing VLQ data
+        offset: Starting position in buffer
+
+    Returns:
+        Tuple of (decoded_value, bytes_consumed)
+    """
+    value = 0
+    consumed = 0
+
+    for _ in range(5):  # Max 5 bytes for 32-bit
+        if offset + consumed >= len(data):
+            raise ValueError("Unexpected end of VLQ data")
+
+        octet = data[offset + consumed]
+        consumed += 1
+
+        value = (value << 7) | (octet & 0x7F)
+
+        if not (octet & 0x80):  # No continuation bit
+            break
+
+    return value, consumed
+
+
+def encode_int32_vlq(value: int) -> bytes:
+    """Encode a signed 32-bit integer as VLQ.
+
+    Signed VLQ uses bit 6 of the first byte as a sign indicator.
+    Negative values are encoded in a compact two's-complement-like form.
+
+    Args:
+        value: Signed integer (-2^31 to 2^31-1)
+
+    Returns:
+        VLQ-encoded bytes (1-5 bytes)
+    """
+    if value < -0x80000000 or value > 0x7FFFFFFF:
+        raise ValueError(f"Value out of range for int32 VLQ: {value}")
+
+    result = bytearray()
+
+    if value == -0x80000000:
+        abs_v = 0x80000000
+    else:
+        abs_v = abs(value)
+
+    b = [0] * 5
+    b[0] = value & 0x7F
+    length = 1
+
+    for i in range(1, 5):
+        if abs_v >= 0x40:
+            length += 1
+            abs_v >>= 7
+            value >>= 7
+            b[i] = ((value & 0x7F) + 0x80) & 0xFF
+        else:
+            break
+
+    # Emit in reverse order (big-endian)
+    for i in range(length - 1, -1, -1):
+        result.append(b[i])
+
+    return bytes(result)
+
+
+def decode_int32_vlq(data: bytes, offset: int = 0) -> tuple[int, int]:
+    """Decode a VLQ-encoded signed 32-bit integer.
+
+    Args:
+        data: Buffer containing VLQ data
+        offset: Starting position in buffer
+
+    Returns:
+        Tuple of (decoded_value, bytes_consumed)
+    """
+    value = 0
+    consumed = 0
+
+    for counter in range(1, 6):  # Max 5 bytes for 32-bit
+        if offset + consumed >= len(data):
+            raise ValueError("Unexpected end of VLQ data")
+
+        octet = data[offset + consumed]
+        consumed += 1
+
+        if counter == 1 and (octet & 0x40):  # Check sign bit
+            octet &= 0xBF
+            value = -64  # Pre-load with one's complement
+        else:
+            value <<= 7
+
+        value += octet & 0x7F
+
+        if not (octet & 0x80):  # No continuation bit
+            break
+
+    return value, consumed
+
+
+def encode_uint64_vlq(value: int) -> bytes:
+    """Encode an unsigned 64-bit integer as VLQ.
+
+    64-bit VLQ has special handling: since 8 groups of 7 bits = 56 bits < 64,
+    the 9th byte uses all 8 bits (no continuation flag).
+
+    Args:
+        value: Unsigned integer (0 to 2^64-1)
+
+    Returns:
+        VLQ-encoded bytes (1-9 bytes)
+    """
+    if value < 0 or value > 0xFFFFFFFFFFFFFFFF:
+        raise ValueError(f"Value out of range for uint64 VLQ: {value}")
+
+    special = value > 0x00FFFFFFFFFFFFFF
+
+    b = [0] * 9
+    if special:
+        b[0] = value & 0xFF
+    else:
+        b[0] = value & 0x7F
+
+    length = 1
+    for i in range(1, 9):
+        if value >= 0x80:
+            length += 1
+            if i == 1 and special:
+                value >>= 8
+            else:
+                value >>= 7
+            b[i] = ((value & 0x7F) + 0x80) & 0xFF
+        else:
+            break
+
+    if special and length == 8:
+        length += 1
+        b[8] = 0x80
+
+    # Emit in reverse order
+    result = bytearray()
+    for i in range(length - 1, -1, -1):
+        result.append(b[i])
+
+    return bytes(result)
+
+
+def decode_uint64_vlq(data: bytes, offset: int = 0) -> tuple[int, int]:
+    """Decode a VLQ-encoded unsigned 64-bit integer.
+
+    Args:
+        data: Buffer containing VLQ data
+        offset: Starting position in buffer
+
+    Returns:
+        Tuple of (decoded_value, bytes_consumed)
+    """
+    value = 0
+    consumed = 0
+    cont = 0
+
+    for counter in range(1, 9):  # Max 8 groups of 7 bits
+        if offset + consumed >= len(data):
+            raise ValueError("Unexpected end of VLQ data")
+
+        octet = data[offset + consumed]
+        consumed += 1
+
+        value = (value << 7) | (octet & 0x7F)
+        cont = octet & 0x80
+
+        if not cont:
+            break
+
+    if cont:
+        # 9th byte: all 8 bits are data (special 64-bit handling)
+        if offset + consumed >= len(data):
+            raise ValueError("Unexpected end of VLQ data")
+
+        octet = data[offset + consumed]
+        consumed += 1
+        value = (value << 8) | octet
+
+    return value, consumed
+
+
+def encode_int64_vlq(value: int) -> bytes:
+    """Encode a signed 64-bit integer as VLQ.
+
+    Args:
+        value: Signed integer (-2^63 to 2^63-1)
+
+    Returns:
+        VLQ-encoded bytes (1-9 bytes)
+    """
+    if value < -0x8000000000000000 or value > 0x7FFFFFFFFFFFFFFF:
+        raise ValueError(f"Value out of range for int64 VLQ: {value}")
+
+    if value == -0x8000000000000000:
+        abs_v = 0x8000000000000000
+    else:
+        abs_v = abs(value)
+
+    special = abs_v > 0x007FFFFFFFFFFFFF
+
+    b = [0] * 9
+    if special:
+        b[0] = value & 0xFF
+    else:
+        b[0] = value & 0x7F
+
+    length = 1
+    for i in range(1, 9):
+        if abs_v >= 0x40:
+            length += 1
+            if i == 1 and special:
+                abs_v >>= 8
+                value >>= 8
+            else:
+                abs_v >>= 7
+                value >>= 7
+            b[i] = ((value & 0x7F) + 0x80) & 0xFF
+        else:
+            break
+
+    if special and length == 8:
+        length += 1
+        b[8] = 0x80 if value >= 0 else 0xFF
+
+    # Emit in reverse order
+    result = bytearray()
+    for i in range(length - 1, -1, -1):
+        result.append(b[i])
+
+    return bytes(result)
+
+
+def decode_int64_vlq(data: bytes, offset: int = 0) -> tuple[int, int]:
+    """Decode a VLQ-encoded signed 64-bit integer.
+
+    Args:
+        data: Buffer containing VLQ data
+        offset: Starting position in buffer
+
+    Returns:
+        Tuple of (decoded_value, bytes_consumed)
+    """
+    value = 0
+    consumed = 0
+    cont = 0
+
+    for counter in range(1, 9):  # Max 8 groups of 7 bits
+        if offset + consumed >= len(data):
+            raise ValueError("Unexpected end of VLQ data")
+
+        octet = data[offset + consumed]
+        consumed += 1
+
+        if counter == 1 and (octet & 0x40):  # Check sign bit
+            octet &= 0xBF
+            value = -64  # Pre-load with one's complement
+        else:
+            value <<= 7
+
+        cont = octet & 0x80
+        value += octet & 0x7F
+
+        if not cont:
+            break
+
+    if cont:
+        # 9th byte: all 8 bits are data
+        if offset + consumed >= len(data):
+            raise ValueError("Unexpected end of VLQ data")
+
+        octet = data[offset + consumed]
+        consumed += 1
+        value = (value << 8) | octet
+
+    return value, consumed

--- a/snap7/s7commplus/vlq.py
+++ b/snap7/s7commplus/vlq.py
@@ -20,6 +20,7 @@ Encoding scheme:
 Reference: thomas-v2/S7CommPlusDriver/Core/S7p.cs
 """
 
+
 def encode_uint32_vlq(value: int) -> bytes:
     """Encode an unsigned 32-bit integer as VLQ.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,8 +65,13 @@ def pytest_configure(config: pytest.Config) -> None:
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
     """Propagate CLI options and skip e2e tests unless --e2e flag is provided."""
-    # Propagate CLI options to test_client_e2e module globals
-    for mod_name in ["tests.test_client_e2e", "test_client_e2e"]:
+    # Propagate CLI options to e2e test module globals
+    for mod_name in [
+        "tests.test_client_e2e",
+        "test_client_e2e",
+        "tests.test_s7commplus_e2e",
+        "test_s7commplus_e2e",
+    ]:
         e2e = sys.modules.get(mod_name)
         if e2e is not None:
             e2e.PLC_IP = str(config.getoption("--plc-ip"))
@@ -75,7 +80,6 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             e2e.PLC_PORT = int(config.getoption("--plc-port"))
             e2e.DB_READ_ONLY = int(config.getoption("--plc-db-read"))
             e2e.DB_READ_WRITE = int(config.getoption("--plc-db-write"))
-            break
 
     # Skip e2e tests if flag not provided
     if config.getoption("--e2e"):

--- a/tests/test_s7commplus_codec.py
+++ b/tests/test_s7commplus_codec.py
@@ -1,0 +1,173 @@
+"""Tests for S7CommPlus codec (header encoding, typed values)."""
+
+import struct
+import pytest
+
+from snap7.s7commplus.codec import (
+    encode_header,
+    decode_header,
+    encode_request_header,
+    decode_response_header,
+    encode_typed_value,
+    encode_uint16,
+    decode_uint16,
+    encode_uint32,
+    decode_uint32,
+    encode_float32,
+    decode_float32,
+    encode_float64,
+    decode_float64,
+    encode_wstring,
+    decode_wstring,
+)
+from snap7.s7commplus.protocol import PROTOCOL_ID, DataType, Opcode, FunctionCode
+
+
+class TestFrameHeader:
+    def test_encode_header(self) -> None:
+        header = encode_header(version=0x03, data_length=100)
+        assert len(header) == 4
+        assert header[0] == PROTOCOL_ID
+        assert header[1] == 0x03
+        assert struct.unpack(">H", header[2:4])[0] == 100
+
+    def test_decode_header(self) -> None:
+        header = encode_header(version=0x03, data_length=256)
+        version, length, consumed = decode_header(header)
+        assert version == 0x03
+        assert length == 256
+        assert consumed == 4
+
+    def test_decode_header_with_offset(self) -> None:
+        prefix = bytes([0x00, 0x00])
+        header = encode_header(version=0x01, data_length=42)
+        version, length, consumed = decode_header(prefix + header, offset=2)
+        assert version == 0x01
+        assert length == 42
+
+    def test_decode_header_wrong_protocol_id(self) -> None:
+        bad_header = bytes([0x32, 0x03, 0x00, 0x10])  # S7comm ID, not S7CommPlus
+        with pytest.raises(ValueError, match="Invalid protocol ID"):
+            decode_header(bad_header)
+
+    def test_decode_header_too_short(self) -> None:
+        with pytest.raises(ValueError, match="Not enough data"):
+            decode_header(bytes([0x72, 0x03]))
+
+
+class TestRequestHeader:
+    def test_encode_request_header(self) -> None:
+        header = encode_request_header(
+            function_code=FunctionCode.CREATE_OBJECT,
+            sequence_number=1,
+            session_id=0,
+            transport_flags=0x36,
+        )
+        assert len(header) == 14
+        assert header[0] == Opcode.REQUEST
+
+    def test_roundtrip_request_response_header(self) -> None:
+        header = encode_request_header(
+            function_code=FunctionCode.GET_MULTI_VARIABLES,
+            sequence_number=42,
+            session_id=0x12345678,
+        )
+        result = decode_response_header(header)
+        assert result["function_code"] == FunctionCode.GET_MULTI_VARIABLES
+        assert result["sequence_number"] == 42
+        assert result["session_id"] == 0x12345678
+        assert result["bytes_consumed"] == 14
+
+
+class TestFixedWidth:
+    def test_uint16_roundtrip(self) -> None:
+        for val in [0, 1, 0xFF, 0xFFFF]:
+            encoded = encode_uint16(val)
+            decoded, consumed = decode_uint16(encoded)
+            assert decoded == val
+            assert consumed == 2
+
+    def test_uint32_roundtrip(self) -> None:
+        for val in [0, 1, 0xFFFF, 0xFFFFFFFF]:
+            encoded = encode_uint32(val)
+            decoded, consumed = decode_uint32(encoded)
+            assert decoded == val
+            assert consumed == 4
+
+    def test_float32_roundtrip(self) -> None:
+        for val in [0.0, 1.0, -1.0, 3.14]:
+            encoded = encode_float32(val)
+            decoded, consumed = decode_float32(encoded)
+            assert abs(decoded - val) < 1e-6
+            assert consumed == 4
+
+    def test_float64_roundtrip(self) -> None:
+        for val in [0.0, 1.0, -1.0, 3.141592653589793]:
+            encoded = encode_float64(val)
+            decoded, consumed = decode_float64(encoded)
+            assert decoded == val
+            assert consumed == 8
+
+
+class TestWString:
+    def test_ascii(self) -> None:
+        encoded = encode_wstring("hello")
+        decoded, consumed = decode_wstring(encoded, 0, len(encoded))
+        assert decoded == "hello"
+
+    def test_unicode(self) -> None:
+        encoded = encode_wstring("Ölprüfung")
+        decoded, consumed = decode_wstring(encoded, 0, len(encoded))
+        assert decoded == "Ölprüfung"
+
+    def test_empty(self) -> None:
+        encoded = encode_wstring("")
+        assert encoded == b""
+        decoded, consumed = decode_wstring(encoded, 0, 0)
+        assert decoded == ""
+
+
+class TestTypedValue:
+    def test_null(self) -> None:
+        encoded = encode_typed_value(DataType.NULL, None)
+        assert encoded == bytes([DataType.NULL])
+
+    def test_bool_true(self) -> None:
+        encoded = encode_typed_value(DataType.BOOL, True)
+        assert encoded == bytes([DataType.BOOL, 0x01])
+
+    def test_bool_false(self) -> None:
+        encoded = encode_typed_value(DataType.BOOL, False)
+        assert encoded == bytes([DataType.BOOL, 0x00])
+
+    def test_usint(self) -> None:
+        encoded = encode_typed_value(DataType.USINT, 42)
+        assert encoded == bytes([DataType.USINT, 42])
+
+    def test_uint(self) -> None:
+        encoded = encode_typed_value(DataType.UINT, 0x1234)
+        assert encoded == bytes([DataType.UINT]) + struct.pack(">H", 0x1234)
+
+    def test_real(self) -> None:
+        encoded = encode_typed_value(DataType.REAL, 1.0)
+        assert encoded == bytes([DataType.REAL]) + struct.pack(">f", 1.0)
+
+    def test_lreal(self) -> None:
+        encoded = encode_typed_value(DataType.LREAL, 3.14)
+        assert encoded == bytes([DataType.LREAL]) + struct.pack(">d", 3.14)
+
+    def test_wstring(self) -> None:
+        encoded = encode_typed_value(DataType.WSTRING, "test")
+        assert encoded[0] == DataType.WSTRING
+        # Should contain VLQ length + UTF-8 data
+        assert b"test" in encoded
+
+    def test_blob(self) -> None:
+        data = bytes([1, 2, 3, 4])
+        encoded = encode_typed_value(DataType.BLOB, data)
+        assert encoded[0] == DataType.BLOB
+        assert encoded.endswith(data)
+
+    def test_unsupported_type(self) -> None:
+        with pytest.raises(ValueError, match="Unsupported DataType"):
+            encode_typed_value(0xFF, None)

--- a/tests/test_s7commplus_e2e.py
+++ b/tests/test_s7commplus_e2e.py
@@ -441,17 +441,17 @@ class TestS7CommPlusDiagnostics(unittest.TestCase):
 
     def test_diag_connection_info(self) -> None:
         """Dump connection state after successful connect."""
-        print(f"\n{'='*60}")
-        print(f"DIAGNOSTIC: Connection Info")
+        print(f"\n{'=' * 60}")
+        print("DIAGNOSTIC: Connection Info")
         print(f"  connected: {self.client.connected}")
         print(f"  protocol_version: V{self.client.protocol_version}")
         print(f"  session_id: 0x{self.client.session_id:08X} ({self.client.session_id})")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
         self.assertTrue(self.client.connected)
 
     def test_diag_explore_raw(self) -> None:
         """Explore and dump the raw response for analysis."""
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print("DIAGNOSTIC: Explore raw response")
         try:
             data = self.client.explore()
@@ -464,22 +464,22 @@ class TestS7CommPlusDiagnostics(unittest.TestCase):
                 print(f"  {i:04x}: {hex_str:<96s} {ascii_str}")
         except Exception as e:
             print(f"  Explore failed: {e}")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
     def test_diag_db_read_single_byte(self) -> None:
         """Try to read a single byte from DB1 offset 0 and dump everything."""
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print("DIAGNOSTIC: db_read(DB1, offset=0, size=1)")
         try:
             data = self.client.db_read(DB_READ_ONLY, 0, 1)
             print(f"  Success! Got {len(data)} bytes: {data.hex(' ')}")
         except Exception as e:
             print(f"  FAILED: {type(e).__name__}: {e}")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
     def test_diag_db_read_full_block(self) -> None:
         """Try to read the full test DB and dump everything."""
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print(f"DIAGNOSTIC: db_read(DB{DB_READ_ONLY}, offset=0, size={DB_SIZE})")
         try:
             data = self.client.db_read(DB_READ_ONLY, 0, DB_SIZE)
@@ -489,7 +489,7 @@ class TestS7CommPlusDiagnostics(unittest.TestCase):
                 print(f"    {i:04x}: {chunk.hex(' ')}")
         except Exception as e:
             print(f"  FAILED: {type(e).__name__}: {e}")
-        print(f"{'='*60}")
+        print(f"{'=' * 60}")
 
     def test_diag_raw_get_multi_variables(self) -> None:
         """Send a raw GetMultiVariables with different payload formats and dump responses.
@@ -499,7 +499,7 @@ class TestS7CommPlusDiagnostics(unittest.TestCase):
         from snap7.s7commplus.protocol import FunctionCode
         from snap7.s7commplus.vlq import encode_uint32_vlq
 
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print("DIAGNOSTIC: Raw GetMultiVariables payload experiments")
 
         assert self.client._connection is not None
@@ -507,10 +507,7 @@ class TestS7CommPlusDiagnostics(unittest.TestCase):
         # Experiment 1: Our current format (item_count + object_id + offset + size)
         payloads = {
             "current_format (count=1, obj=0x00010001, off=0, sz=2)": (
-                encode_uint32_vlq(1)
-                + encode_uint32_vlq(0x00010001)
-                + encode_uint32_vlq(0)
-                + encode_uint32_vlq(2)
+                encode_uint32_vlq(1) + encode_uint32_vlq(0x00010001) + encode_uint32_vlq(0) + encode_uint32_vlq(2)
             ),
             "empty_payload": b"",
             "just_zero": encode_uint32_vlq(0),
@@ -521,9 +518,7 @@ class TestS7CommPlusDiagnostics(unittest.TestCase):
             print(f"\n  --- {label} ---")
             print(f"  Payload ({len(payload)} bytes): {payload.hex(' ')}")
             try:
-                response = self.client._connection.send_request(
-                    FunctionCode.GET_MULTI_VARIABLES, payload
-                )
+                response = self.client._connection.send_request(FunctionCode.GET_MULTI_VARIABLES, payload)
                 print(f"  Response ({len(response)} bytes): {response.hex(' ')}")
 
                 # Try to parse return code
@@ -538,14 +533,13 @@ class TestS7CommPlusDiagnostics(unittest.TestCase):
             except Exception as e:
                 print(f"  EXCEPTION: {type(e).__name__}: {e}")
 
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
 
     def test_diag_raw_set_variable(self) -> None:
         """Try SetVariable (0x04F2) instead of SetMultiVariables to see if PLC responds differently."""
         from snap7.s7commplus.protocol import FunctionCode
-        from snap7.s7commplus.vlq import encode_uint32_vlq
 
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print("DIAGNOSTIC: Raw SetVariable / GetVariable experiments")
 
         assert self.client._connection is not None
@@ -565,14 +559,14 @@ class TestS7CommPlusDiagnostics(unittest.TestCase):
             except Exception as e:
                 print(f"  EXCEPTION: {type(e).__name__}: {e}")
 
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
 
     def test_diag_explore_then_read(self) -> None:
         """Explore first to discover object IDs, then try reading using those IDs."""
         from snap7.s7commplus.protocol import FunctionCode, ElementID
         from snap7.s7commplus.vlq import encode_uint32_vlq, decode_uint32_vlq
 
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")
         print("DIAGNOSTIC: Explore -> extract object IDs -> try reading")
 
         assert self.client._connection is not None
@@ -597,16 +591,9 @@ class TestS7CommPlusDiagnostics(unittest.TestCase):
             # Try reading using each discovered object ID
             for obj_id in object_ids[:5]:  # Limit to first 5
                 print(f"\n  --- Read using object_id=0x{obj_id:08X} ---")
-                payload = (
-                    encode_uint32_vlq(1)
-                    + encode_uint32_vlq(obj_id)
-                    + encode_uint32_vlq(0)
-                    + encode_uint32_vlq(4)
-                )
+                payload = encode_uint32_vlq(1) + encode_uint32_vlq(obj_id) + encode_uint32_vlq(0) + encode_uint32_vlq(4)
                 try:
-                    response = self.client._connection.send_request(
-                        FunctionCode.GET_MULTI_VARIABLES, payload
-                    )
+                    response = self.client._connection.send_request(FunctionCode.GET_MULTI_VARIABLES, payload)
                     print(f"    Response ({len(response)} bytes): {response.hex(' ')}")
                     if len(response) > 0:
                         rc, consumed = decode_uint32_vlq(response, 0)
@@ -617,4 +604,4 @@ class TestS7CommPlusDiagnostics(unittest.TestCase):
         except Exception as e:
             print(f"  Explore failed: {type(e).__name__}: {e}")
 
-        print(f"\n{'='*60}")
+        print(f"\n{'=' * 60}")

--- a/tests/test_s7commplus_e2e.py
+++ b/tests/test_s7commplus_e2e.py
@@ -1,0 +1,410 @@
+"""End-to-end tests for S7CommPlus client against a real Siemens S7-1200/1500 PLC.
+
+These tests require a real PLC connection. Run with:
+
+    pytest tests/test_s7commplus_e2e.py --e2e --plc-ip=YOUR_PLC_IP
+
+Available options:
+    --e2e           Enable e2e tests (required)
+    --plc-ip        PLC IP address (default: 10.10.10.100)
+    --plc-rack      PLC rack number (default: 0)
+    --plc-slot      PLC slot number (default: 1)
+    --plc-port      PLC TCP port (default: 102)
+    --plc-db-read   Read-only DB number (default: 1)
+    --plc-db-write  Read-write DB number (default: 2)
+
+The PLC needs two data blocks configured with the same layout as the
+regular S7 e2e tests:
+
+DB1 "Read_only" - Read-only data block with predefined values:
+    int1: Int = 10           (offset 0, 2 bytes)
+    int2: Int = 255          (offset 2, 2 bytes)
+    float1: Real = 123.45    (offset 4, 4 bytes)
+    float2: Real = 543.21    (offset 8, 4 bytes)
+    byte1: Byte = 0x0F       (offset 12, 1 byte)
+    byte2: Byte = 0xF0       (offset 13, 1 byte)
+    word1: Word = 0xABCD     (offset 14, 2 bytes)
+    word2: Word = 0x1234     (offset 16, 2 bytes)
+    dword1: DWord = 0x12345678 (offset 18, 4 bytes)
+    dword2: DWord = 0x89ABCDEF (offset 22, 4 bytes)
+    dint1: DInt = 2147483647 (offset 26, 4 bytes)
+    dint2: DInt = 42         (offset 30, 4 bytes)
+    char1: Char = 'F'        (offset 34, 1 byte)
+    char2: Char = '-'        (offset 35, 1 byte)
+    bool0-bool7: Bool        (offset 36, 1 byte, value: 0x01)
+
+DB2 "Data_block_2" - Read/write data block with same structure.
+
+Note: S7CommPlus targets S7-1200/1500 PLCs, which use optimized block
+access. Ensure data blocks have "Optimized block access" disabled in
+TIA Portal so that byte offsets match the layout above.
+"""
+
+import os
+import struct
+import unittest
+
+import pytest
+
+from snap7.s7commplus.client import S7CommPlusClient
+
+# =============================================================================
+# PLC Connection Configuration
+# These can be overridden via pytest command line options or environment variables
+# =============================================================================
+PLC_IP = os.environ.get("PLC_IP", "10.10.10.100")
+PLC_RACK = int(os.environ.get("PLC_RACK", "0"))
+PLC_SLOT = int(os.environ.get("PLC_SLOT", "1"))
+PLC_PORT = int(os.environ.get("PLC_PORT", "102"))
+
+# Data block numbers
+DB_READ_ONLY = int(os.environ.get("PLC_DB_READ", "1"))
+DB_READ_WRITE = int(os.environ.get("PLC_DB_WRITE", "2"))
+
+
+# =============================================================================
+# DB Structure - Byte offsets for each variable (same as regular S7 e2e tests)
+# =============================================================================
+OFFSET_INT1 = 0  # Int (2 bytes)
+OFFSET_INT2 = 2  # Int (2 bytes)
+OFFSET_FLOAT1 = 4  # Real (4 bytes)
+OFFSET_FLOAT2 = 8  # Real (4 bytes)
+OFFSET_BYTE1 = 12  # Byte (1 byte)
+OFFSET_BYTE2 = 13  # Byte (1 byte)
+OFFSET_WORD1 = 14  # Word (2 bytes)
+OFFSET_WORD2 = 16  # Word (2 bytes)
+OFFSET_DWORD1 = 18  # DWord (4 bytes)
+OFFSET_DWORD2 = 22  # DWord (4 bytes)
+OFFSET_DINT1 = 26  # DInt (4 bytes)
+OFFSET_DINT2 = 30  # DInt (4 bytes)
+OFFSET_CHAR1 = 34  # Char (1 byte)
+OFFSET_CHAR2 = 35  # Char (1 byte)
+OFFSET_BOOLS = 36  # 8 Bools packed in 1 byte
+
+# Total size of DB
+DB_SIZE = 37
+
+# =============================================================================
+# Expected values from DB1 "Read_only"
+# =============================================================================
+EXPECTED_INT1 = 10
+EXPECTED_INT2 = 255
+EXPECTED_FLOAT1 = 123.45
+EXPECTED_FLOAT2 = 543.21
+EXPECTED_BYTE1 = 0x0F
+EXPECTED_BYTE2 = 0xF0
+EXPECTED_WORD1 = 0xABCD
+EXPECTED_WORD2 = 0x1234
+EXPECTED_DWORD1 = 0x12345678
+EXPECTED_DWORD2 = 0x89ABCDEF
+EXPECTED_DINT1 = 2147483647
+EXPECTED_DINT2 = 42
+EXPECTED_CHAR1 = "F"
+EXPECTED_CHAR2 = "-"
+EXPECTED_BOOL0 = True
+EXPECTED_BOOL1 = False
+
+
+# =============================================================================
+# Test Classes
+# =============================================================================
+
+
+@pytest.mark.e2e
+class TestS7CommPlusConnection(unittest.TestCase):
+    """Tests for S7CommPlus connection."""
+
+    def test_connect_disconnect(self) -> None:
+        """Test connect() and disconnect()."""
+        client = S7CommPlusClient()
+        client.connect(PLC_IP, PLC_PORT, PLC_RACK, PLC_SLOT)
+        self.assertTrue(client.connected)
+        self.assertGreater(client.protocol_version, 0)
+        self.assertGreater(client.session_id, 0)
+        client.disconnect()
+        self.assertFalse(client.connected)
+
+    def test_context_manager(self) -> None:
+        """Test S7CommPlusClient as context manager."""
+        with S7CommPlusClient() as client:
+            client.connect(PLC_IP, PLC_PORT, PLC_RACK, PLC_SLOT)
+            self.assertTrue(client.connected)
+        # After exiting context, client should be disconnected
+
+    def test_properties_before_connect(self) -> None:
+        """Test properties return defaults before connection."""
+        client = S7CommPlusClient()
+        self.assertFalse(client.connected)
+        self.assertEqual(0, client.protocol_version)
+        self.assertEqual(0, client.session_id)
+
+
+@pytest.mark.e2e
+class TestS7CommPlusDBRead(unittest.TestCase):
+    """Tests for db_read() - reading from DB1 (read-only)."""
+
+    client: S7CommPlusClient
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.client = S7CommPlusClient()
+        cls.client.connect(PLC_IP, PLC_PORT, PLC_RACK, PLC_SLOT)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.client:
+            cls.client.disconnect()
+
+    def test_db_read_int(self) -> None:
+        """Test db_read() for Int values."""
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_INT1, 2)
+        value = struct.unpack(">h", data)[0]
+        self.assertEqual(EXPECTED_INT1, value)
+
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_INT2, 2)
+        value = struct.unpack(">h", data)[0]
+        self.assertEqual(EXPECTED_INT2, value)
+
+    def test_db_read_real(self) -> None:
+        """Test db_read() for Real values."""
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_FLOAT1, 4)
+        value = struct.unpack(">f", data)[0]
+        self.assertAlmostEqual(EXPECTED_FLOAT1, value, places=2)
+
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_FLOAT2, 4)
+        value = struct.unpack(">f", data)[0]
+        self.assertAlmostEqual(EXPECTED_FLOAT2, value, places=2)
+
+    def test_db_read_byte(self) -> None:
+        """Test db_read() for Byte values."""
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_BYTE1, 1)
+        self.assertEqual(EXPECTED_BYTE1, data[0])
+
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_BYTE2, 1)
+        self.assertEqual(EXPECTED_BYTE2, data[0])
+
+    def test_db_read_word(self) -> None:
+        """Test db_read() for Word values."""
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_WORD1, 2)
+        value = struct.unpack(">H", data)[0]
+        self.assertEqual(EXPECTED_WORD1, value)
+
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_WORD2, 2)
+        value = struct.unpack(">H", data)[0]
+        self.assertEqual(EXPECTED_WORD2, value)
+
+    def test_db_read_dword(self) -> None:
+        """Test db_read() for DWord values."""
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_DWORD1, 4)
+        value = struct.unpack(">I", data)[0]
+        self.assertEqual(EXPECTED_DWORD1, value)
+
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_DWORD2, 4)
+        value = struct.unpack(">I", data)[0]
+        self.assertEqual(EXPECTED_DWORD2, value)
+
+    def test_db_read_dint(self) -> None:
+        """Test db_read() for DInt values."""
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_DINT1, 4)
+        value = struct.unpack(">i", data)[0]
+        self.assertEqual(EXPECTED_DINT1, value)
+
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_DINT2, 4)
+        value = struct.unpack(">i", data)[0]
+        self.assertEqual(EXPECTED_DINT2, value)
+
+    def test_db_read_char(self) -> None:
+        """Test db_read() for Char values."""
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_CHAR1, 1)
+        self.assertEqual(EXPECTED_CHAR1, chr(data[0]))
+
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_CHAR2, 1)
+        self.assertEqual(EXPECTED_CHAR2, chr(data[0]))
+
+    def test_db_read_bool(self) -> None:
+        """Test db_read() for Bool values (packed in byte)."""
+        data = self.client.db_read(DB_READ_ONLY, OFFSET_BOOLS, 1)
+        self.assertEqual(EXPECTED_BOOL0, bool(data[0] & 0x01))
+        self.assertEqual(EXPECTED_BOOL1, bool(data[0] & 0x02))
+
+    def test_db_read_entire_block(self) -> None:
+        """Test db_read() for entire DB."""
+        data = self.client.db_read(DB_READ_ONLY, 0, DB_SIZE)
+        self.assertEqual(DB_SIZE, len(data))
+
+        # Verify a few values
+        int1 = struct.unpack(">h", data[OFFSET_INT1 : OFFSET_INT1 + 2])[0]
+        self.assertEqual(EXPECTED_INT1, int1)
+
+        float1 = struct.unpack(">f", data[OFFSET_FLOAT1 : OFFSET_FLOAT1 + 4])[0]
+        self.assertAlmostEqual(EXPECTED_FLOAT1, float1, places=2)
+
+        dword1 = struct.unpack(">I", data[OFFSET_DWORD1 : OFFSET_DWORD1 + 4])[0]
+        self.assertEqual(EXPECTED_DWORD1, dword1)
+
+
+@pytest.mark.e2e
+class TestS7CommPlusDBWrite(unittest.TestCase):
+    """Tests for db_write() - writing to DB2 (read/write)."""
+
+    client: S7CommPlusClient
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.client = S7CommPlusClient()
+        cls.client.connect(PLC_IP, PLC_PORT, PLC_RACK, PLC_SLOT)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.client:
+            cls.client.disconnect()
+
+    def test_db_write_int(self) -> None:
+        """Test db_write() for Int values."""
+        test_value = 10
+        data = struct.pack(">h", test_value)
+        self.client.db_write(DB_READ_WRITE, OFFSET_INT1, data)
+
+        result = self.client.db_read(DB_READ_WRITE, OFFSET_INT1, 2)
+        self.assertEqual(test_value, struct.unpack(">h", result)[0])
+
+    def test_db_write_real(self) -> None:
+        """Test db_write() for Real values."""
+        test_value = 456.789
+        data = struct.pack(">f", test_value)
+        self.client.db_write(DB_READ_WRITE, OFFSET_FLOAT1, data)
+
+        result = self.client.db_read(DB_READ_WRITE, OFFSET_FLOAT1, 4)
+        self.assertAlmostEqual(test_value, struct.unpack(">f", result)[0], places=2)
+
+    def test_db_write_byte(self) -> None:
+        """Test db_write() for Byte values."""
+        test_value = 0xAB
+        self.client.db_write(DB_READ_WRITE, OFFSET_BYTE1, bytes([test_value]))
+
+        result = self.client.db_read(DB_READ_WRITE, OFFSET_BYTE1, 1)
+        self.assertEqual(test_value, result[0])
+
+    def test_db_write_word(self) -> None:
+        """Test db_write() for Word values."""
+        test_value = 0x1234
+        data = struct.pack(">H", test_value)
+        self.client.db_write(DB_READ_WRITE, OFFSET_WORD1, data)
+
+        result = self.client.db_read(DB_READ_WRITE, OFFSET_WORD1, 2)
+        self.assertEqual(test_value, struct.unpack(">H", result)[0])
+
+    def test_db_write_dword(self) -> None:
+        """Test db_write() for DWord values."""
+        test_value = 0xDEADBEEF
+        data = struct.pack(">I", test_value)
+        self.client.db_write(DB_READ_WRITE, OFFSET_DWORD1, data)
+
+        result = self.client.db_read(DB_READ_WRITE, OFFSET_DWORD1, 4)
+        self.assertEqual(test_value, struct.unpack(">I", result)[0])
+
+    def test_db_write_dint(self) -> None:
+        """Test db_write() for DInt values."""
+        test_value = -123456789
+        data = struct.pack(">i", test_value)
+        self.client.db_write(DB_READ_WRITE, OFFSET_DINT1, data)
+
+        result = self.client.db_read(DB_READ_WRITE, OFFSET_DINT1, 4)
+        self.assertEqual(test_value, struct.unpack(">i", result)[0])
+
+    def test_db_write_char(self) -> None:
+        """Test db_write() for Char values."""
+        test_value = "X"
+        self.client.db_write(DB_READ_WRITE, OFFSET_CHAR1, test_value.encode("ascii"))
+
+        result = self.client.db_read(DB_READ_WRITE, OFFSET_CHAR1, 1)
+        self.assertEqual(test_value, chr(result[0]))
+
+    def test_db_write_bool(self) -> None:
+        """Test db_write() for Bool values (packed in byte)."""
+        # Read current byte, set bit 0 and bit 7, write back
+        data = bytearray(self.client.db_read(DB_READ_WRITE, OFFSET_BOOLS, 1))
+        data[0] = data[0] | 0x01 | 0x80  # Set bit 0 and bit 7
+        self.client.db_write(DB_READ_WRITE, OFFSET_BOOLS, bytes(data))
+
+        result = self.client.db_read(DB_READ_WRITE, OFFSET_BOOLS, 1)
+        self.assertTrue(bool(result[0] & 0x01))
+        self.assertTrue(bool(result[0] & 0x80))
+
+
+@pytest.mark.e2e
+class TestS7CommPlusMultiRead(unittest.TestCase):
+    """Tests for db_read_multi() - multiple reads in a single request."""
+
+    client: S7CommPlusClient
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.client = S7CommPlusClient()
+        cls.client.connect(PLC_IP, PLC_PORT, PLC_RACK, PLC_SLOT)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.client:
+            cls.client.disconnect()
+
+    def test_multi_read(self) -> None:
+        """Test db_read_multi() reads multiple regions."""
+        items = [
+            (DB_READ_ONLY, OFFSET_INT1, 2),
+            (DB_READ_ONLY, OFFSET_FLOAT1, 4),
+            (DB_READ_ONLY, OFFSET_DWORD1, 4),
+        ]
+        results = self.client.db_read_multi(items)
+        self.assertEqual(3, len(results))
+
+        int_val = struct.unpack(">h", results[0])[0]
+        self.assertEqual(EXPECTED_INT1, int_val)
+
+        float_val = struct.unpack(">f", results[1])[0]
+        self.assertAlmostEqual(EXPECTED_FLOAT1, float_val, places=2)
+
+        dword_val = struct.unpack(">I", results[2])[0]
+        self.assertEqual(EXPECTED_DWORD1, dword_val)
+
+    def test_multi_read_across_dbs(self) -> None:
+        """Test db_read_multi() across different data blocks."""
+        # Write a known value to DB2 first
+        test_int = 777
+        self.client.db_write(DB_READ_WRITE, OFFSET_INT1, struct.pack(">h", test_int))
+
+        items = [
+            (DB_READ_ONLY, OFFSET_INT1, 2),
+            (DB_READ_WRITE, OFFSET_INT1, 2),
+        ]
+        results = self.client.db_read_multi(items)
+        self.assertEqual(2, len(results))
+
+        self.assertEqual(EXPECTED_INT1, struct.unpack(">h", results[0])[0])
+        self.assertEqual(test_int, struct.unpack(">h", results[1])[0])
+
+
+@pytest.mark.e2e
+class TestS7CommPlusExplore(unittest.TestCase):
+    """Tests for explore() - browsing the PLC object tree."""
+
+    client: S7CommPlusClient
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.client = S7CommPlusClient()
+        cls.client.connect(PLC_IP, PLC_PORT, PLC_RACK, PLC_SLOT)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.client:
+            cls.client.disconnect()
+
+    def test_explore(self) -> None:
+        """Test explore() returns data."""
+        try:
+            data = self.client.explore()
+        except Exception as e:
+            pytest.skip(f"Explore not supported: {e}")
+        self.assertIsInstance(data, bytes)
+        self.assertGreater(len(data), 0)

--- a/tests/test_s7commplus_e2e.py
+++ b/tests/test_s7commplus_e2e.py
@@ -40,6 +40,7 @@ access. Ensure data blocks have "Optimized block access" disabled in
 TIA Portal so that byte offsets match the layout above.
 """
 
+import logging
 import os
 import struct
 import unittest
@@ -47,6 +48,14 @@ import unittest
 import pytest
 
 from snap7.s7commplus.client import S7CommPlusClient
+
+# Enable DEBUG logging for all s7commplus modules so we get full hex dumps
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s %(name)s %(levelname)s %(message)s",
+)
+for _mod in ["snap7.s7commplus.client", "snap7.s7commplus.connection", "snap7.connection"]:
+    logging.getLogger(_mod).setLevel(logging.DEBUG)
 
 # =============================================================================
 # PLC Connection Configuration
@@ -408,3 +417,204 @@ class TestS7CommPlusExplore(unittest.TestCase):
             pytest.skip(f"Explore not supported: {e}")
         self.assertIsInstance(data, bytes)
         self.assertGreater(len(data), 0)
+
+
+@pytest.mark.e2e
+class TestS7CommPlusDiagnostics(unittest.TestCase):
+    """Diagnostic tests for debugging protocol issues against real PLCs.
+
+    These tests are designed to dump raw protocol data at every layer
+    to help diagnose why db_read/db_write fail against real hardware.
+    """
+
+    client: S7CommPlusClient
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.client = S7CommPlusClient()
+        cls.client.connect(PLC_IP, PLC_PORT, PLC_RACK, PLC_SLOT)
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.client:
+            cls.client.disconnect()
+
+    def test_diag_connection_info(self) -> None:
+        """Dump connection state after successful connect."""
+        print(f"\n{'='*60}")
+        print(f"DIAGNOSTIC: Connection Info")
+        print(f"  connected: {self.client.connected}")
+        print(f"  protocol_version: V{self.client.protocol_version}")
+        print(f"  session_id: 0x{self.client.session_id:08X} ({self.client.session_id})")
+        print(f"{'='*60}")
+        self.assertTrue(self.client.connected)
+
+    def test_diag_explore_raw(self) -> None:
+        """Explore and dump the raw response for analysis."""
+        print(f"\n{'='*60}")
+        print("DIAGNOSTIC: Explore raw response")
+        try:
+            data = self.client.explore()
+            print(f"  Length: {len(data)} bytes")
+            # Dump in 32-byte rows
+            for i in range(0, len(data), 32):
+                chunk = data[i : i + 32]
+                hex_str = chunk.hex(" ")
+                ascii_str = "".join(chr(b) if 32 <= b < 127 else "." for b in chunk)
+                print(f"  {i:04x}: {hex_str:<96s} {ascii_str}")
+        except Exception as e:
+            print(f"  Explore failed: {e}")
+        print(f"{'='*60}")
+
+    def test_diag_db_read_single_byte(self) -> None:
+        """Try to read a single byte from DB1 offset 0 and dump everything."""
+        print(f"\n{'='*60}")
+        print("DIAGNOSTIC: db_read(DB1, offset=0, size=1)")
+        try:
+            data = self.client.db_read(DB_READ_ONLY, 0, 1)
+            print(f"  Success! Got {len(data)} bytes: {data.hex(' ')}")
+        except Exception as e:
+            print(f"  FAILED: {type(e).__name__}: {e}")
+        print(f"{'='*60}")
+
+    def test_diag_db_read_full_block(self) -> None:
+        """Try to read the full test DB and dump everything."""
+        print(f"\n{'='*60}")
+        print(f"DIAGNOSTIC: db_read(DB{DB_READ_ONLY}, offset=0, size={DB_SIZE})")
+        try:
+            data = self.client.db_read(DB_READ_ONLY, 0, DB_SIZE)
+            print(f"  Success! Got {len(data)} bytes:")
+            for i in range(0, len(data), 16):
+                chunk = data[i : i + 16]
+                print(f"    {i:04x}: {chunk.hex(' ')}")
+        except Exception as e:
+            print(f"  FAILED: {type(e).__name__}: {e}")
+        print(f"{'='*60}")
+
+    def test_diag_raw_get_multi_variables(self) -> None:
+        """Send a raw GetMultiVariables with different payload formats and dump responses.
+
+        This tries several payload encodings to see which ones the PLC accepts.
+        """
+        from snap7.s7commplus.protocol import FunctionCode
+        from snap7.s7commplus.vlq import encode_uint32_vlq
+
+        print(f"\n{'='*60}")
+        print("DIAGNOSTIC: Raw GetMultiVariables payload experiments")
+
+        assert self.client._connection is not None
+
+        # Experiment 1: Our current format (item_count + object_id + offset + size)
+        payloads = {
+            "current_format (count=1, obj=0x00010001, off=0, sz=2)": (
+                encode_uint32_vlq(1)
+                + encode_uint32_vlq(0x00010001)
+                + encode_uint32_vlq(0)
+                + encode_uint32_vlq(2)
+            ),
+            "empty_payload": b"",
+            "just_zero": encode_uint32_vlq(0),
+            "single_vlq_1": encode_uint32_vlq(1),
+        }
+
+        for label, payload in payloads.items():
+            print(f"\n  --- {label} ---")
+            print(f"  Payload ({len(payload)} bytes): {payload.hex(' ')}")
+            try:
+                response = self.client._connection.send_request(
+                    FunctionCode.GET_MULTI_VARIABLES, payload
+                )
+                print(f"  Response ({len(response)} bytes): {response.hex(' ')}")
+
+                # Try to parse return code
+                if len(response) > 0:
+                    from snap7.s7commplus.vlq import decode_uint32_vlq
+
+                    rc, consumed = decode_uint32_vlq(response, 0)
+                    print(f"  Return code (VLQ): {rc} (0x{rc:X})")
+                    remaining = response[consumed:]
+                    if remaining:
+                        print(f"  After return code ({len(remaining)} bytes): {remaining.hex(' ')}")
+            except Exception as e:
+                print(f"  EXCEPTION: {type(e).__name__}: {e}")
+
+        print(f"\n{'='*60}")
+
+    def test_diag_raw_set_variable(self) -> None:
+        """Try SetVariable (0x04F2) instead of SetMultiVariables to see if PLC responds differently."""
+        from snap7.s7commplus.protocol import FunctionCode
+        from snap7.s7commplus.vlq import encode_uint32_vlq
+
+        print(f"\n{'='*60}")
+        print("DIAGNOSTIC: Raw SetVariable / GetVariable experiments")
+
+        assert self.client._connection is not None
+
+        function_codes = {
+            "GET_VARIABLE (0x04FC)": FunctionCode.GET_VARIABLE,
+            "GET_MULTI_VARIABLES (0x054C)": FunctionCode.GET_MULTI_VARIABLES,
+            "SET_VARIABLE (0x04F2)": FunctionCode.SET_VARIABLE,
+        }
+
+        # Simple payload: just try empty or minimal
+        for label, fc in function_codes.items():
+            print(f"\n  --- {label} with empty payload ---")
+            try:
+                response = self.client._connection.send_request(fc, b"")
+                print(f"  Response ({len(response)} bytes): {response.hex(' ')}")
+            except Exception as e:
+                print(f"  EXCEPTION: {type(e).__name__}: {e}")
+
+        print(f"\n{'='*60}")
+
+    def test_diag_explore_then_read(self) -> None:
+        """Explore first to discover object IDs, then try reading using those IDs."""
+        from snap7.s7commplus.protocol import FunctionCode, ElementID
+        from snap7.s7commplus.vlq import encode_uint32_vlq, decode_uint32_vlq
+
+        print(f"\n{'='*60}")
+        print("DIAGNOSTIC: Explore -> extract object IDs -> try reading")
+
+        assert self.client._connection is not None
+
+        try:
+            explore_data = self.client._connection.send_request(FunctionCode.EXPLORE, b"")
+            print(f"  Explore response ({len(explore_data)} bytes)")
+
+            # Scan for StartOfObject markers and extract relation IDs
+            object_ids = []
+            i = 0
+            while i < len(explore_data):
+                if explore_data[i] == ElementID.START_OF_OBJECT:
+                    if i + 5 <= len(explore_data):
+                        rel_id = struct.unpack_from(">I", explore_data, i + 1)[0]
+                        object_ids.append(rel_id)
+                        print(f"    Found object at offset {i}: relation_id=0x{rel_id:08X}")
+                    i += 5
+                else:
+                    i += 1
+
+            # Try reading using each discovered object ID
+            for obj_id in object_ids[:5]:  # Limit to first 5
+                print(f"\n  --- Read using object_id=0x{obj_id:08X} ---")
+                payload = (
+                    encode_uint32_vlq(1)
+                    + encode_uint32_vlq(obj_id)
+                    + encode_uint32_vlq(0)
+                    + encode_uint32_vlq(4)
+                )
+                try:
+                    response = self.client._connection.send_request(
+                        FunctionCode.GET_MULTI_VARIABLES, payload
+                    )
+                    print(f"    Response ({len(response)} bytes): {response.hex(' ')}")
+                    if len(response) > 0:
+                        rc, consumed = decode_uint32_vlq(response, 0)
+                        print(f"    Return code: {rc} (0x{rc:X})")
+                except Exception as e:
+                    print(f"    EXCEPTION: {type(e).__name__}: {e}")
+
+        except Exception as e:
+            print(f"  Explore failed: {type(e).__name__}: {e}")
+
+        print(f"\n{'='*60}")

--- a/tests/test_s7commplus_server.py
+++ b/tests/test_s7commplus_server.py
@@ -235,89 +235,68 @@ class TestClientServerIntegration:
             c.disconnect()
 
 
+@pytest.mark.asyncio
 class TestAsyncClientServerIntegration:
     """Test async client against the server emulator."""
 
-    def test_connect_disconnect(self, server: S7CommPlusServer) -> None:
-        async def _test() -> None:
-            client = S7CommPlusAsyncClient()
+    async def test_connect_disconnect(self, server: S7CommPlusServer) -> None:
+        client = S7CommPlusAsyncClient()
+        await client.connect("127.0.0.1", port=TEST_PORT)
+        assert client.connected
+        assert client.session_id != 0
+        await client.disconnect()
+        assert not client.connected
+
+    async def test_async_context_manager(self, server: S7CommPlusServer) -> None:
+        async with S7CommPlusAsyncClient() as client:
             await client.connect("127.0.0.1", port=TEST_PORT)
             assert client.connected
-            assert client.session_id != 0
-            await client.disconnect()
-            assert not client.connected
+        assert not client.connected
 
-        asyncio.run(_test())
+    async def test_read_real(self, server: S7CommPlusServer) -> None:
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+            data = await client.db_read(1, 0, 4)
+            value = struct.unpack(">f", data)[0]
+            assert abs(value - 23.5) < 0.001
 
-    def test_async_context_manager(self, server: S7CommPlusServer) -> None:
-        async def _test() -> None:
-            async with S7CommPlusAsyncClient() as client:
-                await client.connect("127.0.0.1", port=TEST_PORT)
-                assert client.connected
-            assert not client.connected
+    async def test_write_and_read_back(self, server: S7CommPlusServer) -> None:
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+            await client.db_write(1, 0, struct.pack(">f", 77.7))
+            data = await client.db_read(1, 0, 4)
+            value = struct.unpack(">f", data)[0]
+            assert abs(value - 77.7) < 0.1
 
-        asyncio.run(_test())
+    async def test_multi_read(self, server: S7CommPlusServer) -> None:
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+            results = await client.db_read_multi(
+                [
+                    (1, 0, 4),
+                    (1, 10, 4),
+                ]
+            )
+            assert len(results) == 2
+            temp = struct.unpack(">f", results[0])[0]
+            assert abs(temp - 23.5) < 0.1  # May be modified by earlier test
 
-    def test_read_real(self, server: S7CommPlusServer) -> None:
-        async def _test() -> None:
-            async with S7CommPlusAsyncClient() as client:
-                await client.connect("127.0.0.1", port=TEST_PORT)
-                data = await client.db_read(1, 0, 4)
-                value = struct.unpack(">f", data)[0]
-                assert abs(value - 23.5) < 0.001
+    async def test_explore(self, server: S7CommPlusServer) -> None:
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+            response = await client.explore()
+            assert len(response) > 0
 
-        asyncio.run(_test())
-
-    def test_write_and_read_back(self, server: S7CommPlusServer) -> None:
-        async def _test() -> None:
-            async with S7CommPlusAsyncClient() as client:
-                await client.connect("127.0.0.1", port=TEST_PORT)
-                await client.db_write(1, 0, struct.pack(">f", 77.7))
-                data = await client.db_read(1, 0, 4)
-                value = struct.unpack(">f", data)[0]
-                assert abs(value - 77.7) < 0.1
-
-        asyncio.run(_test())
-
-    def test_multi_read(self, server: S7CommPlusServer) -> None:
-        async def _test() -> None:
-            async with S7CommPlusAsyncClient() as client:
-                await client.connect("127.0.0.1", port=TEST_PORT)
-                results = await client.db_read_multi(
-                    [
-                        (1, 0, 4),
-                        (1, 10, 4),
-                    ]
-                )
-                assert len(results) == 2
-                temp = struct.unpack(">f", results[0])[0]
-                assert abs(temp - 23.5) < 0.1  # May be modified by earlier test
-
-        asyncio.run(_test())
-
-    def test_explore(self, server: S7CommPlusServer) -> None:
-        async def _test() -> None:
-            async with S7CommPlusAsyncClient() as client:
-                await client.connect("127.0.0.1", port=TEST_PORT)
-                response = await client.explore()
-                assert len(response) > 0
-
-        asyncio.run(_test())
-
-    def test_concurrent_reads(self, server: S7CommPlusServer) -> None:
+    async def test_concurrent_reads(self, server: S7CommPlusServer) -> None:
         """Test that asyncio.Lock prevents interleaved requests."""
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
 
-        async def _test() -> None:
-            async with S7CommPlusAsyncClient() as client:
-                await client.connect("127.0.0.1", port=TEST_PORT)
+            async def read_temp() -> float:
+                data = await client.db_read(1, 0, 4)
+                return struct.unpack(">f", data)[0]
 
-                async def read_temp() -> float:
-                    data = await client.db_read(1, 0, 4)
-                    return struct.unpack(">f", data)[0]
-
-                results = await asyncio.gather(read_temp(), read_temp(), read_temp())
-                assert len(results) == 3
-                for r in results:
-                    assert isinstance(r, float)
-
-        asyncio.run(_test())
+            results = await asyncio.gather(read_temp(), read_temp(), read_temp())
+            assert len(results) == 3
+            for r in results:
+                assert isinstance(r, float)

--- a/tests/test_s7commplus_server.py
+++ b/tests/test_s7commplus_server.py
@@ -87,10 +87,10 @@ class TestServer:
 
     def test_data_block_read_past_end(self) -> None:
         db = DataBlock(1, 4)
-        db.write(0, b"\xFF\xFF\xFF\xFF")
+        db.write(0, b"\xff\xff\xff\xff")
         # Read past end should pad with zeros
         data = db.read(2, 4)
-        assert data == b"\xFF\xFF\x00\x00"
+        assert data == b"\xff\xff\x00\x00"
 
     def test_unknown_variable_type(self) -> None:
         db = DataBlock(1, 100)
@@ -181,11 +181,13 @@ class TestClientServerIntegration:
         client = S7CommPlusClient()
         client.connect("127.0.0.1", port=TEST_PORT)
         try:
-            results = client.db_read_multi([
-                (1, 0, 4),   # temperature from DB1
-                (1, 4, 4),   # pressure from DB1
-                (2, 0, 4),   # zeros from DB2
-            ])
+            results = client.db_read_multi(
+                [
+                    (1, 0, 4),  # temperature from DB1
+                    (1, 4, 4),  # pressure from DB1
+                    (2, 0, 4),  # zeros from DB2
+                ]
+            )
             assert len(results) == 3
             temp = struct.unpack(">f", results[0])[0]
             assert abs(temp - 23.5) < 0.001
@@ -203,13 +205,11 @@ class TestClientServerIntegration:
         finally:
             client.disconnect()
 
-    def test_server_data_persists_across_clients(
-        self, server: S7CommPlusServer
-    ) -> None:
+    def test_server_data_persists_across_clients(self, server: S7CommPlusServer) -> None:
         # Client 1 writes
         c1 = S7CommPlusClient()
         c1.connect("127.0.0.1", port=TEST_PORT)
-        c1.db_write(2, 0, b"\xDE\xAD\xBE\xEF")
+        c1.db_write(2, 0, b"\xde\xad\xbe\xef")
         c1.disconnect()
 
         # Client 2 reads
@@ -218,11 +218,9 @@ class TestClientServerIntegration:
         data = c2.db_read(2, 0, 4)
         c2.disconnect()
 
-        assert data == b"\xDE\xAD\xBE\xEF"
+        assert data == b"\xde\xad\xbe\xef"
 
-    def test_multiple_concurrent_clients(
-        self, server: S7CommPlusServer
-    ) -> None:
+    def test_multiple_concurrent_clients(self, server: S7CommPlusServer) -> None:
         clients = []
         for _ in range(3):
             c = S7CommPlusClient()
@@ -237,70 +235,89 @@ class TestClientServerIntegration:
             c.disconnect()
 
 
-@pytest.mark.asyncio
 class TestAsyncClientServerIntegration:
     """Test async client against the server emulator."""
 
-    async def test_connect_disconnect(self, server: S7CommPlusServer) -> None:
-        client = S7CommPlusAsyncClient()
-        await client.connect("127.0.0.1", port=TEST_PORT)
-        assert client.connected
-        assert client.session_id != 0
-        await client.disconnect()
-        assert not client.connected
-
-    async def test_async_context_manager(self, server: S7CommPlusServer) -> None:
-        async with S7CommPlusAsyncClient() as client:
+    def test_connect_disconnect(self, server: S7CommPlusServer) -> None:
+        async def _test() -> None:
+            client = S7CommPlusAsyncClient()
             await client.connect("127.0.0.1", port=TEST_PORT)
             assert client.connected
-        assert not client.connected
+            assert client.session_id != 0
+            await client.disconnect()
+            assert not client.connected
 
-    async def test_read_real(self, server: S7CommPlusServer) -> None:
-        async with S7CommPlusAsyncClient() as client:
-            await client.connect("127.0.0.1", port=TEST_PORT)
-            data = await client.db_read(1, 0, 4)
-            value = struct.unpack(">f", data)[0]
-            assert abs(value - 23.5) < 0.001
+        asyncio.run(_test())
 
-    async def test_write_and_read_back(self, server: S7CommPlusServer) -> None:
-        async with S7CommPlusAsyncClient() as client:
-            await client.connect("127.0.0.1", port=TEST_PORT)
-            await client.db_write(1, 0, struct.pack(">f", 77.7))
-            data = await client.db_read(1, 0, 4)
-            value = struct.unpack(">f", data)[0]
-            assert abs(value - 77.7) < 0.1
+    def test_async_context_manager(self, server: S7CommPlusServer) -> None:
+        async def _test() -> None:
+            async with S7CommPlusAsyncClient() as client:
+                await client.connect("127.0.0.1", port=TEST_PORT)
+                assert client.connected
+            assert not client.connected
 
-    async def test_multi_read(self, server: S7CommPlusServer) -> None:
-        async with S7CommPlusAsyncClient() as client:
-            await client.connect("127.0.0.1", port=TEST_PORT)
-            results = await client.db_read_multi([
-                (1, 0, 4),
-                (1, 10, 4),
-            ])
-            assert len(results) == 2
-            temp = struct.unpack(">f", results[0])[0]
-            assert abs(temp - 23.5) < 0.1  # May be modified by earlier test
+        asyncio.run(_test())
 
-    async def test_explore(self, server: S7CommPlusServer) -> None:
-        async with S7CommPlusAsyncClient() as client:
-            await client.connect("127.0.0.1", port=TEST_PORT)
-            response = await client.explore()
-            assert len(response) > 0
-
-    async def test_concurrent_reads(self, server: S7CommPlusServer) -> None:
-        """Test that asyncio.Lock prevents interleaved requests."""
-        async with S7CommPlusAsyncClient() as client:
-            await client.connect("127.0.0.1", port=TEST_PORT)
-
-            async def read_temp() -> float:
+    def test_read_real(self, server: S7CommPlusServer) -> None:
+        async def _test() -> None:
+            async with S7CommPlusAsyncClient() as client:
+                await client.connect("127.0.0.1", port=TEST_PORT)
                 data = await client.db_read(1, 0, 4)
-                return struct.unpack(">f", data)[0]
+                value = struct.unpack(">f", data)[0]
+                assert abs(value - 23.5) < 0.001
 
-            # Fire multiple concurrent reads
-            results = await asyncio.gather(
-                read_temp(), read_temp(), read_temp()
-            )
-            # All should succeed (lock serializes them)
-            assert len(results) == 3
-            for r in results:
-                assert isinstance(r, float)
+        asyncio.run(_test())
+
+    def test_write_and_read_back(self, server: S7CommPlusServer) -> None:
+        async def _test() -> None:
+            async with S7CommPlusAsyncClient() as client:
+                await client.connect("127.0.0.1", port=TEST_PORT)
+                await client.db_write(1, 0, struct.pack(">f", 77.7))
+                data = await client.db_read(1, 0, 4)
+                value = struct.unpack(">f", data)[0]
+                assert abs(value - 77.7) < 0.1
+
+        asyncio.run(_test())
+
+    def test_multi_read(self, server: S7CommPlusServer) -> None:
+        async def _test() -> None:
+            async with S7CommPlusAsyncClient() as client:
+                await client.connect("127.0.0.1", port=TEST_PORT)
+                results = await client.db_read_multi(
+                    [
+                        (1, 0, 4),
+                        (1, 10, 4),
+                    ]
+                )
+                assert len(results) == 2
+                temp = struct.unpack(">f", results[0])[0]
+                assert abs(temp - 23.5) < 0.1  # May be modified by earlier test
+
+        asyncio.run(_test())
+
+    def test_explore(self, server: S7CommPlusServer) -> None:
+        async def _test() -> None:
+            async with S7CommPlusAsyncClient() as client:
+                await client.connect("127.0.0.1", port=TEST_PORT)
+                response = await client.explore()
+                assert len(response) > 0
+
+        asyncio.run(_test())
+
+    def test_concurrent_reads(self, server: S7CommPlusServer) -> None:
+        """Test that asyncio.Lock prevents interleaved requests."""
+
+        async def _test() -> None:
+            async with S7CommPlusAsyncClient() as client:
+                await client.connect("127.0.0.1", port=TEST_PORT)
+
+                async def read_temp() -> float:
+                    data = await client.db_read(1, 0, 4)
+                    return struct.unpack(">f", data)[0]
+
+                results = await asyncio.gather(read_temp(), read_temp(), read_temp())
+                assert len(results) == 3
+                for r in results:
+                    assert isinstance(r, float)
+
+        asyncio.run(_test())

--- a/tests/test_s7commplus_server.py
+++ b/tests/test_s7commplus_server.py
@@ -2,6 +2,8 @@
 
 import struct
 import time
+from collections.abc import Generator
+
 import pytest
 import asyncio
 
@@ -15,7 +17,7 @@ TEST_PORT = 11120
 
 
 @pytest.fixture()
-def server():
+def server() -> Generator[S7CommPlusServer, None, None]:
     """Create and start an S7CommPlus server with test data blocks."""
     srv = S7CommPlusServer()
 
@@ -294,7 +296,7 @@ class TestAsyncClientServerIntegration:
 
             async def read_temp() -> float:
                 data = await client.db_read(1, 0, 4)
-                return struct.unpack(">f", data)[0]
+                return float(struct.unpack(">f", data)[0])
 
             results = await asyncio.gather(read_temp(), read_temp(), read_temp())
             assert len(results) == 3

--- a/tests/test_s7commplus_server.py
+++ b/tests/test_s7commplus_server.py
@@ -1,0 +1,306 @@
+"""Integration tests for S7CommPlus server, client, and async client."""
+
+import struct
+import time
+import pytest
+import asyncio
+
+from snap7.s7commplus.server import S7CommPlusServer, CPUState, DataBlock
+from snap7.s7commplus.client import S7CommPlusClient
+from snap7.s7commplus.async_client import S7CommPlusAsyncClient
+from snap7.s7commplus.protocol import ProtocolVersion
+
+# Use a high port to avoid conflicts
+TEST_PORT = 11120
+
+
+@pytest.fixture()
+def server():
+    """Create and start an S7CommPlus server with test data blocks."""
+    srv = S7CommPlusServer()
+
+    # Register DB1 with named variables
+    srv.register_db(
+        1,
+        {
+            "temperature": ("Real", 0),
+            "pressure": ("Real", 4),
+            "running": ("Bool", 8),
+            "count": ("DInt", 10),
+            "name": ("Int", 14),
+        },
+    )
+
+    # Register DB2 with raw data
+    srv.register_raw_db(2, bytearray(256))
+
+    # Pre-populate some values in DB1
+    db1 = srv.get_db(1)
+    assert db1 is not None
+    struct.pack_into(">f", db1.data, 0, 23.5)  # temperature
+    struct.pack_into(">f", db1.data, 4, 1.013)  # pressure
+    db1.data[8] = 1  # running = True
+    struct.pack_into(">i", db1.data, 10, 42)  # count
+
+    srv.start(port=TEST_PORT)
+    time.sleep(0.1)  # Let server start
+
+    yield srv
+
+    srv.stop()
+
+
+class TestServer:
+    """Test the server emulator itself."""
+
+    def test_register_db(self) -> None:
+        srv = S7CommPlusServer()
+        db = srv.register_db(1, {"temp": ("Real", 0)})
+        assert db.number == 1
+        assert "temp" in db.variables
+        assert db.variables["temp"].byte_offset == 0
+
+    def test_register_raw_db(self) -> None:
+        srv = S7CommPlusServer()
+        data = bytearray(b"\x01\x02\x03\x04")
+        db = srv.register_raw_db(10, data)
+        assert db.read(0, 4) == b"\x01\x02\x03\x04"
+
+    def test_cpu_state(self) -> None:
+        srv = S7CommPlusServer()
+        assert srv.cpu_state == CPUState.RUN
+        srv.cpu_state = CPUState.STOP
+        assert srv.cpu_state == CPUState.STOP
+
+    def test_data_block_read_write(self) -> None:
+        db = DataBlock(1, 100)
+        db.write(0, b"\x01\x02\x03\x04")
+        assert db.read(0, 4) == b"\x01\x02\x03\x04"
+
+    def test_data_block_named_variable(self) -> None:
+        db = DataBlock(1, 100)
+        db.add_variable("temp", "Real", 0)
+        db.write(0, struct.pack(">f", 42.0))
+        wire_type, raw = db.read_variable("temp")
+        value = struct.unpack(">f", raw)[0]
+        assert abs(value - 42.0) < 0.001
+
+    def test_data_block_read_past_end(self) -> None:
+        db = DataBlock(1, 4)
+        db.write(0, b"\xFF\xFF\xFF\xFF")
+        # Read past end should pad with zeros
+        data = db.read(2, 4)
+        assert data == b"\xFF\xFF\x00\x00"
+
+    def test_unknown_variable_type(self) -> None:
+        db = DataBlock(1, 100)
+        with pytest.raises(ValueError, match="Unknown type name"):
+            db.add_variable("bad", "NonExistentType", 0)
+
+
+class TestClientServerIntegration:
+    """Test client against the server emulator."""
+
+    def test_connect_disconnect(self, server: S7CommPlusServer) -> None:
+        client = S7CommPlusClient()
+        client.connect("127.0.0.1", port=TEST_PORT)
+        assert client.connected
+        assert client.session_id != 0
+        assert client.protocol_version == ProtocolVersion.V1
+        client.disconnect()
+        assert not client.connected
+
+    def test_context_manager(self, server: S7CommPlusServer) -> None:
+        with S7CommPlusClient() as client:
+            client.connect("127.0.0.1", port=TEST_PORT)
+            assert client.connected
+        assert not client.connected
+
+    def test_read_real(self, server: S7CommPlusServer) -> None:
+        client = S7CommPlusClient()
+        client.connect("127.0.0.1", port=TEST_PORT)
+        try:
+            data = client.db_read(1, 0, 4)
+            value = struct.unpack(">f", data)[0]
+            assert abs(value - 23.5) < 0.001
+        finally:
+            client.disconnect()
+
+    def test_read_multiple_values(self, server: S7CommPlusServer) -> None:
+        client = S7CommPlusClient()
+        client.connect("127.0.0.1", port=TEST_PORT)
+        try:
+            # Read temperature and pressure
+            data = client.db_read(1, 0, 8)
+            temp = struct.unpack_from(">f", data, 0)[0]
+            pressure = struct.unpack_from(">f", data, 4)[0]
+            assert abs(temp - 23.5) < 0.001
+            assert abs(pressure - 1.013) < 0.001
+        finally:
+            client.disconnect()
+
+    def test_write_and_read_back(self, server: S7CommPlusServer) -> None:
+        client = S7CommPlusClient()
+        client.connect("127.0.0.1", port=TEST_PORT)
+        try:
+            # Write a new temperature
+            client.db_write(1, 0, struct.pack(">f", 99.9))
+
+            # Read it back
+            data = client.db_read(1, 0, 4)
+            value = struct.unpack(">f", data)[0]
+            assert abs(value - 99.9) < 0.1
+        finally:
+            client.disconnect()
+
+    def test_write_dint(self, server: S7CommPlusServer) -> None:
+        client = S7CommPlusClient()
+        client.connect("127.0.0.1", port=TEST_PORT)
+        try:
+            # Write count
+            client.db_write(1, 10, struct.pack(">i", 12345))
+
+            # Read it back
+            data = client.db_read(1, 10, 4)
+            value = struct.unpack(">i", data)[0]
+            assert value == 12345
+        finally:
+            client.disconnect()
+
+    def test_read_db2_raw(self, server: S7CommPlusServer) -> None:
+        client = S7CommPlusClient()
+        client.connect("127.0.0.1", port=TEST_PORT)
+        try:
+            # DB2 should be all zeros
+            data = client.db_read(2, 0, 10)
+            assert data == b"\x00" * 10
+        finally:
+            client.disconnect()
+
+    def test_multi_read(self, server: S7CommPlusServer) -> None:
+        client = S7CommPlusClient()
+        client.connect("127.0.0.1", port=TEST_PORT)
+        try:
+            results = client.db_read_multi([
+                (1, 0, 4),   # temperature from DB1
+                (1, 4, 4),   # pressure from DB1
+                (2, 0, 4),   # zeros from DB2
+            ])
+            assert len(results) == 3
+            temp = struct.unpack(">f", results[0])[0]
+            assert abs(temp - 23.5) < 0.001
+            assert results[2] == b"\x00\x00\x00\x00"
+        finally:
+            client.disconnect()
+
+    def test_explore(self, server: S7CommPlusServer) -> None:
+        client = S7CommPlusClient()
+        client.connect("127.0.0.1", port=TEST_PORT)
+        try:
+            response = client.explore()
+            # Response should contain data about registered DBs
+            assert len(response) > 0
+        finally:
+            client.disconnect()
+
+    def test_server_data_persists_across_clients(
+        self, server: S7CommPlusServer
+    ) -> None:
+        # Client 1 writes
+        c1 = S7CommPlusClient()
+        c1.connect("127.0.0.1", port=TEST_PORT)
+        c1.db_write(2, 0, b"\xDE\xAD\xBE\xEF")
+        c1.disconnect()
+
+        # Client 2 reads
+        c2 = S7CommPlusClient()
+        c2.connect("127.0.0.1", port=TEST_PORT)
+        data = c2.db_read(2, 0, 4)
+        c2.disconnect()
+
+        assert data == b"\xDE\xAD\xBE\xEF"
+
+    def test_multiple_concurrent_clients(
+        self, server: S7CommPlusServer
+    ) -> None:
+        clients = []
+        for _ in range(3):
+            c = S7CommPlusClient()
+            c.connect("127.0.0.1", port=TEST_PORT)
+            clients.append(c)
+
+        # All should have different session IDs
+        session_ids = {c.session_id for c in clients}
+        assert len(session_ids) == 3
+
+        for c in clients:
+            c.disconnect()
+
+
+@pytest.mark.asyncio
+class TestAsyncClientServerIntegration:
+    """Test async client against the server emulator."""
+
+    async def test_connect_disconnect(self, server: S7CommPlusServer) -> None:
+        client = S7CommPlusAsyncClient()
+        await client.connect("127.0.0.1", port=TEST_PORT)
+        assert client.connected
+        assert client.session_id != 0
+        await client.disconnect()
+        assert not client.connected
+
+    async def test_async_context_manager(self, server: S7CommPlusServer) -> None:
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+            assert client.connected
+        assert not client.connected
+
+    async def test_read_real(self, server: S7CommPlusServer) -> None:
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+            data = await client.db_read(1, 0, 4)
+            value = struct.unpack(">f", data)[0]
+            assert abs(value - 23.5) < 0.001
+
+    async def test_write_and_read_back(self, server: S7CommPlusServer) -> None:
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+            await client.db_write(1, 0, struct.pack(">f", 77.7))
+            data = await client.db_read(1, 0, 4)
+            value = struct.unpack(">f", data)[0]
+            assert abs(value - 77.7) < 0.1
+
+    async def test_multi_read(self, server: S7CommPlusServer) -> None:
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+            results = await client.db_read_multi([
+                (1, 0, 4),
+                (1, 10, 4),
+            ])
+            assert len(results) == 2
+            temp = struct.unpack(">f", results[0])[0]
+            assert abs(temp - 23.5) < 0.1  # May be modified by earlier test
+
+    async def test_explore(self, server: S7CommPlusServer) -> None:
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+            response = await client.explore()
+            assert len(response) > 0
+
+    async def test_concurrent_reads(self, server: S7CommPlusServer) -> None:
+        """Test that asyncio.Lock prevents interleaved requests."""
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+
+            async def read_temp() -> float:
+                data = await client.db_read(1, 0, 4)
+                return struct.unpack(">f", data)[0]
+
+            # Fire multiple concurrent reads
+            results = await asyncio.gather(
+                read_temp(), read_temp(), read_temp()
+            )
+            # All should succeed (lock serializes them)
+            assert len(results) == 3
+            for r in results:
+                assert isinstance(r, float)

--- a/tests/test_s7commplus_vlq.py
+++ b/tests/test_s7commplus_vlq.py
@@ -1,0 +1,161 @@
+"""Tests for S7CommPlus VLQ (Variable-Length Quantity) encoding."""
+
+import pytest
+
+from snap7.s7commplus.vlq import (
+    encode_uint32_vlq,
+    decode_uint32_vlq,
+    encode_int32_vlq,
+    decode_int32_vlq,
+    encode_uint64_vlq,
+    decode_uint64_vlq,
+    encode_int64_vlq,
+    decode_int64_vlq,
+)
+
+
+class TestUInt32Vlq:
+    """Test unsigned 32-bit VLQ encoding/decoding."""
+
+    @pytest.mark.parametrize(
+        "value, expected_bytes",
+        [
+            (0, bytes([0x00])),
+            (1, bytes([0x01])),
+            (0x7F, bytes([0x7F])),
+            (0x80, bytes([0x81, 0x00])),
+            (0xFF, bytes([0x81, 0x7F])),
+            (0x100, bytes([0x82, 0x00])),
+            (0x3FFF, bytes([0xFF, 0x7F])),
+            (0x4000, bytes([0x81, 0x80, 0x00])),
+        ],
+    )
+    def test_encode_known_values(self, value: int, expected_bytes: bytes) -> None:
+        assert encode_uint32_vlq(value) == expected_bytes
+
+    @pytest.mark.parametrize(
+        "value",
+        [0, 1, 127, 128, 255, 256, 16383, 16384, 0xFFFF, 0xFFFFFF, 0xFFFFFFFF],
+    )
+    def test_roundtrip(self, value: int) -> None:
+        encoded = encode_uint32_vlq(value)
+        decoded, consumed = decode_uint32_vlq(encoded)
+        assert decoded == value
+        assert consumed == len(encoded)
+
+    def test_decode_with_offset(self) -> None:
+        prefix = bytes([0xAA, 0xBB])
+        encoded = encode_uint32_vlq(12345)
+        data = prefix + encoded
+        decoded, consumed = decode_uint32_vlq(data, offset=2)
+        assert decoded == 12345
+
+    def test_encode_out_of_range(self) -> None:
+        with pytest.raises(ValueError):
+            encode_uint32_vlq(-1)
+        with pytest.raises(ValueError):
+            encode_uint32_vlq(0x100000000)
+
+    def test_decode_truncated(self) -> None:
+        # Continuation bit set but no more data
+        with pytest.raises(ValueError):
+            decode_uint32_vlq(bytes([0x80]))
+
+
+class TestInt32Vlq:
+    """Test signed 32-bit VLQ encoding/decoding."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [0, 1, -1, 63, -64, 64, -65, 127, -128, 0x7FFFFFFF, -0x80000000, 1234567, -1234567],
+    )
+    def test_roundtrip(self, value: int) -> None:
+        encoded = encode_int32_vlq(value)
+        decoded, consumed = decode_int32_vlq(encoded)
+        assert decoded == value
+        assert consumed == len(encoded)
+
+    def test_negative_one(self) -> None:
+        """Test that -1 encodes compactly."""
+        encoded = encode_int32_vlq(-1)
+        decoded, _ = decode_int32_vlq(encoded)
+        assert decoded == -1
+
+    def test_min_value(self) -> None:
+        """Test INT32_MIN boundary."""
+        encoded = encode_int32_vlq(-0x80000000)
+        decoded, _ = decode_int32_vlq(encoded)
+        assert decoded == -0x80000000
+
+    def test_encode_out_of_range(self) -> None:
+        with pytest.raises(ValueError):
+            encode_int32_vlq(-0x80000001)
+        with pytest.raises(ValueError):
+            encode_int32_vlq(0x80000000)
+
+
+class TestUInt64Vlq:
+    """Test unsigned 64-bit VLQ encoding/decoding."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            0,
+            1,
+            127,
+            128,
+            0xFFFF,
+            0xFFFFFFFF,
+            0xFFFFFFFFFF,
+            0x00FFFFFFFFFFFFFF,  # Just below the special threshold
+            0x00FFFFFFFFFFFFFF + 1,  # At the special threshold
+            0xFFFFFFFFFFFFFFFF,  # Max uint64
+        ],
+    )
+    def test_roundtrip(self, value: int) -> None:
+        encoded = encode_uint64_vlq(value)
+        decoded, consumed = decode_uint64_vlq(encoded)
+        assert decoded == value
+        assert consumed == len(encoded)
+
+    def test_max_encoding_length(self) -> None:
+        """Max uint64 should encode in at most 9 bytes."""
+        encoded = encode_uint64_vlq(0xFFFFFFFFFFFFFFFF)
+        assert len(encoded) <= 9
+
+    def test_encode_out_of_range(self) -> None:
+        with pytest.raises(ValueError):
+            encode_uint64_vlq(-1)
+        with pytest.raises(ValueError):
+            encode_uint64_vlq(0x10000000000000000)
+
+
+class TestInt64Vlq:
+    """Test signed 64-bit VLQ encoding/decoding."""
+
+    @pytest.mark.parametrize(
+        "value",
+        [
+            0,
+            1,
+            -1,
+            63,
+            -64,
+            127,
+            -128,
+            0x7FFFFFFFFFFFFFFF,  # Max int64
+            -0x8000000000000000,  # Min int64
+            123456789012345,
+            -123456789012345,
+        ],
+    )
+    def test_roundtrip(self, value: int) -> None:
+        encoded = encode_int64_vlq(value)
+        decoded, consumed = decode_int64_vlq(encoded)
+        assert decoded == value
+        assert consumed == len(encoded)
+
+    def test_max_encoding_length(self) -> None:
+        """Max/min int64 should encode in at most 9 bytes."""
+        assert len(encode_int64_vlq(0x7FFFFFFFFFFFFFFF)) <= 9
+        assert len(encode_int64_vlq(-0x8000000000000000)) <= 9

--- a/uv.lock
+++ b/uv.lock
@@ -36,11 +36,11 @@ wheels = [
 
 [[package]]
 name = "cachetools"
-version = "7.0.4"
+version = "7.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/cc/eb3fd22f3b96b8b70ce456d0854ef08434e5ca79c02bf8db3fc07ccfca87/cachetools-7.0.4.tar.gz", hash = "sha256:7042c0e4eea87812f04744ce6ee9ed3de457875eb1f82d8a206c46d6e48b6734", size = 37379, upload-time = "2026-03-08T21:37:17.133Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d4/07/56595285564e90777d758ebd383d6b0b971b87729bbe2184a849932a3736/cachetools-7.0.1.tar.gz", hash = "sha256:e31e579d2c5b6e2944177a0397150d312888ddf4e16e12f1016068f0c03b8341", size = 36126, upload-time = "2026-02-10T22:24:05.03Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/bc/72adfb3f2ed19eb0317f89ea9b1eeccc670ae46bc394ec2c4ba1dd8c22b7/cachetools-7.0.4-py3-none-any.whl", hash = "sha256:0c8bb1b9ec8194fa4d764accfde602dfe52f70d0f311e62792d4c3f8c051b1e9", size = 13900, upload-time = "2026-03-08T21:37:15.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/9e/5faefbf9db1db466d633735faceda1f94aa99ce506ac450d232536266b32/cachetools-7.0.1-py3-none-any.whl", hash = "sha256:8f086515c254d5664ae2146d14fc7f65c9a4bce75152eb247e5a9c5e6d7b2ecf", size = 13484, upload-time = "2026-02-10T22:24:03.741Z" },
 ]
 
 [[package]]
@@ -328,11 +328,11 @@ wheels = [
 
 [[package]]
 name = "filelock"
-version = "3.25.0"
+version = "3.24.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/18/a1fd2231c679dcb9726204645721b12498aeac28e1ad0601038f94b42556/filelock-3.25.0.tar.gz", hash = "sha256:8f00faf3abf9dc730a1ffe9c354ae5c04e079ab7d3a683b7c32da5dd05f26af3", size = 40158, upload-time = "2026-03-01T15:08:45.916Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/73/92/a8e2479937ff39185d20dd6a851c1a63e55849e447a55e798cc2e1f49c65/filelock-3.24.3.tar.gz", hash = "sha256:011a5644dc937c22699943ebbfc46e969cdde3e171470a6e40b9533e5a72affa", size = 37935, upload-time = "2026-02-19T00:48:20.543Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/0b/de6f54d4a8bedfe8645c41497f3c18d749f0bd3218170c667bf4b81d0cdd/filelock-3.25.0-py3-none-any.whl", hash = "sha256:5ccf8069f7948f494968fc0713c10e5c182a9c9d9eef3a636307a20c2490f047", size = 26427, upload-time = "2026-03-01T15:08:44.593Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/0f/5d0c71a1aefeb08efff26272149e07ab922b64f46c63363756224bd6872e/filelock-3.24.3-py3-none-any.whl", hash = "sha256:426e9a4660391f7f8a810d71b0555bce9008b0a1cc342ab1f6947d37639e002d", size = 24331, upload-time = "2026-02-19T00:48:18.465Z" },
 ]
 
 [[package]]
@@ -640,11 +640,11 @@ wheels = [
 
 [[package]]
 name = "platformdirs"
-version = "4.9.4"
+version = "4.9.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/56/8d4c30c8a1d07013911a8fdbd8f89440ef9f08d07a1b50ab8ca8be5a20f9/platformdirs-4.9.4.tar.gz", hash = "sha256:1ec356301b7dc906d83f371c8f487070e99d3ccf9e501686456394622a01a934", size = 28737, upload-time = "2026-03-05T18:34:13.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/04/fea538adf7dbbd6d186f551d595961e564a3b6715bdf276b477460858672/platformdirs-4.9.2.tar.gz", hash = "sha256:9a33809944b9db043ad67ca0db94b14bf452cc6aeaac46a88ea55b26e2e9d291", size = 28394, upload-time = "2026-02-16T03:56:10.574Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/d7/97f7e3a6abb67d8080dd406fd4df842c2be0efaf712d1c899c32a075027c/platformdirs-4.9.4-py3-none-any.whl", hash = "sha256:68a9a4619a666ea6439f2ff250c12a853cd1cbd5158d258bd824a7df6be2f868", size = 21216, upload-time = "2026-03-05T18:34:12.172Z" },
+    { url = "https://files.pythonhosted.org/packages/48/31/05e764397056194206169869b50cf2fee4dbbbc71b344705b9c0d878d4d8/platformdirs-4.9.2-py3-none-any.whl", hash = "sha256:9170634f126f8efdae22fb58ae8a0eaa86f38365bc57897a6c4f781d1f5875bd", size = 21168, upload-time = "2026-02-16T03:56:08.891Z" },
 ]
 
 [[package]]
@@ -852,27 +852,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.6"
+version = "0.15.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/51/df/f8629c19c5318601d3121e230f74cbee7a3732339c52b21daa2b82ef9c7d/ruff-0.15.6.tar.gz", hash = "sha256:8394c7bb153a4e3811a4ecdacd4a8e6a4fa8097028119160dffecdcdf9b56ae4", size = 4597916, upload-time = "2026-03-12T23:05:47.51Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/31/d6e536cdebb6568ae75a7f00e4b4819ae0ad2640c3604c305a0428680b0c/ruff-0.15.4.tar.gz", hash = "sha256:3412195319e42d634470cc97aa9803d07e9d5c9223b99bcb1518f0c725f26ae1", size = 4569550, upload-time = "2026-02-26T20:04:14.959Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/2f/4e03a7e5ce99b517e98d3b4951f411de2b0fa8348d39cf446671adcce9a2/ruff-0.15.6-py3-none-linux_armv6l.whl", hash = "sha256:7c98c3b16407b2cf3d0f2b80c80187384bc92c6774d85fefa913ecd941256fff", size = 10508953, upload-time = "2026-03-12T23:05:17.246Z" },
-    { url = "https://files.pythonhosted.org/packages/70/60/55bcdc3e9f80bcf39edf0cd272da6fa511a3d94d5a0dd9e0adf76ceebdb4/ruff-0.15.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee7dcfaad8b282a284df4aa6ddc2741b3f4a18b0555d626805555a820ea181c3", size = 10942257, upload-time = "2026-03-12T23:05:23.076Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/f9/005c29bd1726c0f492bfa215e95154cf480574140cb5f867c797c18c790b/ruff-0.15.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3bd9967851a25f038fc8b9ae88a7fbd1b609f30349231dffaa37b6804923c4bb", size = 10322683, upload-time = "2026-03-12T23:05:33.738Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/74/2f861f5fd7cbb2146bddb5501450300ce41562da36d21868c69b7a828169/ruff-0.15.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:13f4594b04e42cd24a41da653886b04d2ff87adbf57497ed4f728b0e8a4866f8", size = 10660986, upload-time = "2026-03-12T23:05:53.245Z" },
-    { url = "https://files.pythonhosted.org/packages/c1/a1/309f2364a424eccb763cdafc49df843c282609f47fe53aa83f38272389e0/ruff-0.15.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e2ed8aea2f3fe57886d3f00ea5b8aae5bf68d5e195f487f037a955ff9fbaac9e", size = 10332177, upload-time = "2026-03-12T23:05:56.145Z" },
-    { url = "https://files.pythonhosted.org/packages/30/41/7ebf1d32658b4bab20f8ac80972fb19cd4e2c6b78552be263a680edc55ac/ruff-0.15.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:70789d3e7830b848b548aae96766431c0dc01a6c78c13381f423bf7076c66d15", size = 11170783, upload-time = "2026-03-12T23:06:01.742Z" },
-    { url = "https://files.pythonhosted.org/packages/76/be/6d488f6adca047df82cd62c304638bcb00821c36bd4881cfca221561fdfc/ruff-0.15.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:542aaf1de3154cea088ced5a819ce872611256ffe2498e750bbae5247a8114e9", size = 12044201, upload-time = "2026-03-12T23:05:28.697Z" },
-    { url = "https://files.pythonhosted.org/packages/71/68/e6f125df4af7e6d0b498f8d373274794bc5156b324e8ab4bf5c1b4fc0ec7/ruff-0.15.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1c22e6f02c16cfac3888aa636e9eba857254d15bbacc9906c9689fdecb1953ab", size = 11421561, upload-time = "2026-03-12T23:05:31.236Z" },
-    { url = "https://files.pythonhosted.org/packages/f1/9f/f85ef5fd01a52e0b472b26dc1b4bd228b8f6f0435975442ffa4741278703/ruff-0.15.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:98893c4c0aadc8e448cfa315bd0cc343a5323d740fe5f28ef8a3f9e21b381f7e", size = 11310928, upload-time = "2026-03-12T23:05:45.288Z" },
-    { url = "https://files.pythonhosted.org/packages/8c/26/b75f8c421f5654304b89471ed384ae8c7f42b4dff58fa6ce1626d7f2b59a/ruff-0.15.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:70d263770d234912374493e8cc1e7385c5d49376e41dfa51c5c3453169dc581c", size = 11235186, upload-time = "2026-03-12T23:05:50.677Z" },
-    { url = "https://files.pythonhosted.org/packages/fc/d4/d5a6d065962ff7a68a86c9b4f5500f7d101a0792078de636526c0edd40da/ruff-0.15.6-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:55a1ad63c5a6e54b1f21b7514dfadc0c7fb40093fa22e95143cf3f64ebdcd512", size = 10635231, upload-time = "2026-03-12T23:05:37.044Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/56/7c3acf3d50910375349016cf33de24be021532042afbed87942858992491/ruff-0.15.6-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:8dc473ba093c5ec238bb1e7429ee676dca24643c471e11fbaa8a857925b061c0", size = 10340357, upload-time = "2026-03-12T23:06:04.748Z" },
-    { url = "https://files.pythonhosted.org/packages/06/54/6faa39e9c1033ff6a3b6e76b5df536931cd30caf64988e112bbf91ef5ce5/ruff-0.15.6-py3-none-musllinux_1_2_i686.whl", hash = "sha256:85b042377c2a5561131767974617006f99f7e13c63c111b998f29fc1e58a4cfb", size = 10860583, upload-time = "2026-03-12T23:05:58.978Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/1e/509a201b843b4dfb0b32acdedf68d951d3377988cae43949ba4c4133a96a/ruff-0.15.6-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:cef49e30bc5a86a6a92098a7fbf6e467a234d90b63305d6f3ec01225a9d092e0", size = 11410976, upload-time = "2026-03-12T23:05:39.955Z" },
-    { url = "https://files.pythonhosted.org/packages/6c/25/3fc9114abf979a41673ce877c08016f8e660ad6cf508c3957f537d2e9fa9/ruff-0.15.6-py3-none-win32.whl", hash = "sha256:bbf67d39832404812a2d23020dda68fee7f18ce15654e96fb1d3ad21a5fe436c", size = 10616872, upload-time = "2026-03-12T23:05:42.451Z" },
-    { url = "https://files.pythonhosted.org/packages/89/7a/09ece68445ceac348df06e08bf75db72d0e8427765b96c9c0ffabc1be1d9/ruff-0.15.6-py3-none-win_amd64.whl", hash = "sha256:aee25bc84c2f1007ecb5037dff75cef00414fdf17c23f07dc13e577883dca406", size = 11787271, upload-time = "2026-03-12T23:05:20.168Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/d0/578c47dd68152ddddddf31cd7fc67dc30b7cdf639a86275fda821b0d9d98/ruff-0.15.6-py3-none-win_arm64.whl", hash = "sha256:c34de3dd0b0ba203be50ae70f5910b17188556630e2178fd7d79fc030eb0d837", size = 11060497, upload-time = "2026-03-12T23:05:25.968Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/82/c11a03cfec3a4d26a0ea1e571f0f44be5993b923f905eeddfc397c13d360/ruff-0.15.4-py3-none-linux_armv6l.whl", hash = "sha256:a1810931c41606c686bae8b5b9a8072adac2f611bb433c0ba476acba17a332e0", size = 10453333, upload-time = "2026-02-26T20:04:20.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/5d/6a1f271f6e31dffb31855996493641edc3eef8077b883eaf007a2f1c2976/ruff-0.15.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5a1632c66672b8b4d3e1d1782859e98d6e0b4e70829530666644286600a33992", size = 10853356, upload-time = "2026-02-26T20:04:05.808Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d8/0fab9f8842b83b1a9c2bf81b85063f65e93fb512e60effa95b0be49bfc54/ruff-0.15.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a4386ba2cd6c0f4ff75252845906acc7c7c8e1ac567b7bc3d373686ac8c222ba", size = 10187434, upload-time = "2026-02-26T20:03:54.656Z" },
+    { url = "https://files.pythonhosted.org/packages/85/cc/cc220fd9394eff5db8d94dec199eec56dd6c9f3651d8869d024867a91030/ruff-0.15.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2496488bdfd3732747558b6f95ae427ff066d1fcd054daf75f5a50674411e75", size = 10535456, upload-time = "2026-02-26T20:03:52.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/0f/bced38fa5cf24373ec767713c8e4cadc90247f3863605fb030e597878661/ruff-0.15.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3f1c4893841ff2d54cbda1b2860fa3260173df5ddd7b95d370186f8a5e66a4ac", size = 10287772, upload-time = "2026-02-26T20:04:08.138Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/90/58a1802d84fed15f8f281925b21ab3cecd813bde52a8ca033a4de8ab0e7a/ruff-0.15.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:820b8766bd65503b6c30aaa6331e8ef3a6e564f7999c844e9a547c40179e440a", size = 11049051, upload-time = "2026-02-26T20:04:03.53Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ac/b7ad36703c35f3866584564dc15f12f91cb1a26a897dc2fd13d7cb3ae1af/ruff-0.15.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9fb74bab47139c1751f900f857fa503987253c3ef89129b24ed375e72873e85", size = 11890494, upload-time = "2026-02-26T20:04:10.497Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/3eb2f47a39a8b0da99faf9c54d3eb24720add1e886a5309d4d1be73a6380/ruff-0.15.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f80c98765949c518142b3a50a5db89343aa90f2c2bf7799de9986498ae6176db", size = 11326221, upload-time = "2026-02-26T20:04:12.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/90/bf134f4c1e5243e62690e09d63c55df948a74084c8ac3e48a88468314da6/ruff-0.15.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:451a2e224151729b3b6c9ffb36aed9091b2996fe4bdbd11f47e27d8f2e8888ec", size = 11168459, upload-time = "2026-02-26T20:04:00.969Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e5/a64d27688789b06b5d55162aafc32059bb8c989c61a5139a36e1368285eb/ruff-0.15.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a8f157f2e583c513c4f5f896163a93198297371f34c04220daf40d133fdd4f7f", size = 11104366, upload-time = "2026-02-26T20:03:48.099Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f6/32d1dcb66a2559763fc3027bdd65836cad9eb09d90f2ed6a63d8e9252b02/ruff-0.15.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:917cc68503357021f541e69b35361c99387cdbbf99bd0ea4aa6f28ca99ff5338", size = 10510887, upload-time = "2026-02-26T20:03:45.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/92/22d1ced50971c5b6433aed166fcef8c9343f567a94cf2b9d9089f6aa80fe/ruff-0.15.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e9737c8161da79fd7cfec19f1e35620375bd8b2a50c3e77fa3d2c16f574105cc", size = 10285939, upload-time = "2026-02-26T20:04:22.42Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f4/7c20aec3143837641a02509a4668fb146a642fd1211846634edc17eb5563/ruff-0.15.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:291258c917539e18f6ba40482fe31d6f5ac023994ee11d7bdafd716f2aab8a68", size = 10765471, upload-time = "2026-02-26T20:03:58.924Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/09/6d2f7586f09a16120aebdff8f64d962d7c4348313c77ebb29c566cefc357/ruff-0.15.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3f83c45911da6f2cd5936c436cf86b9f09f09165f033a99dcf7477e34041cbc3", size = 11263382, upload-time = "2026-02-26T20:04:24.424Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/fa/2ef715a1cd329ef47c1a050e10dee91a9054b7ce2fcfdd6a06d139afb7ec/ruff-0.15.4-py3-none-win32.whl", hash = "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22", size = 10506664, upload-time = "2026-02-26T20:03:50.56Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a8/c688ef7e29983976820d18710f955751d9f4d4eb69df658af3d006e2ba3e/ruff-0.15.4-py3-none-win_amd64.whl", hash = "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f", size = 11651048, upload-time = "2026-02-26T20:04:17.191Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0a/9e1be9035b37448ce2e68c978f0591da94389ade5a5abafa4cf99985d1b2/ruff-0.15.4-py3-none-win_arm64.whl", hash = "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453", size = 10966776, upload-time = "2026-02-26T20:03:56.908Z" },
 ]
 
 [[package]]
@@ -1117,17 +1117,8 @@ wheels = [
 ]
 
 [[package]]
-name = "tomli-w"
-version = "1.2.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
-]
-
-[[package]]
 name = "tox"
-version = "4.49.1"
+version = "4.46.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cachetools" },
@@ -1138,39 +1129,38 @@ dependencies = [
     { name = "pluggy" },
     { name = "pyproject-api" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
-    { name = "tomli-w" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "virtualenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2a/e8/6f7dac9ab53a03b79d5dda2dd462147341069f70b138e1c7ac04219e72ea/tox-4.49.1.tar.gz", hash = "sha256:4130d02e1d53648d7107d121ed79f69a27b717817c5e9da521d50319dd261212", size = 260048, upload-time = "2026-03-09T22:44:10.504Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/45/03/10faee6ee03437867cd76198afd22dc5af3fca61d9b9b5a8d8cff1952db2/tox-4.46.3.tar.gz", hash = "sha256:2e87609b7832c818cad093304ea23d7eb124f8ecbab0625463b73ce5e850e1c2", size = 250933, upload-time = "2026-02-25T15:48:33.542Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a4/ac/44201a13332b2f477ba43ca1e835844d8c3abb678e664333a82bc25bbdea/tox-4.49.1-py3-none-any.whl", hash = "sha256:6dd2d7d4e4fd5895ce4ea20e258fce0d4b81e914b697d116a5ab0365f8303bad", size = 206912, upload-time = "2026-03-09T22:44:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/03/c2/d0e0d9700f9e2a6f20361c59c9fc044c1efebcdc5f13cbf353dd7d112410/tox-4.46.3-py3-none-any.whl", hash = "sha256:e9e1a91bce2836dba8169c005254913bd22aac490131c75a5ffc4fd091dffe0b", size = 201424, upload-time = "2026-02-25T15:48:31.684Z" },
 ]
 
 [[package]]
 name = "tox-uv"
-version = "1.33.4"
+version = "1.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "tox-uv-bare" },
     { name = "uv" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/60/f3419045763389b7c1645753ccab1917c8758b0a95b6bad01fed479a9d5b/tox_uv-1.33.4-py3-none-any.whl", hash = "sha256:fe63d7597a0aac6116e06c0f1366b0925bc94b0b92b62a9ec5a9f3e4c17ad5b2", size = 5482, upload-time = "2026-03-12T21:20:54.221Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/67/736f40388b5e1d1b828b236014be7dd3d62a10642122763e6928d950edad/tox_uv-1.33.0-py3-none-any.whl", hash = "sha256:bb3055599940f111f3dead552dd7560b94339175ec58ffa7628ef59fad760d91", size = 5363, upload-time = "2026-02-25T13:22:52.186Z" },
 ]
 
 [[package]]
 name = "tox-uv-bare"
-version = "1.33.4"
+version = "1.33.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "packaging" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "tox" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/56/12f8602a3207b87825564939a4956941c6ddac2f1ac714967926ebb5c9b0/tox_uv_bare-1.33.4.tar.gz", hash = "sha256:310726bd445557f411e7b3096075378c5aac39bb9aa984651a40836f8c988703", size = 27452, upload-time = "2026-03-12T21:20:57.007Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/07/e8/f927b6cb26dae64732cb8c31f20be009d264ecf34751e72cf8ae7c7db17b/tox_uv_bare-1.33.0.tar.gz", hash = "sha256:34d8484a36ad121257f22823df154c246d831b84b01df91c4369a56cb4689d2e", size = 26995, upload-time = "2026-02-25T13:22:54.9Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b7/0d/9d47b320eec0013f7cedb3f340f965e11b8071350b01d5d6e3b301a3e558/tox_uv_bare-1.33.4-py3-none-any.whl", hash = "sha256:fab00d5b0097cdee6607ce0f79326e6c1a8828097b63ab8cb4f327cb132e5fbf", size = 19669, upload-time = "2026-03-12T21:20:55.638Z" },
+    { url = "https://files.pythonhosted.org/packages/32/e5/0cae08b6c2908b4b8e51a91adaead58d06fd2393333aadc88c9a448da2c3/tox_uv_bare-1.33.0-py3-none-any.whl", hash = "sha256:80b5c1f4f5eda2dfd3a9de569665ad2dccdfb128ed1ee9f69c1dacfd100f6b4a", size = 19528, upload-time = "2026-02-25T13:22:53.269Z" },
 ]
 
 [[package]]
@@ -1211,33 +1201,32 @@ wheels = [
 
 [[package]]
 name = "uv"
-version = "0.10.10"
+version = "0.10.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/22/21476e738938bbb36fa0029d369c6989ade90039110a7013a24f4c6211c0/uv-0.10.10.tar.gz", hash = "sha256:266b24bf85aa021af37d3fb22d84ef40746bc4da402e737e365b12badff60e89", size = 3976117, upload-time = "2026-03-13T20:04:44.335Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/53/7a4274dad70b1d17efb99e36d45fc1b5e4e1e531b43247e518604394c761/uv-0.10.6.tar.gz", hash = "sha256:de86e5e1eb264e74a20fccf56889eea2463edb5296f560958e566647c537b52e", size = 3921763, upload-time = "2026-02-25T00:26:27.066Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7a/2b/2cbc9ebc53dc84ad698c31583735605eb55627109af59d9d3424eb824935/uv-0.10.10-py3-none-linux_armv6l.whl", hash = "sha256:2c89017c0532224dc1ec6f3be1bc4ec3d8c3f291c23a229e8a40e3cc5828f599", size = 22712805, upload-time = "2026-03-13T20:03:36.034Z" },
-    { url = "https://files.pythonhosted.org/packages/14/44/4e8db982a986a08808cc5236e73c12bd6619823b3be41c9d6322d4746ebd/uv-0.10.10-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:ee47b5bc1b8ccd246a3801611b2b71c8107db3a2b528e64463d737fd8e4f2798", size = 21857826, upload-time = "2026-03-13T20:03:52.852Z" },
-    { url = "https://files.pythonhosted.org/packages/6f/98/aca12549cafc4c0346b04f8fed7f7ee3bfc2231b45b7e59d062d5b519746/uv-0.10.10-py3-none-macosx_11_0_arm64.whl", hash = "sha256:009a4c534e83bada52c8e2cccea6250e3486d01d609e4eb874cd302e2e534269", size = 20381437, upload-time = "2026-03-13T20:04:00.735Z" },
-    { url = "https://files.pythonhosted.org/packages/93/c4/f3f832e4871b2bb86423c4cdbbd40b10c835a426449e86951f992d63120a/uv-0.10.10-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:5dd85cc8ff9fa967c02c3edbf2b77d54b56bedcb56b323edec0df101f37f26e2", size = 22334006, upload-time = "2026-03-13T20:04:32.887Z" },
-    { url = "https://files.pythonhosted.org/packages/75/e1/852d1eb2630410f465287e858c93b2f2c81b668b7fa63c3f05356896706d/uv-0.10.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:49235f8a745ef10eea24b2f07be1ee77da056792cef897630b78c391c5f1e2e4", size = 22303994, upload-time = "2026-03-13T20:04:04.849Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/39/1678ed510b7ee6d68048460c428ca26d57cc798ca34d4775e113e7801144/uv-0.10.10-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f97709570158efc87d52ddca90f2c96293eea382d81be295b1fd7088153d6a83", size = 22301619, upload-time = "2026-03-13T20:03:40.56Z" },
-    { url = "https://files.pythonhosted.org/packages/81/2f/e4137b7f3f07c0cc1597b49c341b30f09cea13dbe57cd83ad14f5839dfff/uv-0.10.10-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:9c863fb46a62f3c8a1b7bc1520b0939c05cf4fab06e7233fc48ed17538e6601e", size = 23669879, upload-time = "2026-03-13T20:04:20.356Z" },
-    { url = "https://files.pythonhosted.org/packages/ff/11/44f7f067b7dcfc57e21500918a50e0f2d56b23acdc9b2148dbd4d07b5078/uv-0.10.10-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f56734baf7a8bd616da69cd7effe1a237c2cb364ec4feefe6a4b180f1cf5ec2", size = 24480854, upload-time = "2026-03-13T20:03:31.645Z" },
-    { url = "https://files.pythonhosted.org/packages/9c/b5/d2bed329892b5298c493709bc851346d9750bafed51f8ba2b31e7d3ae0cc/uv-0.10.10-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1085cc907a1315002015bc218cc88e42c5171a03a705421341cdb420400ee2f3", size = 23677933, upload-time = "2026-03-13T20:03:57.052Z" },
-    { url = "https://files.pythonhosted.org/packages/02/95/84166104b968c02c2bb54c32082d702d29beb24384fb3f13ade0cb2456fb/uv-0.10.10-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e42e9e4a196ef75d1089715574eb1fe9bb62d390da05c6c8b36650a4de23d59f", size = 23473055, upload-time = "2026-03-13T20:03:48.648Z" },
-    { url = "https://files.pythonhosted.org/packages/b9/b6/9cc6e5442e3734615b5dbf45dcacf94cd46a05b1d04066cbdb992701e6bf/uv-0.10.10-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:fbd827042dbdcadeb5e3418bee73ded9feb5ead8edac23e6e1b5dadb5a90f8b2", size = 22403569, upload-time = "2026-03-13T20:04:08.514Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/8c/2e0a3690603e86f8470bae3a27896a9f8b56677b5cd337d131c4d594e0dc/uv-0.10.10-py3-none-manylinux_2_31_riscv64.musllinux_1_1_riscv64.whl", hash = "sha256:41a3cc94e0c43070e48a521b6b26156ffde1cdc2088339891aa35eb2245ac5cf", size = 23309789, upload-time = "2026-03-13T20:03:44.764Z" },
-    { url = "https://files.pythonhosted.org/packages/24/e5/5af4d7426e39d7a7a751f8d1a7646d04e042a3c2c2c6aeb9d940ddc34df0/uv-0.10.10-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:8a59c80ade3aa20baf9ec5d17b6449f4fdba9212f6e3d1bdf2a6db94cbc64c21", size = 23329370, upload-time = "2026-03-13T20:04:24.525Z" },
-    { url = "https://files.pythonhosted.org/packages/3a/10/94b773933cd2e39aa9768dd11f85f32844e4dcb687c6df0714dfb3c0234a/uv-0.10.10-py3-none-musllinux_1_1_i686.whl", hash = "sha256:e77e52ba74e0085a1c03a16611146c6f813034787f83a2fd260cdc8357e18d2d", size = 22818945, upload-time = "2026-03-13T20:04:29.064Z" },
-    { url = "https://files.pythonhosted.org/packages/85/71/6fb74f35ef3afdb6b3f77e35a29a571a5c789e89d97ec5cb7fd1285eb48e/uv-0.10.10-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:4f9fd7f62df91c2d91c02e2039d4c5bad825077d04ebd27af8ea35a8cc736daf", size = 23667652, upload-time = "2026-03-13T20:04:41.239Z" },
-    { url = "https://files.pythonhosted.org/packages/df/7b/3042f2fb5bf7288cbe7f954ca64badb1243bbac207c0119b4a2cef561564/uv-0.10.10-py3-none-win32.whl", hash = "sha256:52e8b70a4fd7a734833c6a55714b679a10b29cf69b2e663e657df1995cf11c6a", size = 21778937, upload-time = "2026-03-13T20:04:37.11Z" },
-    { url = "https://files.pythonhosted.org/packages/89/c8/d314c4aab369aa105959a6b266e3e082a1252b8517564ea7a28b439726a2/uv-0.10.10-py3-none-win_amd64.whl", hash = "sha256:3da90c197e8e9f5d49862556fa9f4a9dd5b8617c0bbcc88585664e777209a315", size = 24176234, upload-time = "2026-03-13T20:04:16.406Z" },
-    { url = "https://files.pythonhosted.org/packages/e8/89/ea5852f4dadf01d6490131e5be88b2e12ea85b9cd5ffdc2efc933a3b6892/uv-0.10.10-py3-none-win_arm64.whl", hash = "sha256:3873b965d62b282ab51e328f4b15a760b32b11a7231dc3fe658fa11d98f20136", size = 22561685, upload-time = "2026-03-13T20:04:12.36Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/f9/faf599c6928dc00d941629260bef157dadb67e8ffb7f4b127b8601f41177/uv-0.10.6-py3-none-linux_armv6l.whl", hash = "sha256:2b46ad78c86d68de6ec13ffaa3a8923467f757574eeaf318e0fce0f63ff77d7a", size = 22412946, upload-time = "2026-02-25T00:26:10.826Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8f/82dd6aa8acd2e1b1ba12fd49210bd19843383538e0e63e8d7a23a7d39d93/uv-0.10.6-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a1d9873eb26cbef9138f8c52525bc3fd63be2d0695344cdcf84f0dc2838a6844", size = 21524262, upload-time = "2026-02-25T00:27:09.318Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/48/5767af19db6f21176e43dfde46ea04e33c49ba245ac2634e83db15d23c8f/uv-0.10.6-py3-none-macosx_11_0_arm64.whl", hash = "sha256:5a62cdf5ba356dcc792b960e744d67056b0e6d778ce7381e1d78182357bd82e8", size = 20184248, upload-time = "2026-02-25T00:26:20.281Z" },
+    { url = "https://files.pythonhosted.org/packages/27/1b/13c2fcdb776ae78b5c22eb2d34931bb3ef9bd71b9578b8fa7af8dd7c11c4/uv-0.10.6-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.musllinux_1_1_aarch64.whl", hash = "sha256:b70a04d51e2239b3aee0e4d4ed9af18c910360155953017cecded5c529588e65", size = 22049300, upload-time = "2026-02-25T00:26:07.039Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/43/348e2c378b3733eba15f6144b35a8c84af5c884232d6bbed29e256f74b6f/uv-0.10.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.musllinux_1_1_armv7l.whl", hash = "sha256:2b622059a1ae287f8b995dcb6f5548de83b89b745ff112801abbf09e25fd8fa9", size = 22030505, upload-time = "2026-02-25T00:26:46.171Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3f/dcec580099bc52f73036bfb09acb42616660733de1cc3f6c92287d2c7f3e/uv-0.10.6-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f43db1aa80776386646453c07d5590e1ae621f031a2afe6efba90f89c34c628c", size = 22041360, upload-time = "2026-02-25T00:26:53.725Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/96/f70abe813557d317998806517bb53b3caa5114591766db56ae9cc142ff39/uv-0.10.6-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4ca8a26694ba7d0ae902f11054734805741f2b080fe8397401b80c99264edab6", size = 23309916, upload-time = "2026-02-25T00:27:12.99Z" },
+    { url = "https://files.pythonhosted.org/packages/db/1d/d8b955937dd0153b48fdcfd5ff70210d26e4b407188e976df620572534fd/uv-0.10.6-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6f2cddae800d14159a9ccb4ff161648b0b0d1b31690d9c17076ec00f538c52ac", size = 24191174, upload-time = "2026-02-25T00:26:30.051Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/3d/3d0669d65bf4a270420d70ca0670917ce5c25c976c8b0acd52465852509b/uv-0.10.6-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:153fcf5375c988b2161bf3a6a7d9cc907d6bbe38f3cb16276da01b2dae4df72c", size = 23320328, upload-time = "2026-02-25T00:26:23.82Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f2/f2ccc2196fd6cf1321c2e8751a96afabcbc9509b184c671ece3e804effda/uv-0.10.6-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f27f2d135d4533f88537ecd254c72dfd25311d912da8649d15804284d70adb93", size = 23229798, upload-time = "2026-02-25T00:26:50.12Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/b9/1008266a041e8a55430a92aef8ecc58aaaa7eb7107a26cf4f7c127d14363/uv-0.10.6-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:dd993ec2bf5303a170946342955509559763cf8dcfe334ec7bb9f115a0f86021", size = 22143661, upload-time = "2026-02-25T00:26:42.507Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e4/1f8de7da5f844b4c9eafa616e262749cd4e3d9c685190b7967c4681869da/uv-0.10.6-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:8529e4d4aac40b4e7588177321cb332cc3309d36d7cc482470a1f6cfe7a7e14a", size = 22888045, upload-time = "2026-02-25T00:26:15.935Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/2b/03b840dd0101dc69ef6e83ceb2e2970e4b4f118291266cf3332a4b64092c/uv-0.10.6-py3-none-musllinux_1_1_i686.whl", hash = "sha256:ed9e16453a5f73ee058c566392885f445d00534dc9e754e10ab9f50f05eb27a5", size = 22549404, upload-time = "2026-02-25T00:27:05.333Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/4e/1ee4d4301874136a4b3bbd9eeba88da39f4bafa6f633b62aef77d8195c56/uv-0.10.6-py3-none-musllinux_1_1_x86_64.whl", hash = "sha256:33e5362039bfa91599df0b7487854440ffef1386ac681ec392d9748177fb1d43", size = 23426872, upload-time = "2026-02-25T00:26:35.01Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/e3/e000030118ff1a82ecfc6bd5af70949821edac739975a027994f5b17258f/uv-0.10.6-py3-none-win32.whl", hash = "sha256:fa7c504a1e16713b845d457421b07dd9c40f40d911ffca6897f97388de49df5a", size = 21501863, upload-time = "2026-02-25T00:26:57.182Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/cc/dd88c9f20c054ef0aea84ad1dd9f8b547463824857e4376463a948983bed/uv-0.10.6-py3-none-win_amd64.whl", hash = "sha256:ecded4d21834b21002bc6e9a2628d21f5c8417fd77a5db14250f1101bcb69dac", size = 23981891, upload-time = "2026-02-25T00:26:38.773Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/06/ca117002cd64f6701359253d8566ec7a0edcf61715b4969f07ee41d06f61/uv-0.10.6-py3-none-win_arm64.whl", hash = "sha256:4b5688625fc48565418c56a5cd6c8c32020dbb7c6fb7d10864c2d2c93c508302", size = 22339889, upload-time = "2026-02-25T00:27:00.818Z" },
 ]
 
 [[package]]
 name = "virtualenv"
-version = "21.2.0"
+version = "21.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "distlib" },
@@ -1246,7 +1235,7 @@ dependencies = [
     { name = "python-discovery" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/aa/92/58199fe10049f9703c2666e809c4f686c54ef0a68b0f6afccf518c0b1eb9/virtualenv-21.2.0.tar.gz", hash = "sha256:1720dc3a62ef5b443092e3f499228599045d7fea4c79199770499df8becf9098", size = 5840618, upload-time = "2026-03-09T17:24:38.013Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/4f/d6a5ff3b020c801c808b14e2d2330cdc8ebefe1cdfbc457ecc368e971fec/virtualenv-21.0.0.tar.gz", hash = "sha256:e8efe4271b4a5efe7a4dce9d60a05fd11859406c0d6aa8464f4cf451bc132889", size = 5836591, upload-time = "2026-02-25T20:21:07.691Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c6/59/7d02447a55b2e55755011a647479041bc92a82e143f96a8195cb33bd0a1c/virtualenv-21.2.0-py3-none-any.whl", hash = "sha256:1bd755b504931164a5a496d217c014d098426cddc79363ad66ac78125f9d908f", size = 5825084, upload-time = "2026-03-09T17:24:35.378Z" },
+    { url = "https://files.pythonhosted.org/packages/29/d1/3f62e4f9577b28c352c11623a03fb916096d5c131303d4861b4914481b6b/virtualenv-21.0.0-py3-none-any.whl", hash = "sha256:d44e70637402c7f4b10f48491c02a6397a3a187152a70cba0b6bc7642d69fb05", size = 5817167, upload-time = "2026-02-25T20:21:05.476Z" },
 ]


### PR DESCRIPTION
## Summary

Adds the `snap7.s7commplus` package for S7CommPlus protocol support, targeting S7-1200/1500 PLCs across all protocol versions (V1/V2/V3/TLS). Includes a **functional server emulator**, **sync client**, **async client**, and **111 passing tests**.

### Architecture

| Module | Description | Status |
|--------|-------------|--------|
| `protocol.py` | Protocol constants: opcodes, function codes, data types, element IDs, soft data types | Complete |
| `vlq.py` | Variable-Length Quantity encoding/decoding (32/64-bit, signed/unsigned) | Complete |
| `codec.py` | Frame headers, request/response headers, typed value serialization | Complete |
| `server.py` | PLC emulator with data blocks, named variables, session management, multi-client | Complete (V1) |
| `client.py` | Sync client: db_read, db_write, db_read_multi, explore | Complete (V1) |
| `async_client.py` | Async client with asyncio.Lock for concurrent safety | Complete (V1) |
| `connection.py` | Multi-version connection with COTP/TPKT transport | Complete (V1) |

### Server emulator

The server emulates an S7-1200/1500 PLC with:
- **Data blocks** with named variables and type metadata (`register_db()`)
- **Thread-safe memory model** with per-block locking
- **S7CommPlus protocol handling**: CreateObject, DeleteObject, Explore, GetMultiVariables, SetMultiVariables
- **Multi-client support** (threaded, each client gets a unique session ID)
- **CPU state management** (Run/Stop)

```python
server = S7CommPlusServer()
server.register_db(1, {
    "temperature": ("Real", 0),
    "pressure": ("Real", 4),
    "running": ("Bool", 8),
})
server.start(port=11020)
```

### Protocol version support

| Version | Target PLCs | Authentication | Status |
|---------|------------|----------------|--------|
| V1 | S7-1200 FW V4.0+ | Trivial anti-replay | **Working** |
| V2 | S7-1200/1500 older FW | Proprietary HMAC-SHA256/AES | Planned |
| V3 | S7-1200/1500 pre-V17 | ECC key exchange | Planned |
| V3+TLS | TIA Portal V17+ | Standard TLS 1.3 | Planned |

The wire protocol (VLQ, data types, object model) is identical across all versions -- only the session authentication layer differs.

### Tests (111 total)

- **62 VLQ tests**: Boundary values, roundtrips, signed/unsigned, 32/64-bit
- **24 codec tests**: Frame headers, request headers, fixed-width, typed values, strings
- **7 server unit tests**: Data blocks, named variables, CPU state, edge cases
- **11 sync client integration tests**: Connect, read, write, multi-read, explore, persistence, concurrent clients
- **7 async client integration tests**: Connect, read, write, concurrent reads with Lock

## Test plan

- [x] 111 passing tests (VLQ, codec, server unit, sync integration, async integration)
- [x] Ruff lint passes
- [x] Existing test suite unaffected
- [x] Server handles multiple concurrent clients with unique sessions
- [x] Data persists across client sessions
- [x] Async Lock serializes concurrent reads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Tracking issue:** #630