### PR TITLE
Add get_ulint and get_lint to snap7.util exports

### DIFF
--- a/snap7/util/__init__.py
+++ b/snap7/util/__init__.py
@@ -52,6 +52,8 @@ from .getters import (
     get_char,
     get_wchar,
     get_dtl,
+    get_lint,
+    get_ulint,
 )
 
 __all__ = [
@@ -82,6 +84,8 @@ __all__ = [
     "get_fstring",
     "get_string",
     "get_wstring",
+    "get_lint",
+    "get_ulint",
     "set_real",
     "set_dword",
     "set_date",

--- a/snap7/util/__init__.py
+++ b/snap7/util/__init__.py
@@ -54,6 +54,7 @@ from .getters import (
     get_dtl,
     get_lint,
     get_ulint,
+    get_date_time_object,
 )
 
 __all__ = [
@@ -86,6 +87,7 @@ __all__ = [
     "get_wstring",
     "get_lint",
     "get_ulint",
+    "get_date_time_object",
     "set_real",
     "set_dword",
     "set_date",

--- a/snap7/util/getters.py
+++ b/snap7/util/getters.py
@@ -486,7 +486,7 @@ def get_lint(bytearray_: Buffer, byte_index: int) -> int:
         >>> from snap7 import Client
         >>> data = Client().db_read(db_number=1, start=10, size=8)
         >>> get_lint(data, 0)
-            12345
+        12345
     """
 
     raw_lint = bytearray_[byte_index : byte_index + 8]
@@ -562,7 +562,7 @@ def get_ulint(bytearray_: Buffer, byte_index: int) -> int:
         >>> from snap7 import Client
         >>> data = Client().db_read(db_number=1, start=10, size=8)
         >>> get_ulint(data, 0)
-            12345
+        12345
     """
     raw_ulint = bytearray_[byte_index : byte_index + 8]
     lint: int = struct.unpack(">Q", struct.pack("8B", *raw_ulint))[0]

--- a/snap7/util/getters.py
+++ b/snap7/util/getters.py
@@ -1,6 +1,6 @@
 import struct
 from datetime import timedelta, datetime, date
-from typing import NoReturn, Union
+from typing import Union
 from logging import getLogger
 
 #: Buffer types accepted by getter functions.
@@ -787,7 +787,3 @@ def get_wstring(bytearray_: Buffer, byte_index: int) -> str:
         )
 
     return bytes(bytearray_[wstring_start : wstring_start + wstr_symbols_amount]).decode("utf-16-be")
-
-
-def get_array(bytearray_: Buffer, byte_index: int) -> NoReturn:
-    raise NotImplementedError


### PR DESCRIPTION
## Summary
- Export `get_ulint`, `get_lint`, and `get_date_time_object` from `snap7.util`
- Remove unimplemented `get_array` stub (raised `NotImplementedError` since 2024, no references anywhere)
- Clean up unused `NoReturn` import in getters.py

Closes #651

## Test plan
- [x] Verified `from snap7.util import get_ulint, get_lint, get_date_time_object` works
- [x] Verified no remaining references to `get_array`
- [x] ruff and mypy pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)