### PR TITLE
Remove Codecov integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,4 @@ jobs:
           uv venv --python python${{ matrix.python-version }}
           uv pip install ".[test]"
       - name: Run pytest
-        run: uv run pytest --cov=snap7 --cov-report=xml --cov-report=term
-      - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.13' && matrix.runs-on == 'ubuntu-24.04'
-        uses: codecov/codecov-action@v5
-        with:
-          files: coverage.xml
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
+        run: uv run pytest --cov=snap7 --cov-report=term

--- a/README.rst
+++ b/README.rst
@@ -13,9 +13,6 @@
 .. image:: https://readthedocs.org/projects/python-snap7/badge/
    :target: https://python-snap7.readthedocs.io/en/latest/
 
-.. image:: https://codecov.io/gh/gijzelaerr/python-snap7/branch/master/graph/badge.svg
-   :target: https://codecov.io/gh/gijzelaerr/python-snap7
-
 About
 =====
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: 80%


### PR DESCRIPTION
## Summary
- Remove `codecov.yml` config and coverage upload CI step
- Remove Codecov badge from README
- Local coverage reporting (`--cov-report=term`) is kept

## Test plan
- [x] CI should still run tests with coverage output to terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)