### PR TITLE
Add tests to improve coverage from 78% to 84%

### DIFF
--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -1,0 +1,475 @@
+"""Tests for snap7.connection module — socket mocking, COTP parsing, exception paths."""
+
+import socket
+import struct
+import pytest
+from unittest.mock import patch, MagicMock
+
+from snap7.connection import ISOTCPConnection, TPDUSize
+from snap7.error import S7ConnectionError, S7TimeoutError
+
+
+class TestTPDUSize:
+    """Test TPDUSize enum values."""
+
+    def test_sizes(self) -> None:
+        assert TPDUSize.S_128 == 0x07
+        assert TPDUSize.S_1024 == 0x0A
+        assert TPDUSize.S_8192 == 0x0D
+
+
+class TestISOTCPConnectionInit:
+    """Test constructor defaults."""
+
+    def test_defaults(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        assert conn.host == "1.2.3.4"
+        assert conn.port == 102
+        assert conn.connected is False
+        assert conn.socket is None
+        assert conn.pdu_size == 240
+
+    def test_custom_params(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4", port=1102, local_tsap=0x200, remote_tsap=0x300, tpdu_size=TPDUSize.S_512)
+        assert conn.port == 1102
+        assert conn.local_tsap == 0x200
+        assert conn.remote_tsap == 0x300
+        assert conn.tpdu_size == TPDUSize.S_512
+
+
+class TestBuildTPKT:
+    """Test TPKT frame building."""
+
+    def test_tpkt_structure(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        payload = b"\x01\x02\x03"
+        frame = conn._build_tpkt(payload)
+        assert frame[:2] == b"\x03\x00"  # version=3, reserved=0
+        length = struct.unpack(">H", frame[2:4])[0]
+        assert length == 7  # 4 header + 3 payload
+        assert frame[4:] == payload
+
+
+class TestBuildCOTPCR:
+    """Test COTP Connection Request building."""
+
+    def test_cr_structure(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4", local_tsap=0x0100, remote_tsap=0x0102)
+        cr = conn._build_cotp_cr()
+        # First byte = PDU length
+        pdu_type = cr[1]
+        assert pdu_type == 0xE0  # COTP_CR
+        # Should contain parameters for TSAP and PDU size
+        assert len(cr) > 7
+
+
+class TestBuildCOTPDT:
+    """Test COTP Data Transfer building."""
+
+    def test_dt_structure(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        data = b"\xaa\xbb"
+        dt = conn._build_cotp_dt(data)
+        assert dt[0] == 2  # PDU length
+        assert dt[1] == 0xF0  # COTP_DT
+        assert dt[2] == 0x80  # EOT
+        assert dt[3:] == data
+
+
+class TestParseCOTPCC:
+    """Test COTP Connection Confirm parsing."""
+
+    def test_valid_cc(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        # Build a valid CC: len, type, dst_ref, src_ref, class_opt
+        cc_data = struct.pack(">BBHHB", 6, 0xD0, 0x1234, 0x0001, 0x00)
+        conn._parse_cotp_cc(cc_data)
+        assert conn.dst_ref == 0x1234
+
+    def test_cc_too_short(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        with pytest.raises(S7ConnectionError, match="too short"):
+            conn._parse_cotp_cc(b"\x00\x01\x02")
+
+    def test_cc_wrong_type(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        cc_data = struct.pack(">BBHHB", 6, 0xE0, 0x0000, 0x0001, 0x00)  # CR instead of CC
+        with pytest.raises(S7ConnectionError, match="Expected COTP CC"):
+            conn._parse_cotp_cc(cc_data)
+
+    def test_cc_with_pdu_size_param_1byte(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        base = struct.pack(">BBHHB", 10, 0xD0, 0x0001, 0x0001, 0x00)
+        # PDU size parameter: code=0xC0, len=1, value=0x0A (=1024)
+        param = struct.pack(">BBB", 0xC0, 1, 0x0A)
+        conn._parse_cotp_cc(base + param)
+        assert conn.pdu_size == 1024
+
+    def test_cc_with_pdu_size_param_2byte(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        base = struct.pack(">BBHHB", 11, 0xD0, 0x0001, 0x0001, 0x00)
+        # PDU size parameter: code=0xC0, len=2, value=2048
+        param = struct.pack(">BBH", 0xC0, 2, 2048)
+        conn._parse_cotp_cc(base + param)
+        assert conn.pdu_size == 2048
+
+
+class TestParseCOTPParameters:
+    """Test COTP parameter parsing edge cases."""
+
+    def test_unknown_parameter(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        # Unknown param code 0xFF, length 1, data 0x00
+        params = struct.pack(">BBB", 0xFF, 1, 0x00)
+        conn._parse_cotp_parameters(params)
+        # Should not crash; pdu_size should remain default
+        assert conn.pdu_size == 240
+
+    def test_truncated_params(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        # Just one byte — should break out of loop
+        conn._parse_cotp_parameters(b"\xc0")
+        assert conn.pdu_size == 240
+
+    def test_param_len_exceeds_data(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        # code=0xC0, len=5, but only 1 byte of data follows
+        params = struct.pack(">BBB", 0xC0, 5, 0x0A)
+        conn._parse_cotp_parameters(params)
+        # Should break early without error
+        assert conn.pdu_size == 240
+
+
+class TestParseCOTPData:
+    """Test COTP Data Transfer parsing."""
+
+    def test_valid_dt(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        pdu = struct.pack(">BBB", 2, 0xF0, 0x80) + b"\xde\xad"
+        result = conn._parse_cotp_data(pdu)
+        assert result == b"\xde\xad"
+
+    def test_dt_too_short(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        with pytest.raises(S7ConnectionError, match="too short"):
+            conn._parse_cotp_data(b"\x02")
+
+    def test_dt_wrong_type(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        pdu = struct.pack(">BBB", 2, 0xD0, 0x80)  # CC instead of DT
+        with pytest.raises(S7ConnectionError, match="Expected COTP DT"):
+            conn._parse_cotp_data(pdu)
+
+
+class TestSendData:
+    """Test send_data() error paths."""
+
+    def test_send_when_not_connected(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        with pytest.raises(S7ConnectionError, match="Not connected"):
+            conn.send_data(b"\x00")
+
+    def test_send_socket_error(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.connected = True
+        conn.socket = MagicMock()
+        conn.socket.sendall.side_effect = socket.error("broken pipe")
+        with pytest.raises(S7ConnectionError, match="Send failed"):
+            conn.send_data(b"\x00")
+        assert conn.connected is False
+
+
+class TestReceiveData:
+    """Test receive_data() error paths."""
+
+    def test_receive_when_not_connected(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        with pytest.raises(S7ConnectionError, match="Not connected"):
+            conn.receive_data()
+
+    def test_receive_invalid_tpkt_version(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.connected = True
+        mock_socket = MagicMock()
+        conn.socket = mock_socket
+        # TPKT with version 5 instead of 3
+        mock_socket.recv.return_value = struct.pack(">BBH", 5, 0, 10)
+        with pytest.raises(S7ConnectionError, match="Invalid TPKT version"):
+            conn.receive_data()
+
+    def test_receive_invalid_tpkt_length(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.connected = True
+        mock_socket = MagicMock()
+        conn.socket = mock_socket
+        # Length = 3, remaining = -1
+        mock_socket.recv.return_value = struct.pack(">BBH", 3, 0, 3)
+        with pytest.raises(S7ConnectionError, match="Invalid TPKT length"):
+            conn.receive_data()
+
+    def test_receive_timeout(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.connected = True
+        mock_socket = MagicMock()
+        conn.socket = mock_socket
+        mock_socket.recv.side_effect = socket.timeout("timeout")
+        with pytest.raises(S7TimeoutError, match="Receive timeout"):
+            conn.receive_data()
+        assert conn.connected is False
+
+    def test_receive_socket_error(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.connected = True
+        mock_socket = MagicMock()
+        conn.socket = mock_socket
+        # First recv returns valid TPKT header, second raises error
+        mock_socket.recv.side_effect = [struct.pack(">BBH", 3, 0, 10), socket.error("reset")]
+        with pytest.raises(S7ConnectionError, match="Receive error"):
+            conn.receive_data()
+        assert conn.connected is False
+
+
+class TestRecvExact:
+    """Test _recv_exact() with various scenarios."""
+
+    def test_socket_none(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        with pytest.raises(S7ConnectionError, match="Socket not initialized"):
+            conn._recv_exact(4)
+
+    def test_connection_closed(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.socket = MagicMock()
+        conn.socket.recv.return_value = b""  # empty = connection closed
+        with pytest.raises(S7ConnectionError, match="Connection closed"):
+            conn._recv_exact(4)
+        assert conn.connected is False
+
+    def test_partial_reads(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.socket = MagicMock()
+        conn.socket.recv.side_effect = [b"\x01\x02", b"\x03\x04"]
+        result = conn._recv_exact(4)
+        assert result == b"\x01\x02\x03\x04"
+
+    def test_timeout(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.socket = MagicMock()
+        conn.socket.recv.side_effect = socket.timeout("timeout")
+        with pytest.raises(S7TimeoutError):
+            conn._recv_exact(4)
+
+    def test_socket_error(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.socket = MagicMock()
+        conn.socket.recv.side_effect = socket.error("broken")
+        with pytest.raises(S7ConnectionError, match="Receive error"):
+            conn._recv_exact(4)
+
+
+class TestSendCOTPDisconnect:
+    """Test _send_cotp_disconnect()."""
+
+    def test_disconnect_no_socket(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.socket = None
+        # Should return without error
+        conn._send_cotp_disconnect()
+
+    def test_disconnect_sends_dr(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        mock_socket = MagicMock()
+        conn.socket = mock_socket
+        conn._send_cotp_disconnect()
+        mock_socket.sendall.assert_called_once()
+
+    def test_disconnect_ignores_socket_error(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        mock_socket = MagicMock()
+        mock_socket.sendall.side_effect = socket.error("broken")
+        conn.socket = mock_socket
+        # Should not raise
+        conn._send_cotp_disconnect()
+
+
+class TestConnect:
+    """Test connect() orchestration."""
+
+    @patch.object(ISOTCPConnection, "_tcp_connect")
+    @patch.object(ISOTCPConnection, "_iso_connect")
+    def test_successful_connect(self, mock_iso: MagicMock, mock_tcp: MagicMock) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.connect(timeout=2.0)
+        assert conn.connected is True
+        assert conn.timeout == 2.0
+        mock_tcp.assert_called_once()
+        mock_iso.assert_called_once()
+
+    @patch.object(ISOTCPConnection, "_tcp_connect", side_effect=OSError("connection refused"))
+    @patch.object(ISOTCPConnection, "disconnect")
+    def test_connect_failure_wraps_in_s7error(self, mock_disc: MagicMock, mock_tcp: MagicMock) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        with pytest.raises(S7ConnectionError, match="Connection failed"):
+            conn.connect()
+        mock_disc.assert_called_once()
+
+    @patch.object(ISOTCPConnection, "_tcp_connect")
+    @patch.object(ISOTCPConnection, "_iso_connect", side_effect=S7ConnectionError("COTP fail"))
+    @patch.object(ISOTCPConnection, "disconnect")
+    def test_connect_reraises_s7_errors(self, mock_disc: MagicMock, mock_iso: MagicMock, mock_tcp: MagicMock) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        with pytest.raises(S7ConnectionError, match="COTP fail"):
+            conn.connect()
+
+
+class TestDisconnect:
+    """Test disconnect() behavior."""
+
+    def test_disconnect_when_no_socket(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        # Should not raise
+        conn.disconnect()
+
+    def test_disconnect_closes_socket(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        mock_socket = MagicMock()
+        conn.socket = mock_socket
+        conn.connected = True
+        conn.disconnect()
+        mock_socket.close.assert_called_once()
+        assert conn.socket is None
+        assert conn.connected is False
+
+    def test_disconnect_ignores_errors(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        mock_socket = MagicMock()
+        mock_socket.close.side_effect = OSError("already closed")
+        conn.socket = mock_socket
+        conn.connected = False
+        conn.disconnect()
+        assert conn.socket is None
+
+
+class TestContextManager:
+    """Test __enter__ / __exit__."""
+
+    def test_enter_returns_self(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        assert conn.__enter__() is conn
+
+    def test_exit_calls_disconnect(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.socket = MagicMock()
+        conn.connected = True
+        conn.__exit__(None, None, None)
+        assert conn.socket is None
+        assert conn.connected is False
+
+    def test_context_manager_protocol(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        with conn as c:
+            assert c is conn
+        assert conn.connected is False
+
+
+class TestCheckConnection:
+    """Test check_connection() method."""
+
+    def test_not_connected(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        assert conn.check_connection() is False
+
+    def test_socket_none(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.connected = True
+        conn.socket = None
+        assert conn.check_connection() is False
+
+    def test_connection_alive_no_data(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.connected = True
+        mock_socket = MagicMock()
+        conn.socket = mock_socket
+        mock_socket.gettimeout.return_value = 5.0
+        mock_socket.recv.side_effect = BlockingIOError
+        assert conn.check_connection() is True
+
+    def test_connection_alive_with_data(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.connected = True
+        mock_socket = MagicMock()
+        conn.socket = mock_socket
+        mock_socket.gettimeout.return_value = 5.0
+        mock_socket.recv.return_value = b"\x00"
+        assert conn.check_connection() is True
+
+    def test_connection_closed_by_peer(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.connected = True
+        mock_socket = MagicMock()
+        conn.socket = mock_socket
+        mock_socket.gettimeout.return_value = 5.0
+        mock_socket.recv.return_value = b""
+        assert conn.check_connection() is False
+        assert conn.connected is False
+
+    def test_connection_socket_error(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.connected = True
+        mock_socket = MagicMock()
+        conn.socket = mock_socket
+        mock_socket.gettimeout.return_value = 5.0
+        mock_socket.recv.side_effect = socket.error("reset")
+        assert conn.check_connection() is False
+        assert conn.connected is False
+
+    def test_connection_exception_in_outer_try(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.connected = True
+        mock_socket = MagicMock()
+        conn.socket = mock_socket
+        mock_socket.gettimeout.side_effect = Exception("unexpected")
+        assert conn.check_connection() is False
+
+
+class TestTCPConnect:
+    """Test _tcp_connect()."""
+
+    @patch("snap7.connection.socket.socket")
+    def test_tcp_connect_failure(self, mock_socket_cls: MagicMock) -> None:
+        mock_sock = MagicMock()
+        mock_socket_cls.return_value = mock_sock
+        mock_sock.connect.side_effect = socket.error("refused")
+        conn = ISOTCPConnection("1.2.3.4")
+        with pytest.raises(S7ConnectionError, match="TCP connection failed"):
+            conn._tcp_connect()
+
+    @patch("snap7.connection.socket.socket")
+    def test_tcp_connect_success(self, mock_socket_cls: MagicMock) -> None:
+        mock_sock = MagicMock()
+        mock_socket_cls.return_value = mock_sock
+        conn = ISOTCPConnection("1.2.3.4")
+        conn._tcp_connect()
+        mock_sock.settimeout.assert_called_once()
+        mock_sock.connect.assert_called_once_with(("1.2.3.4", 102))
+
+
+class TestISOConnect:
+    """Test _iso_connect()."""
+
+    def test_iso_connect_no_socket(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        conn.socket = None
+        with pytest.raises(S7ConnectionError, match="Socket not initialized"):
+            conn._iso_connect()
+
+    def test_iso_connect_bad_tpkt_version(self) -> None:
+        conn = ISOTCPConnection("1.2.3.4")
+        mock_socket = MagicMock()
+        conn.socket = mock_socket
+        # Build a valid CC response wrapped in a bad TPKT
+        cc = struct.pack(">BBHHB", 6, 0xD0, 0x0001, 0x0001, 0x00)
+        bad_tpkt = struct.pack(">BBH", 5, 0, 4 + len(cc))
+        mock_socket.recv.side_effect = [bad_tpkt, cc]
+        with pytest.raises(S7ConnectionError, match="Invalid TPKT version"):
+            conn._iso_connect()

--- a/tests/test_db_coverage.py
+++ b/tests/test_db_coverage.py
@@ -1,0 +1,546 @@
+"""Tests for snap7.util.db — DB/Row dict-like interface, read/write with mocked client, type conversions."""
+
+import datetime
+import logging
+import struct
+import pytest
+from unittest.mock import MagicMock
+
+from snap7 import DB, Row
+from snap7.type import Area
+from snap7.util.db import print_row
+
+# Reuse the test spec and bytearray from test_util.py
+test_spec = """
+4       ID           INT
+6       NAME         STRING[4]
+
+12.0    testbool1    BOOL
+12.1    testbool2    BOOL
+13      testReal     REAL
+17      testDword    DWORD
+21      testint2     INT
+23      testDint     DINT
+27      testWord     WORD
+29      testS5time   S5TIME
+31      testdateandtime DATE_AND_TIME
+43      testusint0   USINT
+44      testsint0    SINT
+46      testTime     TIME
+50      testByte     BYTE
+51      testUint     UINT
+53      testUdint    UDINT
+57      testLreal    LREAL
+65      testChar     CHAR
+66      testWchar    WCHAR
+68      testWstring  WSTRING[4]
+80      testDate     DATE
+82      testTod      TOD
+86      testDtl      DTL
+98      testFstring  FSTRING[8]
+"""
+
+_bytearray = bytearray(
+    [
+        0,
+        0,  # test int
+        4,
+        4,
+        ord("t"),
+        ord("e"),
+        ord("s"),
+        ord("t"),  # test string
+        0x0F,  # test bools
+        68,
+        78,
+        211,
+        51,  # test real
+        255,
+        255,
+        255,
+        255,  # test dword
+        0,
+        0,  # test int 2
+        128,
+        0,
+        0,
+        0,  # test dint
+        255,
+        255,  # test word
+        0,
+        16,  # test s5time
+        32,
+        7,
+        18,
+        23,
+        50,
+        2,
+        133,
+        65,  # date_and_time (8 bytes)
+        254,
+        254,
+        254,
+        254,
+        254,  # padding
+        127,  # usint
+        128,  # sint
+        143,
+        255,
+        255,
+        255,  # time
+        254,  # byte
+        48,
+        57,  # uint
+        7,
+        91,
+        205,
+        21,  # udint
+        65,
+        157,
+        111,
+        52,
+        84,
+        126,
+        107,
+        117,  # lreal
+        65,  # char 'A'
+        3,
+        169,  # wchar
+        0,
+        4,
+        0,
+        4,
+        3,
+        169,
+        0,
+        ord("s"),
+        0,
+        ord("t"),
+        0,
+        196,  # wstring
+        45,
+        235,  # date
+        2,
+        179,
+        41,
+        128,  # tod
+        7,
+        230,
+        3,
+        9,
+        4,
+        12,
+        34,
+        45,
+        0,
+        0,
+        0,
+        0,  # dtl
+        116,
+        101,
+        115,
+        116,
+        32,
+        32,
+        32,
+        32,  # fstring 'test    '
+    ]
+)
+
+
+class TestPrintRow:
+    def test_print_row_output(self, caplog: pytest.LogCaptureFixture) -> None:
+        data = bytearray([65, 66, 67, 68, 69])
+        with caplog.at_level(logging.INFO, logger="snap7.util.db"):
+            print_row(data)
+        assert "65" in caplog.text
+        assert "A" in caplog.text
+
+
+class TestDBDictInterface:
+    def setup_method(self) -> None:
+        test_array = bytearray(_bytearray * 3)
+        self.db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=3, layout_offset=4, db_offset=0)
+
+    def test_len(self) -> None:
+        assert len(self.db) == 3
+
+    def test_getitem(self) -> None:
+        row = self.db["0"]
+        assert row is not None
+
+    def test_getitem_missing(self) -> None:
+        row = self.db["999"]
+        assert row is None
+
+    def test_contains(self) -> None:
+        assert "0" in self.db
+        assert "999" not in self.db
+
+    def test_keys(self) -> None:
+        keys = list(self.db.keys())
+        assert "0" in keys
+        assert len(keys) == 3
+
+    def test_items(self) -> None:
+        items = list(self.db.items())
+        assert len(items) == 3
+        for key, row in items:
+            assert isinstance(key, str)
+            assert isinstance(row, Row)
+
+    def test_iter(self) -> None:
+        for key, row in self.db:
+            assert isinstance(key, str)
+            assert isinstance(row, Row)
+
+    def test_get_bytearray(self) -> None:
+        ba = self.db.get_bytearray()
+        assert isinstance(ba, bytearray)
+
+
+class TestDBWithIdField:
+    def test_id_field_creates_named_index(self) -> None:
+        test_array = bytearray(_bytearray * 2)
+        # Set different ID values for each row
+        struct.pack_into(">h", test_array, 0, 10)  # row 0, ID at offset 0 (spec offset 4, layout_offset 4)
+        struct.pack_into(">h", test_array, len(_bytearray), 20)  # row 1
+        db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=2, id_field="ID", layout_offset=4, db_offset=0)
+        assert "10" in db
+        assert "20" in db
+
+
+class TestDBSetData:
+    def test_set_data_valid(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0)
+        new_data = bytearray(len(_bytearray))
+        db.set_data(new_data)
+        assert db.get_bytearray() is new_data
+
+    def test_set_data_invalid_type(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0)
+        with pytest.raises(TypeError):
+            db.set_data(b"not a bytearray")  # type: ignore[arg-type]
+
+
+class TestDBReadWrite:
+    """Test DB.read() and DB.write() with mocked client."""
+
+    def test_read_db_area(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0)
+        mock_client = MagicMock()
+        mock_client.db_read.return_value = bytearray(len(_bytearray))
+        db.read(mock_client)
+        mock_client.db_read.assert_called_once()
+
+    def test_read_non_db_area(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(0, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0, area=Area.MK)
+        mock_client = MagicMock()
+        mock_client.read_area.return_value = bytearray(len(_bytearray))
+        db.read(mock_client)
+        mock_client.read_area.assert_called_once()
+
+    def test_read_negative_row_size(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0)
+        db.row_size = -1
+        mock_client = MagicMock()
+        with pytest.raises(ValueError, match="row_size"):
+            db.read(mock_client)
+
+    def test_write_db_area(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0)
+        mock_client = MagicMock()
+        db.write(mock_client)
+        mock_client.db_write.assert_called_once()
+
+    def test_write_non_db_area(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(0, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0, area=Area.MK)
+        mock_client = MagicMock()
+        db.write(mock_client)
+        mock_client.write_area.assert_called_once()
+
+    def test_write_negative_row_size(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0)
+        db.row_size = -1
+        mock_client = MagicMock()
+        with pytest.raises(ValueError, match="row_size"):
+            db.write(mock_client)
+
+    def test_write_with_row_offset(self) -> None:
+        test_array = bytearray(_bytearray * 2)
+        db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=2, layout_offset=4, db_offset=0, row_offset=4)
+        mock_client = MagicMock()
+        db.write(mock_client)
+        # Should write each row individually via Row.write()
+        assert mock_client.db_write.call_count == 2
+
+
+class TestRowRepr:
+    def test_repr(self) -> None:
+        test_array = bytearray(_bytearray)
+        row = Row(test_array, test_spec, layout_offset=4)
+        r = repr(row)
+        assert "ID" in r
+        assert "NAME" in r
+
+
+class TestRowUnchanged:
+    def test_unchanged_true(self) -> None:
+        test_array = bytearray(_bytearray)
+        row = Row(test_array, test_spec, layout_offset=4)
+        assert row.unchanged(test_array) is True
+
+    def test_unchanged_false(self) -> None:
+        test_array = bytearray(_bytearray)
+        row = Row(test_array, test_spec, layout_offset=4)
+        other = bytearray(len(_bytearray))
+        assert row.unchanged(other) is False
+
+
+class TestRowTypeError:
+    def test_invalid_bytearray_type(self) -> None:
+        with pytest.raises(TypeError):
+            Row("not a bytearray", test_spec)  # type: ignore[arg-type]
+
+
+class TestRowReadWrite:
+    """Test Row.read() and Row.write() with mocked client through DB parent."""
+
+    def test_row_write_db_area(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0)
+        row = db["0"]
+        assert row is not None
+        mock_client = MagicMock()
+        row.write(mock_client)
+        mock_client.db_write.assert_called_once()
+
+    def test_row_write_non_db_area(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(0, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0, area=Area.MK)
+        row = db["0"]
+        assert row is not None
+        mock_client = MagicMock()
+        row.write(mock_client)
+        mock_client.write_area.assert_called_once()
+
+    def test_row_write_not_db_parent(self) -> None:
+        test_array = bytearray(_bytearray)
+        row = Row(test_array, test_spec, layout_offset=4)
+        mock_client = MagicMock()
+        with pytest.raises(TypeError):
+            row.write(mock_client)
+
+    def test_row_write_negative_row_size(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0)
+        row = db["0"]
+        assert row is not None
+        row.row_size = -1
+        mock_client = MagicMock()
+        with pytest.raises(ValueError, match="row_size"):
+            row.write(mock_client)
+
+    def test_row_read_db_area(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0)
+        row = db["0"]
+        assert row is not None
+        mock_client = MagicMock()
+        mock_client.db_read.return_value = bytearray(len(_bytearray))
+        row.read(mock_client)
+        mock_client.db_read.assert_called_once()
+
+    def test_row_read_non_db_area(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(0, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0, area=Area.MK)
+        row = db["0"]
+        assert row is not None
+        mock_client = MagicMock()
+        mock_client.read_area.return_value = bytearray(len(_bytearray))
+        row.read(mock_client)
+        mock_client.read_area.assert_called_once()
+
+    def test_row_read_not_db_parent(self) -> None:
+        test_array = bytearray(_bytearray)
+        row = Row(test_array, test_spec, layout_offset=4)
+        mock_client = MagicMock()
+        with pytest.raises(TypeError):
+            row.read(mock_client)
+
+    def test_row_read_negative_row_size(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0)
+        row = db["0"]
+        assert row is not None
+        row.row_size = -1
+        mock_client = MagicMock()
+        with pytest.raises(ValueError, match="row_size"):
+            row.read(mock_client)
+
+
+class TestRowSetValueTypes:
+    """Test set_value for various type branches."""
+
+    def setup_method(self) -> None:
+        self.test_array = bytearray(_bytearray)
+        self.row = Row(self.test_array, test_spec, layout_offset=4)
+
+    def test_set_int(self) -> None:
+        self.row.set_value(4, "INT", 42)
+        assert self.row.get_value(4, "INT") == 42
+
+    def test_set_uint(self) -> None:
+        self.row.set_value(51, "UINT", 1000)
+        assert self.row.get_value(51, "UINT") == 1000
+
+    def test_set_dint(self) -> None:
+        self.row.set_value(23, "DINT", -100)
+        assert self.row.get_value(23, "DINT") == -100
+
+    def test_set_udint(self) -> None:
+        self.row.set_value(53, "UDINT", 999999)
+        assert self.row.get_value(53, "UDINT") == 999999
+
+    def test_set_word(self) -> None:
+        self.row.set_value(27, "WORD", 12345)
+        assert self.row.get_value(27, "WORD") == 12345
+
+    def test_set_usint(self) -> None:
+        self.row.set_value(43, "USINT", 200)
+        assert self.row.get_value(43, "USINT") == 200
+
+    def test_set_sint(self) -> None:
+        self.row.set_value(44, "SINT", -50)
+        assert self.row.get_value(44, "SINT") == -50
+
+    def test_set_time(self) -> None:
+        self.row.set_value(46, "TIME", "1:2:3:4.5")
+        assert self.row.get_value(46, "TIME") is not None
+
+    def test_set_date(self) -> None:
+        d = datetime.date(2024, 1, 15)
+        self.row.set_value(80, "DATE", d)
+        assert self.row.get_value(80, "DATE") == d
+
+    def test_set_tod(self) -> None:
+        td = datetime.timedelta(hours=5, minutes=30)
+        self.row.set_value(82, "TOD", td)
+        assert self.row.get_value(82, "TOD") == td
+
+    def test_set_time_of_day(self) -> None:
+        td = datetime.timedelta(hours=1)
+        self.row.set_value(82, "TIME_OF_DAY", td)
+        assert self.row.get_value(82, "TIME_OF_DAY") == td
+
+    def test_set_dtl(self) -> None:
+        dt = datetime.datetime(2024, 6, 15, 10, 20, 30)
+        self.row.set_value(86, "DTL", dt)
+        result = self.row.get_value(86, "DTL")
+        assert result.year == 2024  # type: ignore[union-attr]
+
+    def test_set_date_and_time(self) -> None:
+        dt = datetime.datetime(2020, 7, 12, 17, 32, 2, 854000)
+        self.row.set_value(31, "DATE_AND_TIME", dt)
+        result = self.row.get_value(31, "DATE_AND_TIME")
+        assert "2020" in str(result)
+
+    def test_set_unknown_type_raises(self) -> None:
+        with pytest.raises(ValueError):
+            self.row.set_value(4, "UNKNOWN_TYPE", 42)
+
+    def test_set_string(self) -> None:
+        self.row.set_value(6, "STRING[4]", "ab")
+        assert self.row.get_value(6, "STRING[4]") == "ab"
+
+    def test_set_wstring(self) -> None:
+        self.row.set_value(68, "WSTRING[4]", "ab")
+        assert self.row.get_value(68, "WSTRING[4]") == "ab"
+
+    def test_set_fstring(self) -> None:
+        self.row.set_value(98, "FSTRING[8]", "hi")
+        assert self.row.get_value(98, "FSTRING[8]") == "hi"
+
+    def test_set_real(self) -> None:
+        self.row.set_value(13, "REAL", 3.14)
+        assert abs(self.row.get_value(13, "REAL") - 3.14) < 0.01  # type: ignore[operator]
+
+    def test_set_lreal(self) -> None:
+        self.row.set_value(57, "LREAL", 2.718281828)
+        assert abs(self.row.get_value(57, "LREAL") - 2.718281828) < 0.0001  # type: ignore[operator]
+
+    def test_set_char(self) -> None:
+        self.row.set_value(65, "CHAR", "Z")
+        assert self.row.get_value(65, "CHAR") == "Z"
+
+    def test_set_wchar(self) -> None:
+        self.row.set_value(66, "WCHAR", "W")
+        assert self.row.get_value(66, "WCHAR") == "W"
+
+
+class TestRowGetValueEdgeCases:
+    """Test get_value for edge cases."""
+
+    def setup_method(self) -> None:
+        self.test_array = bytearray(_bytearray)
+        self.row = Row(self.test_array, test_spec, layout_offset=4)
+
+    def test_unknown_type_raises(self) -> None:
+        with pytest.raises(ValueError):
+            self.row.get_value(4, "NONEXISTENT")
+
+    def test_string_no_max_size(self) -> None:
+        spec = "4    test    STRING"
+        row = Row(bytearray(20), spec, layout_offset=0)
+        with pytest.raises(ValueError, match="Max size"):
+            row.get_value(4, "STRING")
+
+    def test_fstring_no_max_size(self) -> None:
+        with pytest.raises(ValueError, match="Max size"):
+            self.row.get_value(98, "FSTRING")
+
+    def test_wstring_no_max_size(self) -> None:
+        with pytest.raises(ValueError, match="Max size"):
+            self.row.get_value(68, "WSTRING")
+
+
+class TestRowSetValueEdgeCases:
+    """Test set_value edge cases for string types."""
+
+    def setup_method(self) -> None:
+        self.test_array = bytearray(_bytearray)
+        self.row = Row(self.test_array, test_spec, layout_offset=4)
+
+    def test_fstring_no_max_size(self) -> None:
+        with pytest.raises(ValueError, match="Max size"):
+            self.row.set_value(98, "FSTRING", "test")
+
+    def test_string_no_max_size(self) -> None:
+        with pytest.raises(ValueError, match="Max size"):
+            self.row.set_value(6, "STRING", "test")
+
+    def test_wstring_no_max_size(self) -> None:
+        with pytest.raises(ValueError, match="Max size"):
+            self.row.set_value(68, "WSTRING", "test")
+
+
+class TestRowWriteWithRowOffset:
+    """Test Row.write() with row_offset set."""
+
+    def test_write_with_row_offset(self) -> None:
+        test_array = bytearray(_bytearray)
+        db = DB(1, test_array, test_spec, row_size=len(_bytearray), size=1, layout_offset=4, db_offset=0, row_offset=10)
+        row = db["0"]
+        assert row is not None
+        mock_client = MagicMock()
+        row.write(mock_client)
+        # The data written should start at db_offset + row_offset
+        mock_client.db_write.assert_called_once()

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,0 +1,181 @@
+"""Tests for snap7.error module — error routing, check_error(), error_wrap() decorator."""
+
+import pytest
+
+from snap7.error import (
+    S7Error,
+    S7ConnectionError,
+    S7ProtocolError,
+    S7TimeoutError,
+    S7AuthenticationError,
+    S7StalePacketError,
+    S7PacketLostError,
+    get_error_message,
+    get_protocol_error_message,
+    check_error,
+    error_text,
+    error_wrap,
+)
+
+
+class TestExceptionClasses:
+    """Verify all exception classes can be instantiated with expected attributes."""
+
+    def test_s7error_with_code(self) -> None:
+        err = S7Error("msg", error_code=42)
+        assert str(err) == "msg"
+        assert err.error_code == 42
+
+    def test_s7error_without_code(self) -> None:
+        err = S7Error("msg")
+        assert err.error_code is None
+
+    def test_subclass_hierarchy(self) -> None:
+        assert issubclass(S7ConnectionError, S7Error)
+        assert issubclass(S7ProtocolError, S7Error)
+        assert issubclass(S7TimeoutError, S7Error)
+        assert issubclass(S7AuthenticationError, S7Error)
+        assert issubclass(S7StalePacketError, S7ProtocolError)
+        assert issubclass(S7PacketLostError, S7ProtocolError)
+
+    def test_all_subclasses_instantiate(self) -> None:
+        for cls in (
+            S7ConnectionError,
+            S7ProtocolError,
+            S7TimeoutError,
+            S7AuthenticationError,
+            S7StalePacketError,
+            S7PacketLostError,
+        ):
+            e = cls("test", error_code=1)
+            assert str(e) == "test"
+            assert e.error_code == 1
+
+
+class TestGetErrorMessage:
+    """Tests for get_error_message() — known and unknown codes."""
+
+    def test_success_code(self) -> None:
+        assert get_error_message(0x00000000) == "Success"
+
+    def test_known_client_error(self) -> None:
+        # Use a code unique to client errors (not overlapping with server: 0x009+)
+        assert get_error_message(0x00900000) == "errCliAddressOutOfRange"
+
+    def test_known_isotcp_error(self) -> None:
+        assert get_error_message(0x00010000) == "errIsoConnect"
+
+    def test_known_server_error(self) -> None:
+        assert get_error_message(0x00200000) == "errSrvDBNullPointer"
+
+    def test_unknown_code(self) -> None:
+        msg = get_error_message(0xDEADBEEF)
+        assert "Unknown error" in msg
+        assert "0xdeadbeef" in msg
+
+
+class TestGetProtocolErrorMessage:
+    """Tests for get_protocol_error_message() — known and unknown protocol codes."""
+
+    def test_known_protocol_code(self) -> None:
+        assert get_protocol_error_message(0x0000) == "No error"
+
+    def test_known_protocol_error(self) -> None:
+        assert "block number" in get_protocol_error_message(0x0110).lower()
+
+    def test_unknown_protocol_code(self) -> None:
+        msg = get_protocol_error_message(0xFFFF)
+        assert "Unknown protocol error" in msg
+
+
+class TestErrorText:
+    """Tests for error_text() with different contexts."""
+
+    def test_client_context(self) -> None:
+        msg = error_text(0x00100000, "client")
+        assert msg == "errNegotiatingPDU"
+
+    def test_server_context(self) -> None:
+        # Server dict has its own 0x00100000 entry
+        msg = error_text(0x00100000, "server")
+        assert msg == "errSrvCannotStart"
+
+    def test_partner_context(self) -> None:
+        # Partner uses client errors
+        msg = error_text(0x00100000, "partner")
+        assert msg == "errNegotiatingPDU"
+
+    def test_unknown_context_falls_back_to_client(self) -> None:
+        msg = error_text(0x00100000, "unknown_context")
+        assert msg == "errNegotiatingPDU"
+
+    def test_unknown_error_code(self) -> None:
+        msg = error_text(0xBADC0DE, "client")
+        assert "Unknown error" in msg
+
+    def test_caching(self) -> None:
+        # Calling twice should return the same cached result
+        a = error_text(0x00100000, "client")
+        b = error_text(0x00100000, "client")
+        assert a == b
+
+
+class TestCheckError:
+    """Tests for check_error() — routes error codes to exception types."""
+
+    def test_zero_returns_none(self) -> None:
+        # Should not raise
+        check_error(0)
+
+    def test_iso_connect_raises_connection_error(self) -> None:
+        with pytest.raises(S7ConnectionError):
+            check_error(0x00010000)
+
+    def test_iso_disconnect_raises_connection_error(self) -> None:
+        with pytest.raises(S7ConnectionError):
+            check_error(0x00020000)
+
+    def test_timeout_raises_timeout_error(self) -> None:
+        with pytest.raises(S7TimeoutError):
+            check_error(0x02000000)
+
+    def test_other_isotcp_raises_connection_error(self) -> None:
+        with pytest.raises(S7ConnectionError):
+            check_error(0x00030000)  # errIsoInvalidPDU
+
+    def test_generic_error_raises_runtime_error(self) -> None:
+        with pytest.raises(RuntimeError):
+            check_error(0x00100000)  # errNegotiatingPDU (client error)
+
+
+class TestErrorWrap:
+    """Tests for error_wrap() decorator."""
+
+    def test_no_error(self) -> None:
+        @error_wrap("client")
+        def ok_func() -> int:
+            return 0
+
+        # Should not raise, returns None (decorator suppresses return value)
+        result = ok_func()
+        assert result is None
+
+    def test_raises_on_error(self) -> None:
+        @error_wrap("client")
+        def bad_func() -> int:
+            return 0x02000000  # timeout
+
+        with pytest.raises(S7TimeoutError):
+            bad_func()
+
+    def test_passes_args_through(self) -> None:
+        @error_wrap("client")
+        def func_with_args(a: int, b: int) -> int:
+            return a + b
+
+        # 0 + 0 = 0, no error
+        func_with_args(0, 0)
+
+        with pytest.raises(RuntimeError):
+            # Non-zero = error
+            func_with_args(0x00100000, 0)

--- a/tests/test_s7protocol_coverage.py
+++ b/tests/test_s7protocol_coverage.py
@@ -1,0 +1,535 @@
+"""Tests for snap7.s7protocol — response parsers with crafted PDUs, error paths."""
+
+import struct
+import pytest
+from datetime import datetime
+
+from snap7.s7protocol import (
+    S7Protocol,
+    S7PDUType,
+    S7Function,
+    S7UserDataGroup,
+    S7UserDataSubfunction,
+    get_return_code_description,
+)
+from snap7.error import S7ProtocolError
+
+
+class TestGetReturnCodeDescription:
+    def test_known_code(self) -> None:
+        assert get_return_code_description(0xFF) == "Success"
+
+    def test_unknown_code(self) -> None:
+        assert get_return_code_description(0xAB) == "Unknown error"
+
+
+class TestParseResponse:
+    """Test parse_response() with crafted PDUs."""
+
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def _build_ack_data_pdu(
+        self,
+        func_code: int,
+        item_count: int = 1,
+        data_section: bytes = b"",
+        error_class: int = 0,
+        error_code: int = 0,
+        sequence: int = 1,
+    ) -> bytes:
+        """Build a minimal ACK_DATA PDU."""
+        params = struct.pack(">BB", func_code, item_count)
+        header = struct.pack(
+            ">BBHHHHBB",
+            0x32,
+            S7PDUType.ACK_DATA,
+            0x0000,
+            sequence,
+            len(params),
+            len(data_section),
+            error_class,
+            error_code,
+        )
+        return header + params + data_section
+
+    def test_pdu_too_short(self) -> None:
+        with pytest.raises(S7ProtocolError, match="too short"):
+            self.proto.parse_response(b"\x32\x03\x00")
+
+    def test_invalid_protocol_id(self) -> None:
+        # Build a valid-length PDU with wrong protocol ID
+        pdu = struct.pack(">BBHHHHBB", 0x99, S7PDUType.ACK_DATA, 0, 1, 0, 0, 0, 0)
+        with pytest.raises(S7ProtocolError, match="Invalid protocol ID"):
+            self.proto.parse_response(pdu)
+
+    def test_unexpected_pdu_type(self) -> None:
+        # REQUEST type (0x01) is not a valid response
+        pdu = struct.pack(">BBHHHHBB", 0x32, S7PDUType.REQUEST, 0, 1, 0, 0, 0, 0)
+        with pytest.raises(S7ProtocolError, match="Expected response PDU"):
+            self.proto.parse_response(pdu)
+
+    def test_header_error(self) -> None:
+        pdu = struct.pack(">BBHHHHBB", 0x32, S7PDUType.ACK_DATA, 0, 1, 0, 0, 0x05, 0x04)
+        with pytest.raises(S7ProtocolError, match="S7 protocol error"):
+            self.proto.parse_response(pdu)
+
+    def test_ack_no_data(self) -> None:
+        """ACK (type 0x02) PDU with no params or data — write response."""
+        pdu = struct.pack(">BBHHHHBB", 0x32, S7PDUType.ACK, 0, 1, 0, 0, 0, 0)
+        resp = self.proto.parse_response(pdu)
+        assert resp["sequence"] == 1
+        assert resp["parameters"] is None
+        assert resp["data"] is None
+
+    def test_read_response(self) -> None:
+        """ACK_DATA with read parameters and data."""
+        data_section = struct.pack(">BBH", 0xFF, 0x04, 16) + b"\xab\xcd"  # 16 bits = 2 bytes
+        pdu = self._build_ack_data_pdu(S7Function.READ_AREA, 1, data_section)
+        resp = self.proto.parse_response(pdu)
+        assert resp["parameters"]["function_code"] == S7Function.READ_AREA
+        assert resp["data"]["data"] == b"\xab\xcd"
+
+    def test_write_response_single_byte_data(self) -> None:
+        """Write response with single-byte data section (return code only)."""
+        data_section = b"\xff"  # success
+        pdu = self._build_ack_data_pdu(S7Function.WRITE_AREA, 1, data_section)
+        resp = self.proto.parse_response(pdu)
+        assert resp["data"]["return_code"] == 0xFF
+
+    def test_setup_comm_response(self) -> None:
+        params = struct.pack(">BBHHH", S7Function.SETUP_COMMUNICATION, 0x00, 1, 1, 480)
+        header = struct.pack(">BBHHHHBB", 0x32, S7PDUType.ACK_DATA, 0, 1, len(params), 0, 0, 0)
+        pdu = header + params
+        resp = self.proto.parse_response(pdu)
+        assert resp["parameters"]["pdu_length"] == 480
+
+    def test_param_section_extends_beyond_pdu(self) -> None:
+        # param_len = 100 but PDU is too short
+        header = struct.pack(">BBHHHHBB", 0x32, S7PDUType.ACK_DATA, 0, 1, 100, 0, 0, 0)
+        with pytest.raises(S7ProtocolError, match="Parameter section extends beyond PDU"):
+            self.proto.parse_response(header)
+
+    def test_data_section_extends_beyond_pdu(self) -> None:
+        # data_len = 100 but no data follows
+        params = struct.pack(">BB", S7Function.READ_AREA, 1)
+        header = struct.pack(">BBHHHHBB", 0x32, S7PDUType.ACK_DATA, 0, 1, len(params), 100, 0, 0)
+        pdu = header + params
+        with pytest.raises(S7ProtocolError, match="Data section extends beyond PDU"):
+            self.proto.parse_response(pdu)
+
+    def test_unknown_function_code(self) -> None:
+        pdu = self._build_ack_data_pdu(0xAA, 0)
+        resp = self.proto.parse_response(pdu)
+        assert resp["parameters"]["function_code"] == 0xAA
+
+
+class TestUserDataParsing:
+    """Test USERDATA PDU parsing."""
+
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def _build_userdata_response(
+        self,
+        group: int = S7UserDataGroup.SZL,
+        subfunction: int = S7UserDataSubfunction.READ_SZL,
+        sequence_number: int = 0,
+        last_data_unit: int = 0x00,
+        error_code: int = 0,
+        data_payload: bytes = b"",
+    ) -> bytes:
+        """Build a USERDATA response PDU."""
+        # Parameter section (12 bytes for response)
+        type_group = 0x80 | (group & 0x0F)  # response type
+        param_data = struct.pack(
+            ">BBBBBBBBBBH",
+            0x00,  # Reserved
+            0x01,  # Parameter count
+            0x12,  # Type header
+            0x08,  # Length (response = 8)
+            0x12,  # Method (response)
+            type_group,
+            subfunction,
+            sequence_number,
+            0x00,  # Data unit reference
+            last_data_unit,
+            error_code,
+        )
+
+        # Data section
+        data_section = (
+            struct.pack(
+                ">BBH",
+                0xFF,  # Return code (success)
+                0x09,  # Transport size (octet string)
+                len(data_payload),
+            )
+            + data_payload
+        )
+
+        header = struct.pack(
+            ">BBHHHH",
+            0x32,
+            S7PDUType.USERDATA,
+            0x0000,
+            1,
+            len(param_data),
+            len(data_section),
+        )
+
+        return header + param_data + data_section
+
+    def test_userdata_too_short(self) -> None:
+        pdu = struct.pack(">BBHH", 0x32, S7PDUType.USERDATA, 0, 1)
+        with pytest.raises(S7ProtocolError, match="too short"):
+            self.proto.parse_response(pdu)
+
+    def test_userdata_response(self) -> None:
+        pdu = self._build_userdata_response(data_payload=b"\x01\x02\x03\x04")
+        resp = self.proto.parse_response(pdu)
+        assert resp["parameters"]["group"] == S7UserDataGroup.SZL
+        assert resp["data"]["data"] == b"\x01\x02\x03\x04"
+
+    def test_userdata_with_error(self) -> None:
+        pdu = self._build_userdata_response(error_code=0x8104)
+        resp = self.proto.parse_response(pdu)
+        assert resp["parameters"]["error_code"] == 0x8104
+
+    def test_userdata_more_data_available(self) -> None:
+        pdu = self._build_userdata_response(last_data_unit=0x01, sequence_number=0x05)
+        resp = self.proto.parse_response(pdu)
+        assert resp["parameters"]["last_data_unit"] == 0x01
+        assert resp["parameters"]["sequence_number"] == 0x05
+
+
+class TestParseStartUploadResponse:
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def test_valid_response(self) -> None:
+        # Layout: func(1) + status(1) + reserved(1) + reserved(1) + upload_id(4) = 8 bytes
+        # Parser reads upload_id from raw_params[4:8]
+        raw_params = struct.pack(">BBBBI", S7Function.START_UPLOAD, 0x00, 0x00, 0x00, 0x12345678)
+        # Add block length: len_field(1) + length_str
+        # Condition: len(raw_params) > 9 + len_field, so we need total > 9 + len(length_str)
+        length_str = b"000100"
+        raw_params += struct.pack(">B", len(length_str)) + length_str + b"\x00"  # extra byte to satisfy >
+        response = {"raw_parameters": raw_params}
+        result = self.proto.parse_start_upload_response(response)
+        assert result["upload_id"] == 0x12345678
+        assert result["block_length"] == 100
+
+    def test_short_response(self) -> None:
+        response = {"raw_parameters": b"\x00\x00\x00"}
+        result = self.proto.parse_start_upload_response(response)
+        assert result["upload_id"] == 0
+        assert result["block_length"] == 0
+
+    def test_no_raw_parameters(self) -> None:
+        response = {}
+        result = self.proto.parse_start_upload_response(response)
+        assert result["upload_id"] == 0
+
+    def test_invalid_length_string(self) -> None:
+        raw_params = struct.pack(">BBBI", 0x1D, 0, 0, 1)
+        raw_params += struct.pack(">B", 3) + b"abc"
+        response = {"raw_parameters": raw_params}
+        result = self.proto.parse_start_upload_response(response)
+        assert result["block_length"] == 0  # ValueError caught
+
+
+class TestParseUploadResponse:
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def test_valid_response(self) -> None:
+        response = {"data": {"data": b"\x01\x02\x03\x04\x05"}}
+        result = self.proto.parse_upload_response(response)
+        assert result == b"\x01\x02\x03\x04\x05"
+
+    def test_short_data(self) -> None:
+        response = {"data": {"data": b"\x01\x02"}}
+        result = self.proto.parse_upload_response(response)
+        assert result == b""
+
+    def test_empty_response(self) -> None:
+        response = {"data": {"data": b""}}
+        result = self.proto.parse_upload_response(response)
+        assert result == b""
+
+    def test_no_data_key(self) -> None:
+        response = {}
+        result = self.proto.parse_upload_response(response)
+        assert result == b""
+
+
+class TestParseListBlocksResponse:
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def test_valid_response(self) -> None:
+        # Build entries: indicator(0x30) + type + count(2 bytes)
+        data = b""
+        data += struct.pack(">BBH", 0x30, 0x38, 5)  # OB: 5
+        data += struct.pack(">BBH", 0x30, 0x41, 3)  # DB: 3
+        data += struct.pack(">BBH", 0x30, 0x43, 7)  # FC: 7
+        response = {"data": {"data": data}}
+        result = self.proto.parse_list_blocks_response(response)
+        assert result["OBCount"] == 5
+        assert result["DBCount"] == 3
+        assert result["FCCount"] == 7
+        assert result["FBCount"] == 0
+
+    def test_empty_data(self) -> None:
+        response = {"data": {"data": b""}}
+        result = self.proto.parse_list_blocks_response(response)
+        assert result["DBCount"] == 0
+
+    def test_no_data(self) -> None:
+        response = {}
+        result = self.proto.parse_list_blocks_response(response)
+        assert all(v == 0 for v in result.values())
+
+    def test_unknown_block_type_ignored(self) -> None:
+        data = struct.pack(">BBH", 0x30, 0xFF, 99)  # unknown type
+        response = {"data": {"data": data}}
+        result = self.proto.parse_list_blocks_response(response)
+        assert all(v == 0 for v in result.values())
+
+
+class TestParseListBlocksOfTypeResponse:
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def test_valid_response(self) -> None:
+        # Each entry: block_num(2) + unknown(1) + lang(1)
+        data = struct.pack(">HBB", 1, 0, 0) + struct.pack(">HBB", 5, 0, 0) + struct.pack(">HBB", 100, 0, 0)
+        response = {"data": {"data": data}}
+        result = self.proto.parse_list_blocks_of_type_response(response)
+        assert result == [1, 5, 100]
+
+    def test_empty_data(self) -> None:
+        response = {"data": {"data": b""}}
+        result = self.proto.parse_list_blocks_of_type_response(response)
+        assert result == []
+
+    def test_no_data(self) -> None:
+        response = {}
+        result = self.proto.parse_list_blocks_of_type_response(response)
+        assert result == []
+
+
+class TestParseGetBlockInfoResponse:
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def test_short_data(self) -> None:
+        response = {"data": {"data": b"\x00" * 10}}
+        result = self.proto.parse_get_block_info_response(response)
+        assert result["block_type"] == 0
+        assert result["mc7_size"] == 0
+
+    def test_valid_data(self) -> None:
+        raw_data = bytearray(80)
+        raw_data[1] = 0x41  # block_type = DB
+        raw_data[9] = 0x01  # flags
+        raw_data[10] = 0x05  # lang
+        struct.pack_into(">H", raw_data, 12, 42)  # block_number
+        struct.pack_into(">I", raw_data, 14, 1024)  # load_size
+        struct.pack_into(">H", raw_data, 34, 100)  # sbb_length
+        struct.pack_into(">H", raw_data, 38, 50)  # local_data
+        struct.pack_into(">H", raw_data, 40, 200)  # mc7_size
+        raw_data[66] = 0x03  # version
+        struct.pack_into(">H", raw_data, 68, 0xABCD)  # checksum
+
+        response = {"data": {"data": bytes(raw_data)}}
+        result = self.proto.parse_get_block_info_response(response)
+        assert result["block_type"] == 0x41
+        assert result["block_number"] == 42
+        assert result["mc7_size"] == 200
+        assert result["load_size"] == 1024
+        assert result["checksum"] == 0xABCD
+        assert result["version"] == 0x03
+
+    def test_no_data(self) -> None:
+        response = {}
+        result = self.proto.parse_get_block_info_response(response)
+        assert result["block_type"] == 0
+
+
+class TestParseReadSZLResponse:
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def test_first_fragment(self) -> None:
+        raw_data = struct.pack(">HH", 0x0011, 0x0000) + b"\x01\x02\x03"
+        response = {"data": {"data": raw_data}}
+        result = self.proto.parse_read_szl_response(response, first_fragment=True)
+        assert result["szl_id"] == 0x0011
+        assert result["szl_index"] == 0x0000
+        assert result["data"] == b"\x01\x02\x03"
+
+    def test_first_fragment_short_data(self) -> None:
+        response = {"data": {"data": b"\x00\x01"}}
+        result = self.proto.parse_read_szl_response(response, first_fragment=True)
+        assert result["szl_id"] == 0
+        assert result["data"] == b""
+
+    def test_followup_fragment(self) -> None:
+        response = {"data": {"data": b"\xaa\xbb\xcc"}}
+        result = self.proto.parse_read_szl_response(response, first_fragment=False)
+        assert result["data"] == b"\xaa\xbb\xcc"
+        assert result["szl_id"] == 0
+
+    def test_empty_data(self) -> None:
+        response = {}
+        result = self.proto.parse_read_szl_response(response)
+        assert result["data"] == b""
+
+
+class TestParseGetClockResponse:
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def test_valid_bcd_time(self) -> None:
+        # BCD: reserved, year=24, month=03, day=15, hour=10, minute=30, second=45, dow=6(Saturday)
+        raw_data = struct.pack(">BBBBBBBB", 0x00, 0x24, 0x03, 0x15, 0x10, 0x30, 0x45, 0x06)
+        response = {"data": {"data": raw_data}}
+        result = self.proto.parse_get_clock_response(response)
+        assert result.year == 2024
+        assert result.month == 3
+        assert result.day == 15
+        assert result.hour == 10
+        assert result.minute == 30
+        assert result.second == 45
+
+    def test_year_90_is_1990(self) -> None:
+        raw_data = struct.pack(">BBBBBBBB", 0x00, 0x90, 0x01, 0x01, 0x00, 0x00, 0x00, 0x01)
+        response = {"data": {"data": raw_data}}
+        result = self.proto.parse_get_clock_response(response)
+        assert result.year == 1990
+
+    def test_short_data_returns_now(self) -> None:
+        response = {"data": {"data": b"\x00\x01"}}
+        result = self.proto.parse_get_clock_response(response)
+        # Should return roughly "now"
+        assert isinstance(result, datetime)
+
+    def test_invalid_bcd_date_returns_now(self) -> None:
+        # Month=99 is invalid
+        raw_data = struct.pack(">BBBBBBBB", 0x00, 0x24, 0x99, 0x15, 0x10, 0x30, 0x45, 0x06)
+        response = {"data": {"data": raw_data}}
+        result = self.proto.parse_get_clock_response(response)
+        # Should fallback to now
+        assert isinstance(result, datetime)
+
+
+class TestParseParameterEdgeCases:
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def test_empty_parameters(self) -> None:
+        result = self.proto._parse_parameters(b"")
+        assert result == {}
+
+    def test_read_response_params_too_short(self) -> None:
+        with pytest.raises(S7ProtocolError, match="too short"):
+            self.proto._parse_read_response_params(b"\x04")
+
+    def test_write_response_params_too_short(self) -> None:
+        with pytest.raises(S7ProtocolError, match="too short"):
+            self.proto._parse_write_response_params(b"\x05")
+
+    def test_setup_comm_params_too_short(self) -> None:
+        with pytest.raises(S7ProtocolError, match="too short"):
+            self.proto._parse_setup_comm_response_params(b"\xf0\x00\x00")
+
+
+class TestParseDataSection:
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def test_single_byte(self) -> None:
+        result = self.proto._parse_data_section(b"\xff")
+        assert result["return_code"] == 0xFF
+
+    def test_two_three_bytes_raw(self) -> None:
+        result = self.proto._parse_data_section(b"\xaa\xbb")
+        assert result["raw_data"] == b"\xaa\xbb"
+
+    def test_octet_string_transport(self) -> None:
+        # Transport size 0x09 = octet string (byte length)
+        data = struct.pack(">BBH", 0xFF, 0x09, 3) + b"\x01\x02\x03"
+        result = self.proto._parse_data_section(data)
+        assert result["data"] == b"\x01\x02\x03"
+
+    def test_byte_transport_bit_length(self) -> None:
+        # Transport size 0x04 = byte (bit length)
+        data = struct.pack(">BBH", 0xFF, 0x04, 24) + b"\x01\x02\x03"  # 24 bits = 3 bytes
+        result = self.proto._parse_data_section(data)
+        assert result["data"] == b"\x01\x02\x03"
+
+
+class TestExtractReadData:
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def test_no_data_in_response(self) -> None:
+        with pytest.raises(S7ProtocolError, match="No data"):
+            self.proto.extract_read_data({}, None, 0)  # type: ignore[arg-type]
+
+    def test_non_success_return_code(self) -> None:
+        response = {"data": {"return_code": 0x05, "data": b""}}
+        with pytest.raises(S7ProtocolError, match="Read operation failed"):
+            self.proto.extract_read_data(response, None, 0)  # type: ignore[arg-type]
+
+    def test_success(self) -> None:
+        from snap7.datatypes import S7WordLen
+
+        response = {"data": {"return_code": 0xFF, "data": b"\x01\x02\x03"}}
+        result = self.proto.extract_read_data(response, S7WordLen.BYTE, 3)
+        assert result == [1, 2, 3]
+
+
+class TestCheckWriteResponse:
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def test_header_error(self) -> None:
+        with pytest.raises(S7ProtocolError, match="Write operation failed"):
+            self.proto.check_write_response({"error_code": 0x8104})
+
+    def test_data_section_error(self) -> None:
+        with pytest.raises(S7ProtocolError, match="Write operation failed"):
+            self.proto.check_write_response({"error_code": 0, "data": {"return_code": 0x05}})
+
+    def test_success_with_data(self) -> None:
+        # Should not raise
+        self.proto.check_write_response({"error_code": 0, "data": {"return_code": 0xFF}})
+
+    def test_success_without_data(self) -> None:
+        # ACK without data section — should not raise
+        self.proto.check_write_response({"error_code": 0})
+
+
+class TestValidatePDUReference:
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+        self.proto.sequence = 5
+
+    def test_matching(self) -> None:
+        # Should not raise
+        self.proto.validate_pdu_reference(5)
+
+    def test_stale(self) -> None:
+        from snap7.error import S7StalePacketError
+
+        with pytest.raises(S7StalePacketError):
+            self.proto.validate_pdu_reference(3)
+
+    def test_lost(self) -> None:
+        from snap7.error import S7PacketLostError
+
+        with pytest.raises(S7PacketLostError):
+            self.proto.validate_pdu_reference(7)

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -1,7 +1,10 @@
 """Tests for snap7.server.__main__ — CLI entrypoint."""
 
-from click.testing import CliRunner
-from snap7.server.__main__ import main
+import pytest
+
+click = pytest.importorskip("click")
+from click.testing import CliRunner  # noqa: E402
+from snap7.server.__main__ import main  # noqa: E402
 
 
 class TestServerCLI:

--- a/tests/test_server_cli.py
+++ b/tests/test_server_cli.py
@@ -1,0 +1,27 @@
+"""Tests for snap7.server.__main__ — CLI entrypoint."""
+
+from click.testing import CliRunner
+from snap7.server.__main__ import main
+
+
+class TestServerCLI:
+    """Test the Click CLI entrypoint."""
+
+    def test_help(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["--help"])
+        assert result.exit_code == 0
+        assert "Start a S7 dummy server" in result.output
+
+    def test_help_short(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["-h"])
+        assert result.exit_code == 0
+        assert "--port" in result.output
+
+    def test_version(self) -> None:
+        runner = CliRunner()
+        result = runner.invoke(main, ["--version"])
+        assert result.exit_code == 0
+        # Should print version string
+        assert "version" in result.output.lower() or "." in result.output


### PR DESCRIPTION
## Summary
- Added 203 new tests across 5 new test files to improve overall code coverage from 78% to 84%
- All tests run without a real PLC, using mocks, crafted byte sequences, and unit testing
- Key coverage improvements:
  - `snap7/error.py`: 70% -> **100%** (check_error, error_wrap decorator, get_error_message)
  - `snap7/connection.py`: 68% -> **98%** (COTP parsing, socket error paths, context manager)
  - `snap7/s7protocol.py`: 89% -> **98%** (response parsers with crafted PDUs, error paths)
  - `snap7/util/db.py`: 65% -> **99%** (DB/Row dict-like interface, read/write with mocked client, all type branches)
  - `snap7/server/__main__.py`: 0% -> **62%** (Click CLI help/version)

## New test files
- `tests/test_error.py` — exception classes, check_error(), error_wrap(), get_error_message()
- `tests/test_connection.py` — ISOTCPConnection with mocked sockets, COTP CC/DT parsing, error paths
- `tests/test_server_cli.py` — Click CLI entrypoint (--help, --version)
- `tests/test_s7protocol_coverage.py` — S7Protocol response parsers with crafted PDUs
- `tests/test_db_coverage.py` — DB/Row dict interface, read/write with mocked client, all type conversions

## Test plan
- [x] All 650 tests pass (`uv run pytest tests/ --ignore=tests/test_s7commplus_e2e.py`)
- [x] mypy clean (`uv run mypy snap7`)
- [x] ruff check clean (`uv run ruff check snap7 tests/`)
- [x] ruff format clean (`uv run ruff format --check snap7 tests/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)