### PR TITLE
Add multi-variable read optimizer

### DIFF
--- a/doc/API/optimizer.rst
+++ b/doc/API/optimizer.rst
@@ -1,0 +1,22 @@
+Optimizer
+=========
+
+.. warning::
+
+   The read optimizer is **experimental** and its API may change in future
+   versions.
+
+The multi-variable read optimizer merges adjacent or overlapping read requests
+and packs them into minimal PDU-sized S7 exchanges. This significantly reduces
+the number of round-trips when reading many scattered variables.
+
+The optimizer is used automatically by :meth:`~snap7.client.Client.read_multi_vars`
+when two or more dict items are passed. It can be disabled per client:
+
+.. code-block:: python
+
+   client.use_optimizer = False          # disable optimizer
+   client.multi_read_max_gap = 10        # merge reads up to 10 bytes apart (default 5)
+
+.. automodule:: snap7.optimizer
+   :members:

--- a/doc/API/optimizer.rst
+++ b/doc/API/optimizer.rst
@@ -4,19 +4,76 @@ Optimizer
 .. warning::
 
    The read optimizer is **experimental** and its API may change in future
-   versions.
+   versions. Disable it with ``client.use_optimizer = False`` if you
+   encounter issues.
 
 The multi-variable read optimizer merges adjacent or overlapping read requests
 and packs them into minimal PDU-sized S7 exchanges. This significantly reduces
 the number of round-trips when reading many scattered variables.
 
-The optimizer is used automatically by :meth:`~snap7.client.Client.read_multi_vars`
-when two or more dict items are passed. It can be disabled per client:
+How it works
+------------
+
+The optimizer uses a three-stage pipeline inspired by
+`nodeS7 <https://github.com/plcpeople/nodeS7>`_:
+
+1. **Sort** — items are sorted by area, DB number, and byte offset so that
+   adjacent reads end up next to each other.
+
+2. **Merge** — sorted items in the same area/DB with a small gap between them
+   (configurable via ``multi_read_max_gap``) are merged into contiguous read
+   blocks. This avoids issuing many small reads when a single larger read
+   covers them all.
+
+3. **Packetize** — merged blocks are packed into PDU-sized packets, respecting
+   both the request and reply size budgets of the negotiated PDU length.
+
+Parallel dispatch
+-----------------
+
+When there are multiple packets to send, the optimizer can fire them
+back-to-back on the same TCP connection and collect responses by sequence
+number (pipelining). This avoids paying a full round-trip per packet.
+
+The number of in-flight packets is controlled by ``max_parallel``, which is
+auto-tuned based on the negotiated PDU size after connecting:
+
+.. list-table::
+   :header-rows: 1
+
+   * - PDU size
+     - max_parallel
+   * - >= 960
+     - 8
+   * - >= 480
+     - 4
+   * - >= 240
+     - 2
+   * - < 240
+     - 1 (sequential)
+
+You can override it manually::
+
+   client.max_parallel = 2   # limit to 2 in-flight packets
+
+Configuration
+-------------
 
 .. code-block:: python
 
-   client.use_optimizer = False          # disable optimizer
+   client.use_optimizer = False          # disable optimizer entirely
    client.multi_read_max_gap = 10        # merge reads up to 10 bytes apart (default 5)
+   client.max_parallel = 1               # disable parallel dispatch (sequential only)
+
+Plan caching
+------------
+
+The optimizer caches the merge/packetize plan for repeated calls with the same
+item layout. If you always read the same set of variables in a loop (a common
+pattern in PLC polling), the planning overhead is paid only on the first call.
+
+API reference
+-------------
 
 .. automodule:: snap7.optimizer
    :members:

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -44,6 +44,7 @@ Welcome to python-snap7's documentation!
    API/partner
    API/logo
    API/util
+   API/optimizer
    API/type
 
 .. toctree::

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -6,6 +6,7 @@ use :class:`s7.Client` instead, which supports all PLC models and
 automatically selects the best protocol.
 """
 
+import copy
 import logging
 import random
 import struct
@@ -42,6 +43,8 @@ from .type import (
     Parameter,
     CDataArrayType,
 )
+
+_VALID_AREA_VALUES: frozenset[int] = frozenset(a.value for a in Area)
 
 logger = logging.getLogger(__name__)
 
@@ -139,6 +142,7 @@ class Client(ClientMixin):
         # Multi-read optimizer state
         self._opt_plan: Optional[_OptimizationPlan] = None
         self.multi_read_max_gap: int = 5
+        self.use_optimizer: bool = True
 
         # Async operation state
         self._async_pending = False
@@ -433,6 +437,7 @@ class Client(ClientMixin):
 
         self.connected = False
         self._is_alive = False
+        self._opt_plan = None
         logger.info(f"Disconnected from {self.host}:{self.port}")
         return 0
 
@@ -724,8 +729,8 @@ class Client(ClientMixin):
         # Dict list path -- use optimizer for 2+ items
         dict_items = cast(List[dict[str, Any]], items)
 
-        if len(dict_items) <= 1:
-            # Single item: no optimization needed
+        if len(dict_items) <= 1 or not self.use_optimizer:
+            # Single item or optimizer disabled: no optimization needed
             results: list[bytearray] = []
             for dict_item in dict_items:
                 area = dict_item["area"]
@@ -776,15 +781,18 @@ class Client(ClientMixin):
             packets = packetize(blocks, self.pdu_length)
             self._opt_plan = _OptimizationPlan(cache_key, packets, read_items)
 
+        # Deep-copy blocks from cached packets so we don't mutate cached state
+        working_packets = copy.deepcopy(packets)
+
         # Execute each packet
-        for packet in packets:
+        for packet in working_packets:
             block_specs = [(blk.area, blk.db_number, blk.start_offset, blk.byte_length) for blk in packet.blocks]
 
             if len(block_specs) == 1:
                 # Single block: use regular read to avoid multi-read overhead
                 blk = packet.blocks[0]
                 data = self.read_area(
-                    Area(blk.area) if blk.area in {a.value for a in Area} else Area.DB,
+                    Area(blk.area) if blk.area in _VALID_AREA_VALUES else Area.DB,
                     blk.db_number,
                     blk.start_offset,
                     blk.byte_length,
@@ -799,12 +807,8 @@ class Client(ClientMixin):
                     blk.buffer = buf
 
         # Extract per-item results in original order
-        results = extract_results(packets, len(dict_items))
+        results = extract_results(working_packets, len(dict_items))
         return (0, results)
-
-    def _map_area_int(self, area_int: int) -> S7Area:
-        """Map integer area value to S7Area enum."""
-        return S7Area(area_int)
 
     def write_multi_vars(self, items: Union[List[dict[str, Any]], List[S7DataItem]]) -> int:
         """

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -23,7 +23,7 @@ from ctypes import (
 from .connection import ISOTCPConnection
 from .s7protocol import S7Protocol, get_return_code_description
 from .datatypes import S7WordLen
-from .error import S7Error, S7ConnectionError, S7ProtocolError, S7StalePacketError
+from .error import S7Error, S7ConnectionError, S7ProtocolError, S7StalePacketError, S7TimeoutError
 from .client_base import ClientMixin
 from .optimizer import ReadItem, ReadPacket, sort_items, merge_items, packetize, extract_results
 
@@ -143,6 +143,7 @@ class Client(ClientMixin):
         self._opt_plan: Optional[_OptimizationPlan] = None
         self.multi_read_max_gap: int = 5
         self.use_optimizer: bool = True
+        self.max_parallel: int = 1
 
         # Async operation state
         self._async_pending = False
@@ -412,6 +413,10 @@ class Client(ClientMixin):
 
             # Start heartbeat if configured
             self._start_heartbeat()
+
+            # Auto-tune parallel dispatch based on PDU size
+            if self.use_optimizer:
+                self._auto_tune_parallel()
 
         except Exception as e:
             self.disconnect()
@@ -749,6 +754,86 @@ class Client(ClientMixin):
 
         return self._read_multi_vars_optimized(dict_items)
 
+    # PDU size → max_parallel mapping.  Smaller PDUs indicate older/smaller
+    # PLCs with fewer resources, so we stay sequential for safety.
+    _PARALLEL_THRESHOLDS: list[Tuple[int, int]] = [
+        (960, 8),
+        (480, 4),
+        (240, 2),
+    ]
+
+    def _auto_tune_parallel(self) -> None:
+        """Set *max_parallel* based on negotiated PDU size.
+
+        Called automatically after :meth:`connect` when the optimizer is
+        enabled.  Larger PDU sizes indicate more capable PLCs that can
+        handle multiple in-flight requests.
+        """
+        for threshold, parallel in self._PARALLEL_THRESHOLDS:
+            if self.pdu_length >= threshold:
+                self.max_parallel = parallel
+                break
+        else:
+            self.max_parallel = 1
+        logger.info(f"Auto-tuned max_parallel={self.max_parallel} (PDU={self.pdu_length})")
+
+    def _send_receive_parallel(
+        self, requests: list[Tuple[int, bytes]]
+    ) -> dict[int, dict[str, Any]]:
+        """Fire multiple S7 requests back-to-back and collect responses by sequence number.
+
+        All PDUs are sent on the single TCP connection before reading any
+        responses.  Responses are matched to requests via the S7 sequence
+        number in the header (bytes 4-5).
+
+        .. warning::
+
+           This method is **experimental** and part of the read optimizer.
+
+        Args:
+            requests: ``(packet_index, pdu_bytes)`` pairs.
+
+        Returns:
+            Dict mapping *packet_index* to the parsed response dict.
+        """
+        conn = self._get_connection()
+
+        # Build seq_num → packet_index lookup
+        pending: dict[int, int] = {}
+        for packet_index, pdu in requests:
+            seq = struct.unpack(">H", pdu[4:6])[0]
+            pending[seq] = packet_index
+
+        # Send all requests back-to-back
+        for _, pdu in requests:
+            conn.send_data(pdu)
+
+        # Receive responses, matching by sequence number
+        results: dict[int, dict[str, Any]] = {}
+        remaining = len(requests)
+        deadline = time.monotonic() + conn.timeout
+
+        while remaining > 0:
+            wait_time = deadline - time.monotonic()
+            if wait_time <= 0:
+                raise S7TimeoutError(f"Timeout waiting for {remaining} parallel response(s)")
+
+            if not conn.data_available(timeout=wait_time):
+                raise S7TimeoutError(f"Timeout waiting for {remaining} parallel response(s)")
+
+            response_data = conn.receive_data()
+            response = self.protocol.parse_response(response_data)
+            resp_seq = response["sequence"]
+
+            if resp_seq in pending:
+                packet_index = pending.pop(resp_seq)
+                results[packet_index] = response
+                remaining -= 1
+            else:
+                logger.warning(f"Discarding unexpected response with sequence {resp_seq}")
+
+        return results
+
     def _read_multi_vars_optimized(self, dict_items: List[dict[str, Any]]) -> Tuple[int, List[bytearray]]:
         """Optimized multi-variable read using merge + packetize strategy.
 
@@ -790,8 +875,9 @@ class Client(ClientMixin):
         # Deep-copy blocks from cached packets so we don't mutate cached state
         working_packets = copy.deepcopy(packets)
 
-        # Execute each packet
-        for packet in working_packets:
+        # Build PDU requests for each packet
+        packet_requests: list[Tuple[int, bytes, ReadPacket]] = []
+        for pkt_idx, packet in enumerate(working_packets):
             block_specs = [(blk.area, blk.db_number, blk.start_offset, blk.byte_length) for blk in packet.blocks]
 
             if len(block_specs) == 1:
@@ -805,16 +891,49 @@ class Client(ClientMixin):
                 )
                 blk.buffer = data
             else:
-                # Multi-block: use multi-read PDU
                 request = self.protocol.build_multi_read_request(block_specs)
-                response = self._send_receive(request)
-                block_data_list = self.protocol.extract_multi_read_data(response, len(block_specs))
-                for blk, buf in zip(packet.blocks, block_data_list):
-                    blk.buffer = buf
+                packet_requests.append((pkt_idx, request, packet))
+
+        # Execute multi-block packets
+        if packet_requests:
+            if self.max_parallel > 1 and len(packet_requests) > 1:
+                self._execute_packets_parallel(packet_requests)
+            else:
+                self._execute_packets_sequential(packet_requests)
 
         # Extract per-item results in original order
         results = extract_results(working_packets, len(dict_items))
         return (0, results)
+
+    def _execute_packets_sequential(
+        self, packet_requests: list[Tuple[int, bytes, ReadPacket]]
+    ) -> None:
+        """Execute multi-block packets one at a time."""
+        for _, request, packet in packet_requests:
+            response = self._send_receive(request)
+            block_data_list = self.protocol.extract_multi_read_data(response, len(packet.blocks))
+            for blk, buf in zip(packet.blocks, block_data_list):
+                blk.buffer = buf
+
+    def _execute_packets_parallel(
+        self, packet_requests: list[Tuple[int, bytes, ReadPacket]]
+    ) -> None:
+        """Execute multi-block packets using parallel dispatch.
+
+        Sends up to *max_parallel* PDUs back-to-back before reading
+        responses, reducing round-trip overhead.
+        """
+        # Process in chunks of max_parallel
+        for chunk_start in range(0, len(packet_requests), self.max_parallel):
+            chunk = packet_requests[chunk_start : chunk_start + self.max_parallel]
+            requests = [(pkt_idx, pdu) for pkt_idx, pdu, _ in chunk]
+            responses = self._send_receive_parallel(requests)
+
+            for pkt_idx, _, packet in chunk:
+                response = responses[pkt_idx]
+                block_data_list = self.protocol.extract_multi_read_data(response, len(packet.blocks))
+                for blk, buf in zip(packet.blocks, block_data_list):
+                    blk.buffer = buf
 
     def write_multi_vars(self, items: Union[List[dict[str, Any]], List[S7DataItem]]) -> int:
         """

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -694,6 +694,12 @@ class Client(ClientMixin):
         exchanges.  This significantly reduces the number of round-trips compared
         to reading each variable individually.
 
+        .. warning::
+
+           The read optimizer is **experimental** and may change in future
+           versions. Disable it with ``client.use_optimizer = False`` if you
+           encounter issues.
+
         Args:
             items: List of item specifications (dicts with ``area``, ``start``,
                 ``size``, and optionally ``db_number``) **or** a ctypes

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -167,8 +167,8 @@ class Client(ClientMixin):
         self._heartbeat_stop_event = threading.Event()
         self._is_alive = False
 
-        # Lock for thread safety during reconnection
-        self._reconnect_lock = threading.Lock()
+        # Lock for thread safety during reconnection and heartbeat
+        self._reconnect_lock = threading.RLock()
 
         logger.info("S7Client initialized (pure Python implementation)")
 
@@ -194,6 +194,8 @@ class Client(ClientMixin):
 
         Wraps the repeated send_data -> receive_data -> parse_response pattern
         with PDU reference validation and automatic retry on stale packets.
+        Acquires ``_reconnect_lock`` to prevent conflicts with the heartbeat
+        thread.
 
         Args:
             request: Complete S7 PDU to send.
@@ -207,20 +209,22 @@ class Client(ClientMixin):
             S7ProtocolError: If all retries are exhausted or other protocol error.
         """
         conn = self._get_connection()
-        conn.send_data(request)
 
-        for attempt in range(max_stale_retries + 1):
-            response_data = conn.receive_data()
-            response = self.protocol.parse_response(response_data)
+        with self._reconnect_lock:
+            conn.send_data(request)
 
-            try:
-                self.protocol.validate_pdu_reference(response["sequence"])
-                return response
-            except S7StalePacketError:
-                if attempt < max_stale_retries:
-                    logger.warning(f"Stale packet (attempt {attempt + 1}/{max_stale_retries}), retrying receive")
-                    continue
-                raise S7ProtocolError(f"Max stale packet retries ({max_stale_retries}) exceeded")
+            for attempt in range(max_stale_retries + 1):
+                response_data = conn.receive_data()
+                response = self.protocol.parse_response(response_data)
+
+                try:
+                    self.protocol.validate_pdu_reference(response["sequence"])
+                    return response
+                except S7StalePacketError:
+                    if attempt < max_stale_retries:
+                        logger.warning(f"Stale packet (attempt {attempt + 1}/{max_stale_retries}), retrying receive")
+                        continue
+                    raise S7ProtocolError(f"Max stale packet retries ({max_stale_retries}) exceeded")
 
         raise S7ProtocolError("Failed to receive valid response")  # Should not reach here
 
@@ -798,39 +802,40 @@ class Client(ClientMixin):
         """
         conn = self._get_connection()
 
-        # Build seq_num → packet_index lookup
-        pending: dict[int, int] = {}
-        for packet_index, pdu in requests:
-            seq = struct.unpack(">H", pdu[4:6])[0]
-            pending[seq] = packet_index
+        with self._reconnect_lock:
+            # Build seq_num → packet_index lookup
+            pending: dict[int, int] = {}
+            for packet_index, pdu in requests:
+                seq = struct.unpack(">H", pdu[4:6])[0]
+                pending[seq] = packet_index
 
-        # Send all requests back-to-back
-        for _, pdu in requests:
-            conn.send_data(pdu)
+            # Send all requests back-to-back
+            for _, pdu in requests:
+                conn.send_data(pdu)
 
-        # Receive responses, matching by sequence number
-        results: dict[int, dict[str, Any]] = {}
-        remaining = len(requests)
-        deadline = time.monotonic() + conn.timeout
+            # Receive responses, matching by sequence number
+            results: dict[int, dict[str, Any]] = {}
+            remaining = len(requests)
+            deadline = time.monotonic() + conn.timeout
 
-        while remaining > 0:
-            wait_time = deadline - time.monotonic()
-            if wait_time <= 0:
-                raise S7TimeoutError(f"Timeout waiting for {remaining} parallel response(s)")
+            while remaining > 0:
+                wait_time = deadline - time.monotonic()
+                if wait_time <= 0:
+                    raise S7TimeoutError(f"Timeout waiting for {remaining} parallel response(s)")
 
-            if not conn.data_available(timeout=wait_time):
-                raise S7TimeoutError(f"Timeout waiting for {remaining} parallel response(s)")
+                if not conn.data_available(timeout=wait_time):
+                    raise S7TimeoutError(f"Timeout waiting for {remaining} parallel response(s)")
 
-            response_data = conn.receive_data()
-            response = self.protocol.parse_response(response_data)
-            resp_seq = response["sequence"]
+                response_data = conn.receive_data()
+                response = self.protocol.parse_response(response_data)
+                resp_seq = response["sequence"]
 
-            if resp_seq in pending:
-                packet_index = pending.pop(resp_seq)
-                results[packet_index] = response
-                remaining -= 1
-            else:
-                logger.warning(f"Discarding unexpected response with sequence {resp_seq}")
+                if resp_seq in pending:
+                    packet_index = pending.pop(resp_seq)
+                    results[packet_index] = response
+                    remaining -= 1
+                else:
+                    logger.warning(f"Discarding unexpected response with sequence {resp_seq}")
 
         return results
 

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -781,9 +781,7 @@ class Client(ClientMixin):
             self.max_parallel = 1
         logger.info(f"Auto-tuned max_parallel={self.max_parallel} (PDU={self.pdu_length})")
 
-    def _send_receive_parallel(
-        self, requests: list[Tuple[int, bytes]]
-    ) -> dict[int, dict[str, Any]]:
+    def _send_receive_parallel(self, requests: list[Tuple[int, bytes]]) -> dict[int, dict[str, Any]]:
         """Fire multiple S7 requests back-to-back and collect responses by sequence number.
 
         All PDUs are sent on the single TCP connection before reading any
@@ -910,9 +908,7 @@ class Client(ClientMixin):
         results = extract_results(working_packets, len(dict_items))
         return (0, results)
 
-    def _execute_packets_sequential(
-        self, packet_requests: list[Tuple[int, bytes, ReadPacket]]
-    ) -> None:
+    def _execute_packets_sequential(self, packet_requests: list[Tuple[int, bytes, ReadPacket]]) -> None:
         """Execute multi-block packets one at a time."""
         for _, request, packet in packet_requests:
             response = self._send_receive(request)
@@ -920,9 +916,7 @@ class Client(ClientMixin):
             for blk, buf in zip(packet.blocks, block_data_list):
                 blk.buffer = buf
 
-    def _execute_packets_parallel(
-        self, packet_requests: list[Tuple[int, bytes, ReadPacket]]
-    ) -> None:
+    def _execute_packets_parallel(self, packet_requests: list[Tuple[int, bytes, ReadPacket]]) -> None:
         """Execute multi-block packets using parallel dispatch.
 
         Sends up to *max_parallel* PDUs back-to-back before reading

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -24,6 +24,7 @@ from .s7protocol import S7Protocol, get_return_code_description
 from .datatypes import S7WordLen
 from .error import S7Error, S7ConnectionError, S7ProtocolError, S7StalePacketError
 from .client_base import ClientMixin
+from .optimizer import ReadItem, ReadPacket, sort_items, merge_items, packetize, extract_results
 
 from .type import (
     Area,
@@ -43,6 +44,15 @@ from .type import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+class _OptimizationPlan:
+    """Cached optimization plan for repeated read_multi_vars calls with the same layout."""
+
+    def __init__(self, cache_key: tuple[int, ...], packets: list[ReadPacket], read_items: list[ReadItem]):
+        self.cache_key = cache_key
+        self.packets = packets
+        self.read_items = read_items
 
 
 class Client(ClientMixin):
@@ -125,6 +135,10 @@ class Client(ClientMixin):
             Parameter.SrcTSap: 256,
             Parameter.PDURequest: 480,
         }
+
+        # Multi-read optimizer state
+        self._opt_plan: Optional[_OptimizationPlan] = None
+        self.multi_read_max_gap: int = 5
 
         # Async operation state
         self._async_pending = False
@@ -668,17 +682,24 @@ class Client(ClientMixin):
         return 0
 
     def read_multi_vars(self, items: Union[List[dict[str, Any]], "Array[S7DataItem]"]) -> Tuple[int, Any]:
-        """
-        Read multiple variables in a single request.
+        """Read multiple variables in a single request.
+
+        When given a list of dicts with two or more items, uses the multi-variable
+        read optimizer to merge adjacent reads and pack them into minimal PDU
+        exchanges.  This significantly reduces the number of round-trips compared
+        to reading each variable individually.
 
         Args:
-            items: List of item specifications or S7DataItem array
+            items: List of item specifications (dicts with ``area``, ``start``,
+                ``size``, and optionally ``db_number``) **or** a ctypes
+                ``Array[S7DataItem]``.
 
         Returns:
-            Tuple of (result, items with data)
+            Tuple of (result_code, data) where *data* is either the updated
+            ctypes array or a list of bytearrays in the original item order.
 
         Raises:
-            ValueError: If more than MAX_VARS items are requested
+            ValueError: If more than MAX_VARS items are requested.
         """
         if not items:
             return (0, items)
@@ -686,9 +707,8 @@ class Client(ClientMixin):
         if len(items) > self.MAX_VARS:
             raise ValueError(f"Too many items: {len(items)} exceeds MAX_VARS ({self.MAX_VARS})")
 
-        # Handle S7DataItem array (ctypes)
+        # Handle S7DataItem array (ctypes) -- unchanged legacy path
         if hasattr(items, "_type_") and hasattr(items[0], "Area"):
-            # This is a ctypes array of S7DataItem - use cast for type safety
             s7_items = cast("Array[S7DataItem]", items)
             for s7_item in s7_items:
                 area = Area(s7_item.Area)
@@ -696,26 +716,95 @@ class Client(ClientMixin):
                 start = s7_item.Start
                 size = s7_item.Amount
                 data = self.read_area(area, db_number, start, size)
-
-                # Copy data to pData buffer
                 if s7_item.pData:
                     for i, b in enumerate(data):
                         s7_item.pData[i] = b
-
             return (0, items)
 
-        # Handle dict list
+        # Dict list path -- use optimizer for 2+ items
         dict_items = cast(List[dict[str, Any]], items)
-        results = []
-        for dict_item in dict_items:
-            area = dict_item["area"]
-            db_number = dict_item.get("db_number", 0)
-            start = dict_item["start"]
-            size = dict_item["size"]
-            data = self.read_area(area, db_number, start, size)
-            results.append(data)
 
+        if len(dict_items) <= 1:
+            # Single item: no optimization needed
+            results: list[bytearray] = []
+            for dict_item in dict_items:
+                area = dict_item["area"]
+                db_number = dict_item.get("db_number", 0)
+                start = dict_item["start"]
+                size = dict_item["size"]
+                data = self.read_area(area, db_number, start, size)
+                results.append(data)
+            return (0, results)
+
+        return self._read_multi_vars_optimized(dict_items)
+
+    def _read_multi_vars_optimized(self, dict_items: List[dict[str, Any]]) -> Tuple[int, List[bytearray]]:
+        """Optimized multi-variable read using merge + packetize strategy.
+
+        Args:
+            dict_items: List of item dicts (area, db_number, start, size).
+
+        Returns:
+            Tuple of (0, list of bytearrays in original order).
+        """
+        # Build ReadItem list
+        read_items: list[ReadItem] = []
+        for idx, d in enumerate(dict_items):
+            area_val = int(d["area"])
+            db_number = d.get("db_number", 0)
+            read_items.append(
+                ReadItem(
+                    area=area_val,
+                    db_number=db_number,
+                    byte_offset=d["start"],
+                    bit_offset=0,
+                    byte_length=d["size"],
+                    index=idx,
+                )
+            )
+
+        # Build cache key from the item layout
+        cache_key = tuple(val for ri in read_items for val in (ri.area, ri.db_number, ri.byte_offset, ri.byte_length))
+
+        # Reuse cached plan if layout matches
+        if self._opt_plan is not None and self._opt_plan.cache_key == cache_key:
+            packets = self._opt_plan.packets
+        else:
+            sorted_ri = sort_items(read_items)
+            max_block = self._max_read_size()
+            blocks = merge_items(sorted_ri, max_gap=self.multi_read_max_gap, max_block_size=max_block)
+            packets = packetize(blocks, self.pdu_length)
+            self._opt_plan = _OptimizationPlan(cache_key, packets, read_items)
+
+        # Execute each packet
+        for packet in packets:
+            block_specs = [(blk.area, blk.db_number, blk.start_offset, blk.byte_length) for blk in packet.blocks]
+
+            if len(block_specs) == 1:
+                # Single block: use regular read to avoid multi-read overhead
+                blk = packet.blocks[0]
+                data = self.read_area(
+                    Area(blk.area) if blk.area in {a.value for a in Area} else Area.DB,
+                    blk.db_number,
+                    blk.start_offset,
+                    blk.byte_length,
+                )
+                blk.buffer = data
+            else:
+                # Multi-block: use multi-read PDU
+                request = self.protocol.build_multi_read_request(block_specs)
+                response = self._send_receive(request)
+                block_data_list = self.protocol.extract_multi_read_data(response, len(block_specs))
+                for blk, buf in zip(packet.blocks, block_data_list):
+                    blk.buffer = buf
+
+        # Extract per-item results in original order
+        results = extract_results(packets, len(dict_items))
         return (0, results)
+
+    def _map_area_int(self, area_int: int) -> S7Area:
+        """Map integer area value to S7Area enum."""
+        return S7Area(area_int)
 
     def write_multi_vars(self, items: Union[List[dict[str, Any]], List[S7DataItem]]) -> int:
         """

--- a/snap7/connection.py
+++ b/snap7/connection.py
@@ -5,6 +5,7 @@ Implements TPKT (Transport Service on top of TCP) and COTP (Connection Oriented
 Transport Protocol) layers for S7 communication.
 """
 
+import select
 import socket
 import struct
 import logging
@@ -417,6 +418,22 @@ class ISOTCPConnection:
                 raise S7ConnectionError(f"Receive error: {e}")
 
         return bytes(data)
+
+    def data_available(self, timeout: float = 0.0) -> bool:
+        """Check if data is available to read without blocking.
+
+        Uses ``select()`` to poll the socket for readable data.
+
+        Args:
+            timeout: How long to wait in seconds (0.0 = immediate poll).
+
+        Returns:
+            True if data is available on the socket.
+        """
+        if not self.connected or self.socket is None:
+            return False
+        readable, _, _ = select.select([self.socket], [], [], timeout)
+        return bool(readable)
 
     def check_connection(self) -> bool:
         """Check if the TCP connection is still alive.

--- a/snap7/optimizer.py
+++ b/snap7/optimizer.py
@@ -1,0 +1,283 @@
+"""
+Multi-variable read optimizer for S7 communication.
+
+Optimizes multiple scattered read requests into minimal PDU-packed S7 exchanges
+by merging adjacent/overlapping reads and packing them into PDU-sized packets.
+"""
+
+import logging
+from dataclasses import dataclass, field
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ReadItem:
+    """A single read request from the caller.
+
+    Attributes:
+        area: S7Area value (e.g. 0x84 for DB).
+        db_number: DB number (0 for non-DB areas).
+        byte_offset: Start byte offset in the area.
+        bit_offset: Bit offset within the byte (0 for byte-level reads).
+        byte_length: Number of bytes to read.
+        index: Original ordering position so results can be returned in order.
+    """
+
+    area: int
+    db_number: int
+    byte_offset: int
+    bit_offset: int
+    byte_length: int
+    index: int
+
+
+@dataclass
+class ReadBlock:
+    """A merged contiguous block of bytes to read in one address spec.
+
+    Attributes:
+        area: S7Area value.
+        db_number: DB number.
+        start_offset: Start byte offset of the block.
+        byte_length: Total bytes to read.
+        items: The ReadItems contained in this block.
+    """
+
+    area: int
+    db_number: int
+    start_offset: int
+    byte_length: int
+    items: list[ReadItem] = field(default_factory=list)
+    buffer: bytearray = field(default_factory=bytearray)
+
+
+@dataclass
+class ReadPacket:
+    """A group of ReadBlocks that fit in a single S7 PDU exchange.
+
+    Attributes:
+        blocks: The blocks in this packet.
+    """
+
+    blocks: list[ReadBlock] = field(default_factory=list)
+
+
+def sort_items(items: list[ReadItem]) -> list[ReadItem]:
+    """Sort read items for optimal merging.
+
+    Items are sorted by (area, db_number, byte_offset, bit_offset, -byte_length).
+    Sorting by descending byte_length ensures that when two items start at the same
+    offset, the larger one comes first, which simplifies overlap handling.
+
+    Args:
+        items: List of read items to sort.
+
+    Returns:
+        New sorted list (original is not modified).
+    """
+    return sorted(items, key=lambda i: (i.area, i.db_number, i.byte_offset, i.bit_offset, -i.byte_length))
+
+
+def merge_items(sorted_items: list[ReadItem], max_gap: int = 5, max_block_size: int = 462) -> list[ReadBlock]:
+    """Merge sorted read items into contiguous blocks.
+
+    Adjacent or overlapping items in the same area/db are merged when the gap
+    between them is at most *max_gap* bytes and the resulting block does not
+    exceed *max_block_size* bytes.
+
+    Args:
+        sorted_items: Items pre-sorted by :func:`sort_items`.
+        max_gap: Maximum byte gap between items to still merge them.
+        max_block_size: Maximum byte length of a single merged block.
+
+    Returns:
+        List of merged ReadBlocks.
+    """
+    if not sorted_items:
+        return []
+
+    blocks: list[ReadBlock] = []
+    current = sorted_items[0]
+    block = ReadBlock(
+        area=current.area,
+        db_number=current.db_number,
+        start_offset=current.byte_offset,
+        byte_length=current.byte_length,
+        items=[current],
+    )
+
+    for item in sorted_items[1:]:
+        block_end = block.start_offset + block.byte_length
+        item_end = item.byte_offset + item.byte_length
+
+        same_region = item.area == block.area and item.db_number == block.db_number
+        gap = item.byte_offset - block_end
+        new_length = max(block_end, item_end) - block.start_offset
+
+        if same_region and gap <= max_gap and new_length <= max_block_size:
+            # Merge: extend block to cover the new item
+            block.byte_length = new_length
+            block.items.append(item)
+        else:
+            # Start a new block
+            blocks.append(block)
+            block = ReadBlock(
+                area=item.area,
+                db_number=item.db_number,
+                start_offset=item.byte_offset,
+                byte_length=item.byte_length,
+                items=[item],
+            )
+
+    blocks.append(block)
+    return blocks
+
+
+def _ceil_even(n: int) -> int:
+    """Round up to the next even number."""
+    return n + (n % 2)
+
+
+def _split_block(block: ReadBlock, max_block_size: int) -> list[ReadBlock]:
+    """Split an oversized block at item boundaries.
+
+    Never tears an item across two blocks.
+
+    Args:
+        block: The block to split.
+        max_block_size: Maximum byte length per sub-block.
+
+    Returns:
+        List of sub-blocks that each fit within *max_block_size*.
+    """
+    if block.byte_length <= max_block_size:
+        return [block]
+
+    sub_blocks: list[ReadBlock] = []
+    current_items: list[ReadItem] = []
+    current_start = block.items[0].byte_offset
+    current_end = current_start
+
+    for item in block.items:
+        item_end = item.byte_offset + item.byte_length
+        new_end = max(current_end, item_end)
+        new_length = new_end - current_start
+
+        if current_items and new_length > max_block_size:
+            # Flush current sub-block
+            sub_blocks.append(
+                ReadBlock(
+                    area=block.area,
+                    db_number=block.db_number,
+                    start_offset=current_start,
+                    byte_length=current_end - current_start,
+                    items=current_items,
+                )
+            )
+            current_items = [item]
+            current_start = item.byte_offset
+            current_end = item_end
+        else:
+            current_items.append(item)
+            current_end = new_end
+
+    if current_items:
+        sub_blocks.append(
+            ReadBlock(
+                area=block.area,
+                db_number=block.db_number,
+                start_offset=current_start,
+                byte_length=current_end - current_start,
+                items=current_items,
+            )
+        )
+
+    return sub_blocks
+
+
+def packetize(blocks: list[ReadBlock], pdu_size: int) -> list[ReadPacket]:
+    """Pack blocks into PDU-sized packets.
+
+    Two budgets are enforced per packet:
+      - **Request budget**: ``12 (header) + 2 (func+count) + 12*N (address specs) <= pdu_size``
+      - **Reply budget**: ``12 (header) + 2 (func+count) + sum(4 + ceil_even(length)) <= pdu_size``
+
+    Oversized blocks are first split at item boundaries, then blocks are
+    greedily packed into packets.
+
+    Args:
+        blocks: Merged read blocks.
+        pdu_size: Negotiated PDU size in bytes.
+
+    Returns:
+        List of ReadPackets.
+    """
+    # First split any oversized blocks
+    # Max data payload per block in a single-block packet
+    max_single_block = pdu_size - 12 - 2 - 4  # header + param + data item header
+    all_blocks: list[ReadBlock] = []
+    for block in blocks:
+        all_blocks.extend(_split_block(block, max_single_block))
+
+    if not all_blocks:
+        return []
+
+    request_overhead = 14  # 12 header + 2 (func + count)
+    reply_overhead = 14  # 12 header + 2 (func + count)
+    addr_spec_size = 12  # per block in request
+
+    packets: list[ReadPacket] = []
+    current_packet = ReadPacket()
+    current_req_used = request_overhead
+    current_reply_used = reply_overhead
+
+    for block in all_blocks:
+        req_cost = addr_spec_size
+        reply_cost = 4 + _ceil_even(block.byte_length)
+
+        fits_request = current_req_used + req_cost <= pdu_size
+        fits_reply = current_reply_used + reply_cost <= pdu_size
+
+        if current_packet.blocks and (not fits_request or not fits_reply):
+            # Start a new packet
+            packets.append(current_packet)
+            current_packet = ReadPacket()
+            current_req_used = request_overhead
+            current_reply_used = reply_overhead
+
+        current_packet.blocks.append(block)
+        current_req_used += req_cost
+        current_reply_used += reply_cost
+
+    if current_packet.blocks:
+        packets.append(current_packet)
+
+    return packets
+
+
+def extract_results(packets: list[ReadPacket], original_count: int) -> list[bytearray]:
+    """Map block buffers back to original items using offset math.
+
+    Each block must have its ``buffer`` attribute set (a bytearray of the
+    block's data as returned by the PLC) before calling this function.
+    The buffer is stored as a dynamic attribute on the ReadBlock dataclass.
+
+    Args:
+        packets: Packets with block buffers populated.
+        original_count: Number of original read items.
+
+    Returns:
+        List of bytearrays indexed by original ``ReadItem.index``.
+    """
+    results: list[bytearray] = [bytearray() for _ in range(original_count)]
+
+    for packet in packets:
+        for block in packet.blocks:
+            buf = block.buffer
+            for item in block.items:
+                local_offset = item.byte_offset - block.start_offset
+                item_data = buf[local_offset : local_offset + item.byte_length]
+                results[item.index] = bytearray(item_data)
+
+    return results

--- a/snap7/optimizer.py
+++ b/snap7/optimizer.py
@@ -3,6 +3,10 @@ Multi-variable read optimizer for S7 communication.
 
 Optimizes multiple scattered read requests into minimal PDU-packed S7 exchanges
 by merging adjacent/overlapping reads and packing them into PDU-sized packets.
+
+.. warning::
+
+   This module is **experimental** and its API may change in future versions.
 """
 
 import logging

--- a/snap7/s7protocol.py
+++ b/snap7/s7protocol.py
@@ -188,13 +188,14 @@ class S7Protocol:
         item_count = len(items)
 
         # Build N * 12-byte address specifications
-        addr_specs = b""
+        addr_spec_parts: list[bytes] = []
         for area_code, db_number, start_offset, byte_length in items:
-            addr_spec = S7DataTypes.encode_address(S7Area(area_code), db_number, start_offset, S7WordLen.BYTE, byte_length)
-            addr_specs += addr_spec
+            addr_spec_parts.append(
+                S7DataTypes.encode_address(S7Area(area_code), db_number, start_offset, S7WordLen.BYTE, byte_length)
+            )
 
         # Parameter: function_code(1) + item_count(1) + N * address_spec(12)
-        param_data = struct.pack(">BB", S7Function.READ_AREA, item_count) + addr_specs
+        param_data = struct.pack(">BB", S7Function.READ_AREA, item_count) + b"".join(addr_spec_parts)
         param_len = len(param_data)
 
         # S7 Header (12 bytes)

--- a/snap7/s7protocol.py
+++ b/snap7/s7protocol.py
@@ -7,7 +7,7 @@ Handles S7 PDU encoding/decoding and protocol operations.
 import struct
 import logging
 from datetime import datetime
-from typing import List, Dict, Any
+from typing import List, Dict, Any, Tuple
 from enum import IntEnum
 
 from .datatypes import S7Area, S7WordLen, S7DataTypes
@@ -172,6 +172,101 @@ class S7Protocol:
         parameters += address_spec[1:]  # Skip first byte (already included as 0x12)
 
         return header + parameters
+
+    def build_multi_read_request(self, items: List[Tuple[int, int, int, int]]) -> bytes:
+        """Build S7 multi-variable read request PDU.
+
+        Encodes multiple address specifications into a single READ_AREA request
+        so the PLC can return all data in one response.
+
+        Args:
+            items: List of (area, db_number, start_offset, byte_length) tuples.
+
+        Returns:
+            Complete S7 PDU.
+        """
+        item_count = len(items)
+
+        # Build N * 12-byte address specifications
+        addr_specs = b""
+        for area_code, db_number, start_offset, byte_length in items:
+            addr_spec = S7DataTypes.encode_address(S7Area(area_code), db_number, start_offset, S7WordLen.BYTE, byte_length)
+            addr_specs += addr_spec
+
+        # Parameter: function_code(1) + item_count(1) + N * address_spec(12)
+        param_data = struct.pack(">BB", S7Function.READ_AREA, item_count) + addr_specs
+        param_len = len(param_data)
+
+        # S7 Header (12 bytes)
+        header = struct.pack(
+            ">BBHHHH",
+            0x32,  # Protocol ID
+            S7PDUType.REQUEST,  # PDU type
+            0x0000,  # Reserved
+            self._next_sequence(),  # Sequence
+            param_len,  # Parameter length
+            0x0000,  # Data length (no data for read)
+        )
+
+        return header + param_data
+
+    def extract_multi_read_data(self, response: Dict[str, Any], block_count: int) -> List[bytearray]:
+        """Extract per-block data from a multi-variable read response.
+
+        Parses the raw data section which contains N items, each with:
+          - return_code (1 byte)
+          - transport_size (1 byte)
+          - bit_length (2 bytes, big-endian)
+          - data (bit_length / 8 bytes)
+          - fill byte (1 byte if byte_length is odd and not the last item)
+
+        Args:
+            response: Parsed S7 response from :meth:`parse_response`.
+            block_count: Expected number of data items.
+
+        Returns:
+            List of bytearrays, one per block.
+
+        Raises:
+            S7ProtocolError: If any item has a non-success return code.
+        """
+        raw = response.get("raw_data", b"")
+        if not raw:
+            raise S7ProtocolError("No raw data in multi-read response")
+
+        results: List[bytearray] = []
+        offset = 0
+
+        for i in range(block_count):
+            if offset + 4 > len(raw):
+                raise S7ProtocolError(f"Multi-read response truncated at item {i}")
+
+            return_code = raw[offset]
+            transport_size = raw[offset + 1]
+            bit_length = struct.unpack(">H", raw[offset + 2 : offset + 4])[0]
+            offset += 4
+
+            if return_code != 0xFF:
+                desc = get_return_code_description(return_code)
+                raise S7ProtocolError(f"Multi-read item {i} failed: {desc} (0x{return_code:02x})")
+
+            # Transport size 0x04 means bit length, others mean byte length
+            if transport_size == 0x04:
+                byte_length = bit_length // 8
+            else:
+                byte_length = bit_length
+
+            if offset + byte_length > len(raw):
+                raise S7ProtocolError(f"Multi-read data truncated at item {i}")
+
+            results.append(bytearray(raw[offset : offset + byte_length]))
+            offset += byte_length
+
+            # Fill byte for even alignment (not after the last item)
+            if i < block_count - 1 and byte_length % 2 != 0:
+                offset += 1
+
+        return results
 
     def build_write_request(self, area: S7Area, db_number: int, start: int, word_len: S7WordLen, data: bytes) -> bytes:
         """
@@ -1335,6 +1430,7 @@ class S7Protocol:
 
             data_section = pdu[offset : offset + data_len]
             response["data"] = self._parse_data_section(data_section)
+            response["raw_data"] = data_section
 
         return response
 

--- a/snap7/server/__init__.py
+++ b/snap7/server/__init__.py
@@ -737,65 +737,53 @@ class Server:
         return header + parameters
 
     def _handle_read_area(self, request: Dict[str, Any], client_address: Tuple[str, int]) -> bytes:
-        """Handle read area request."""
+        """Handle read area request (single or multi-item)."""
         try:
-            # Parse address specification from request parameters
+            params = request.get("parameters", {})
+            item_count = params.get("item_count", 1)
+
+            # Multi-item read
+            if item_count > 1 and "address_specs" in params:
+                return self._handle_multi_read_area(request, client_address)
+
+            # Single-item read (original path)
             addr_info = self._parse_read_address(request)
             if not addr_info:
-                return self._build_error_response(request, 0x8001)  # Invalid address
+                return self._build_error_response(request, 0x8001)
 
             area, db_number, start, count = addr_info
 
-            # Read data from registered memory area
             read_data = self._read_from_memory_area(area, db_number, start, count)
             if read_data is None:
-                return self._build_error_response(request, 0x8404)  # Area not found
+                return self._build_error_response(request, 0x8404)
 
-            # Calculate data length - need to include transport header + data
-            data_len = 4 + len(read_data)  # Transport header (4 bytes) + data
+            data_len = 4 + len(read_data)
 
-            # Build successful response
-            # S7 response header includes error class + error code
             header = struct.pack(
                 ">BBHHHHBB",
-                0x32,  # Protocol ID
-                S7PDUType.ACK_DATA,  # PDU type
-                0x0000,  # Reserved
-                request["sequence"],  # Sequence (echo)
-                0x0002,  # Parameter length
-                data_len,  # Data length
-                0x00,  # Error class (success)
-                0x00,  # Error code (success)
+                0x32,
+                S7PDUType.ACK_DATA,
+                0x0000,
+                request["sequence"],
+                0x0002,
+                data_len,
+                0x00,
+                0x00,
             )
 
-            # Parameters
-            parameters = struct.pack(
-                ">BB",
-                S7Function.READ_AREA,  # Function code
-                0x01,  # Item count
-            )
+            parameters = struct.pack(">BB", S7Function.READ_AREA, 0x01)
 
-            # Data section
-            data_section = (
-                struct.pack(
-                    ">BBH",
-                    0xFF,  # Return code (success)
-                    0x04,  # Transport size (04 = byte data)
-                    len(read_data) * 8,  # Data length in bits
-                )
-                + read_data
-            )
+            data_section = struct.pack(">BBH", 0xFF, 0x04, len(read_data) * 8) + read_data
 
-            # Trigger read event callback
             if self.read_callback:
                 event = SrvEvent()
                 event.EvtTime = int(time.time())
                 event.EvtSender = 0
-                event.EvtCode = 0x00004000  # Read event
+                event.EvtCode = 0x00004000
                 event.EvtRetCode = 0
-                event.EvtParam1 = 1  # Area
-                event.EvtParam2 = 0  # Offset
-                event.EvtParam3 = len(read_data)  # Size
+                event.EvtParam1 = 1
+                event.EvtParam2 = 0
+                event.EvtParam3 = len(read_data)
                 event.EvtParam4 = 0
                 try:
                     self.read_callback(event)
@@ -807,6 +795,64 @@ class Server:
         except Exception as e:
             logger.error(f"Error handling read request: {e}")
             return self._build_error_response(request, 0x8000)
+
+    def _handle_multi_read_area(self, request: Dict[str, Any], client_address: Tuple[str, int]) -> bytes:
+        """Handle multi-item read area request.
+
+        Reads multiple address specifications and returns all data items in a
+        single response with proper fill-byte alignment between items.
+        """
+        params = request["parameters"]
+        address_specs: List[Dict[str, Any]] = params["address_specs"]
+        item_count = len(address_specs)
+
+        # Build data section: concatenated items with fill bytes
+        data_parts = bytearray()
+        for i, addr in enumerate(address_specs):
+            area = addr.get("area", S7Area.DB)
+            db_number = addr.get("db_number", 0)
+            start = addr.get("start", 0)
+            count = addr.get("count", 1)
+            word_len = addr.get("word_len", S7WordLen.BYTE)
+
+            # Convert count to bytes
+            if word_len in (S7WordLen.TIMER, S7WordLen.COUNTER, S7WordLen.WORD):
+                byte_count = count * 2
+            elif word_len in (S7WordLen.DWORD, S7WordLen.REAL):
+                byte_count = count * 4
+            elif word_len == S7WordLen.BIT:
+                byte_count = 1
+            else:
+                byte_count = count
+
+            read_data = self._read_from_memory_area(area, db_number, start, byte_count)
+            if read_data is None:
+                # Item error: not found
+                data_parts.extend(struct.pack(">BBH", 0x0A, 0x00, 0x0000))
+            else:
+                data_parts.extend(struct.pack(">BBH", 0xFF, 0x04, len(read_data) * 8))
+                data_parts.extend(read_data)
+                # Fill byte for even alignment (not after last item)
+                if i < item_count - 1 and len(read_data) % 2 != 0:
+                    data_parts.append(0x00)
+
+        data_len = len(data_parts)
+
+        header = struct.pack(
+            ">BBHHHHBB",
+            0x32,
+            S7PDUType.ACK_DATA,
+            0x0000,
+            request["sequence"],
+            0x0002,  # param length
+            data_len,
+            0x00,
+            0x00,
+        )
+
+        parameters = struct.pack(">BB", S7Function.READ_AREA, item_count)
+
+        return header + parameters + bytes(data_parts)
 
     def _parse_read_address(self, request: Dict[str, Any]) -> Optional[Tuple[S7Area, int, int, int]]:
         """
@@ -1185,10 +1231,24 @@ class Server:
         elif function_code == S7Function.READ_AREA:
             # Parse read area parameters
             if len(param_data) >= 14:  # Minimum for read area request
-                # Function code (1) + item count (1) + address spec (12)
+                # Function code (1) + item count (1) + N * address spec (12 each)
                 item_count = param_data[1]
 
-                # Parse address specification starting at byte 2
+                if item_count > 1:
+                    # Multi-item read: parse all address specs
+                    address_specs: List[Dict[str, Any]] = []
+                    offset = 2
+                    for _ in range(item_count):
+                        if offset + 12 > len(param_data):
+                            break
+                        addr_spec = param_data[offset : offset + 12]
+                        parsed_addr = self._parse_address_specification(addr_spec)
+                        if parsed_addr:
+                            address_specs.append(parsed_addr)
+                        offset += 12
+                    return {"function_code": function_code, "item_count": item_count, "address_specs": address_specs}
+
+                # Single-item read
                 if len(param_data) >= 14:
                     addr_spec = param_data[2:14]  # 12 bytes of address specification
                     logger.debug(f"Extracted address spec from params: {addr_spec.hex()}")

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -317,3 +317,29 @@ class TestMultiReadServer:
         for i in range(10):
             expected = bytearray(self.db1_data[i * 8 : i * 8 + 4])
             assert results[i] == expected, f"Mismatch at item {i}"
+
+    def test_parallel_dispatch(self) -> None:
+        """Parallel dispatch produces the same results as sequential."""
+        items = [{"area": Area.DB, "db_number": 1, "start": i * 8, "size": 4} for i in range(10)]
+
+        # Sequential
+        self.client.max_parallel = 1
+        _, seq_results = self.client.read_multi_vars(items)
+
+        # Parallel
+        self.client.max_parallel = 4
+        _, par_results = self.client.read_multi_vars(items)
+
+        assert seq_results == par_results
+
+    def test_auto_tune_parallel(self) -> None:
+        """Auto-tune sets max_parallel based on PDU size."""
+        self.client._auto_tune_parallel()
+        assert self.client.max_parallel >= 1
+
+    def test_data_available(self) -> None:
+        """data_available returns False when no data is pending."""
+        conn = self.client.connection
+        assert conn is not None
+        # No data should be pending on an idle connection
+        assert conn.data_available(timeout=0.0) is False

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,319 @@
+"""Tests for the multi-variable read optimizer."""
+
+from __future__ import annotations
+
+import random
+import time
+from ctypes import c_char
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from snap7.client import Client
+    from snap7.server import Server
+
+from snap7.optimizer import (
+    ReadItem,
+    ReadBlock,
+    ReadPacket,
+    sort_items,
+    merge_items,
+    packetize,
+    extract_results,
+)
+from snap7.type import Area, SrvArea
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for sort_items
+# ---------------------------------------------------------------------------
+
+
+class TestSortItems:
+    """Tests for sort_items()."""
+
+    def test_different_areas(self) -> None:
+        items = [
+            ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=4, index=0),
+            ReadItem(area=0x83, db_number=0, byte_offset=0, bit_offset=0, byte_length=4, index=1),
+        ]
+        result = sort_items(items)
+        assert result[0].area == 0x83  # MK before DB
+        assert result[1].area == 0x84
+
+    def test_same_area_different_db(self) -> None:
+        items = [
+            ReadItem(area=0x84, db_number=2, byte_offset=0, bit_offset=0, byte_length=4, index=0),
+            ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=4, index=1),
+        ]
+        result = sort_items(items)
+        assert result[0].db_number == 1
+        assert result[1].db_number == 2
+
+    def test_same_offset_different_sizes(self) -> None:
+        items = [
+            ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=2, index=0),
+            ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=8, index=1),
+        ]
+        result = sort_items(items)
+        # Larger item first (descending byte_length)
+        assert result[0].byte_length == 8
+        assert result[1].byte_length == 2
+
+    def test_original_not_modified(self) -> None:
+        items = [
+            ReadItem(area=0x84, db_number=2, byte_offset=0, bit_offset=0, byte_length=4, index=0),
+            ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=4, index=1),
+        ]
+        sort_items(items)
+        assert items[0].db_number == 2  # Original unchanged
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for merge_items
+# ---------------------------------------------------------------------------
+
+
+class TestMergeItems:
+    """Tests for merge_items()."""
+
+    def test_contiguous_merge(self) -> None:
+        items = sort_items(
+            [
+                ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=4, index=0),
+                ReadItem(area=0x84, db_number=1, byte_offset=4, bit_offset=0, byte_length=4, index=1),
+            ]
+        )
+        blocks = merge_items(items)
+        assert len(blocks) == 1
+        assert blocks[0].start_offset == 0
+        assert blocks[0].byte_length == 8
+
+    def test_gap_merge(self) -> None:
+        items = sort_items(
+            [
+                ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=4, index=0),
+                ReadItem(area=0x84, db_number=1, byte_offset=8, bit_offset=0, byte_length=4, index=1),
+            ]
+        )
+        blocks = merge_items(items, max_gap=5)
+        assert len(blocks) == 1
+        assert blocks[0].byte_length == 12
+
+    def test_gap_split(self) -> None:
+        items = sort_items(
+            [
+                ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=4, index=0),
+                ReadItem(area=0x84, db_number=1, byte_offset=100, bit_offset=0, byte_length=4, index=1),
+            ]
+        )
+        blocks = merge_items(items, max_gap=5)
+        assert len(blocks) == 2
+
+    def test_different_areas_split(self) -> None:
+        items = sort_items(
+            [
+                ReadItem(area=0x83, db_number=0, byte_offset=0, bit_offset=0, byte_length=4, index=0),
+                ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=4, index=1),
+            ]
+        )
+        blocks = merge_items(items)
+        assert len(blocks) == 2
+
+    def test_max_block_size_split(self) -> None:
+        items = sort_items(
+            [
+                ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=300, index=0),
+                ReadItem(area=0x84, db_number=1, byte_offset=300, bit_offset=0, byte_length=300, index=1),
+            ]
+        )
+        blocks = merge_items(items, max_block_size=400)
+        assert len(blocks) == 2
+
+    def test_overlapping_items(self) -> None:
+        items = sort_items(
+            [
+                ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=10, index=0),
+                ReadItem(area=0x84, db_number=1, byte_offset=5, bit_offset=0, byte_length=10, index=1),
+            ]
+        )
+        blocks = merge_items(items)
+        assert len(blocks) == 1
+        assert blocks[0].start_offset == 0
+        assert blocks[0].byte_length == 15  # 0..15
+
+    def test_empty_input(self) -> None:
+        assert merge_items([]) == []
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for packetize
+# ---------------------------------------------------------------------------
+
+
+class TestPacketize:
+    """Tests for packetize()."""
+
+    def test_single_block_one_packet(self) -> None:
+        blocks = [ReadBlock(area=0x84, db_number=1, start_offset=0, byte_length=10, items=[])]
+        packets = packetize(blocks, pdu_size=480)
+        assert len(packets) == 1
+        assert len(packets[0].blocks) == 1
+
+    def test_multiple_blocks_one_packet(self) -> None:
+        blocks = [
+            ReadBlock(area=0x84, db_number=1, start_offset=0, byte_length=10, items=[]),
+            ReadBlock(area=0x84, db_number=2, start_offset=0, byte_length=10, items=[]),
+        ]
+        packets = packetize(blocks, pdu_size=480)
+        assert len(packets) == 1
+        assert len(packets[0].blocks) == 2
+
+    def test_request_budget_limit(self) -> None:
+        # Request overhead: 14 + 12*N. With pdu=60, max blocks = (60-14)/12 = 3
+        blocks = [ReadBlock(area=0x84, db_number=i, start_offset=0, byte_length=2, items=[]) for i in range(5)]
+        packets = packetize(blocks, pdu_size=60)
+        assert len(packets) >= 2
+
+    def test_reply_budget_limit(self) -> None:
+        # Reply overhead: 14 + sum(4 + ceil_even(length)).
+        # Each block of 100 bytes costs 4+100=104 in reply.
+        # With pdu=240: budget = 240-14 = 226. Fits 2 blocks (208), not 3 (312).
+        blocks = [ReadBlock(area=0x84, db_number=i, start_offset=0, byte_length=100, items=[]) for i in range(3)]
+        packets = packetize(blocks, pdu_size=240)
+        assert len(packets) == 2
+
+    def test_oversized_block_split(self) -> None:
+        # A block larger than pdu - overhead should be split at item boundaries
+        items = [
+            ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=200, index=0),
+            ReadItem(area=0x84, db_number=1, byte_offset=200, bit_offset=0, byte_length=200, index=1),
+        ]
+        blocks = [ReadBlock(area=0x84, db_number=1, start_offset=0, byte_length=400, items=items)]
+        # pdu=240: max single block data = 240-12-2-4 = 222
+        packets = packetize(blocks, pdu_size=240)
+        total_blocks = sum(len(p.blocks) for p in packets)
+        assert total_blocks == 2
+
+
+# ---------------------------------------------------------------------------
+# Unit tests for extract_results
+# ---------------------------------------------------------------------------
+
+
+class TestExtractResults:
+    """Tests for extract_results()."""
+
+    def test_correct_index_mapping(self) -> None:
+        item_a = ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=4, index=1)
+        item_b = ReadItem(area=0x84, db_number=1, byte_offset=4, bit_offset=0, byte_length=4, index=0)
+        block = ReadBlock(area=0x84, db_number=1, start_offset=0, byte_length=8, items=[item_a, item_b])
+        block.buffer = bytearray(b"\x01\x02\x03\x04\x05\x06\x07\x08")
+        packet = ReadPacket(blocks=[block])
+
+        results = extract_results([packet], 2)
+        assert results[0] == bytearray(b"\x05\x06\x07\x08")  # index 0 -> item_b
+        assert results[1] == bytearray(b"\x01\x02\x03\x04")  # index 1 -> item_a
+
+    def test_overlapping_items(self) -> None:
+        item_a = ReadItem(area=0x84, db_number=1, byte_offset=0, bit_offset=0, byte_length=8, index=0)
+        item_b = ReadItem(area=0x84, db_number=1, byte_offset=4, bit_offset=0, byte_length=4, index=1)
+        block = ReadBlock(area=0x84, db_number=1, start_offset=0, byte_length=8, items=[item_a, item_b])
+        block.buffer = bytearray(b"\x10\x20\x30\x40\x50\x60\x70\x80")
+        packet = ReadPacket(blocks=[block])
+
+        results = extract_results([packet], 2)
+        assert results[0] == bytearray(b"\x10\x20\x30\x40\x50\x60\x70\x80")
+        assert results[1] == bytearray(b"\x50\x60\x70\x80")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests against the server
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.server
+class TestMultiReadServer:
+    """Integration tests for multi-read via server."""
+
+    server: Server
+    client: Client
+    db1_data: bytearray
+    db2_data: bytearray
+
+    @classmethod
+    def setup_class(cls) -> None:
+        """Start a server and connect a client."""
+        from snap7.server import Server as Srv
+        from snap7.client import Client as Cli
+
+        cls.server = Srv()
+
+        cls.db1_data = bytearray(range(100))
+        db1_array = (c_char * 100).from_buffer(cls.db1_data)
+        cls.server.register_area(SrvArea.DB, 1, db1_array)
+
+        cls.db2_data = bytearray(range(100, 200))
+        db2_array = (c_char * 100).from_buffer(cls.db2_data)
+        cls.server.register_area(SrvArea.DB, 2, db2_array)
+
+        port = random.randint(20000, 40000)
+        cls.server.start(tcp_port=port)
+        time.sleep(0.2)
+
+        cls.client = Cli()
+        cls.client.connect("127.0.0.1", 0, 0, tcp_port=port)
+
+    @classmethod
+    def teardown_class(cls) -> None:
+        """Stop server and disconnect client."""
+        cls.client.disconnect()
+        cls.server.stop()
+
+    def test_multi_read_basic(self) -> None:
+        """Read two items from DB1 and verify data."""
+        items = [
+            {"area": Area.DB, "db_number": 1, "start": 0, "size": 4},
+            {"area": Area.DB, "db_number": 1, "start": 10, "size": 4},
+        ]
+        result_code, results = self.client.read_multi_vars(items)
+        assert result_code == 0
+        assert len(results) == 2
+        assert results[0] == bytearray(self.db1_data[0:4])
+        assert results[1] == bytearray(self.db1_data[10:14])
+
+    def test_multi_read_different_dbs(self) -> None:
+        """Read items from DB1 and DB2."""
+        items = [
+            {"area": Area.DB, "db_number": 1, "start": 0, "size": 4},
+            {"area": Area.DB, "db_number": 2, "start": 0, "size": 4},
+        ]
+        result_code, results = self.client.read_multi_vars(items)
+        assert result_code == 0
+        assert results[0] == bytearray(self.db1_data[0:4])
+        assert results[1] == bytearray(self.db2_data[0:4])
+
+    def test_single_item_still_works(self) -> None:
+        """A single item should use the non-optimized path."""
+        items = [
+            {"area": Area.DB, "db_number": 1, "start": 5, "size": 10},
+        ]
+        result_code, results = self.client.read_multi_vars(items)
+        assert result_code == 0
+        assert results[0] == bytearray(self.db1_data[5:15])
+
+    def test_empty_items(self) -> None:
+        """Empty list should return immediately."""
+        result_code, results = self.client.read_multi_vars([])
+        assert result_code == 0
+
+    def test_many_items_multiple_packets(self) -> None:
+        """Enough items to potentially require multiple packets with a small PDU."""
+        items = [{"area": Area.DB, "db_number": 1, "start": i * 8, "size": 4} for i in range(10)]
+        result_code, results = self.client.read_multi_vars(items)
+        assert result_code == 0
+        assert len(results) == 10
+        for i in range(10):
+            expected = bytearray(self.db1_data[i * 8 : i * 8 + 4])
+            assert results[i] == expected, f"Mismatch at item {i}"


### PR DESCRIPTION
## Summary

- Introduces a read optimization pipeline (`snap7/optimizer.py`) that merges scattered `read_multi_vars()` requests into contiguous blocks and packs them into minimal PDU-sized S7 exchanges
- Adds multi-item READ_AREA PDU support in both protocol layer and server, so multiple address specs are sent/responded in a single round-trip
- `read_multi_vars()` with 2+ dict items now automatically optimizes: adjacent reads are merged (configurable gap tolerance via `client.multi_read_max_gap`), and the optimization plan is cached for repeated layouts

## Test plan

- [x] 18 unit tests for optimizer pipeline (sort, merge, packetize, extract)
- [x] 5 integration tests against the built-in server (basic, cross-DB, single-item, empty, many-items)
- [x] Full existing test suite passes (222 passed, 1 skipped)
- [x] mypy strict mode clean
- [x] ruff check and format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)