### PR TITLE
Update documentation for recent features

### DIFF
--- a/doc/API/s7commplus.rst
+++ b/doc/API/s7commplus.rst
@@ -43,6 +43,64 @@ Asynchronous client
 
    asyncio.run(main())
 
+V2 connection with TLS
+----------------------
+
+S7-1500 PLCs with firmware 2.x use S7CommPlus V2, which requires TLS. Pass
+``use_tls=True`` to the ``connect()`` method:
+
+.. code-block:: python
+
+   from snap7.s7commplus.client import S7CommPlusClient
+
+   client = S7CommPlusClient()
+   client.connect("192.168.1.10", use_tls=True)
+   data = client.db_read(1, 0, 4)
+   client.disconnect()
+
+For PLCs with custom certificates, provide the certificate paths:
+
+.. code-block:: python
+
+   client.connect(
+       "192.168.1.10",
+       use_tls=True,
+       tls_cert="/path/to/client.pem",
+       tls_key="/path/to/client.key",
+       tls_ca="/path/to/ca.pem",
+   )
+
+Password authentication
+-----------------------
+
+Password-protected PLCs require authentication after connecting. Call
+``authenticate()`` before performing data operations:
+
+.. code-block:: python
+
+   from snap7.s7commplus.client import S7CommPlusClient
+
+   client = S7CommPlusClient()
+   client.connect("192.168.1.10", use_tls=True)
+   client.authenticate(password="my_plc_password")
+
+   data = client.db_read(1, 0, 4)
+   client.disconnect()
+
+The method auto-detects whether to use legacy (SHA-1 XOR) or new-style
+(AES-256-CBC) authentication based on the PLC firmware version. For new-style
+authentication, you can also provide a username:
+
+.. code-block:: python
+
+   client.authenticate(password="my_password", username="admin")
+
+.. note::
+
+   Authentication requires TLS to be active. Calling ``authenticate()``
+   without ``use_tls=True`` will raise :class:`~snap7.error.S7ConnectionError`.
+
+
 Legacy fallback
 ---------------
 

--- a/doc/connection-issues.rst
+++ b/doc/connection-issues.rst
@@ -8,11 +8,57 @@ Connection Issues
 
 .. _connection-recovery:
 
-Connection Recovery
+Automatic Reconnection
+----------------------
+
+The :class:`~snap7.client.Client` has built-in auto-reconnect with exponential
+backoff and optional heartbeat monitoring. This is the recommended approach for
+long-running applications:
+
+.. code-block:: python
+
+   import snap7
+
+   def on_disconnect():
+       print("Connection lost!")
+
+   def on_reconnect():
+       print("Reconnected!")
+
+   client = snap7.Client(
+       auto_reconnect=True,        # Enable automatic reconnection
+       max_retries=5,              # Retry up to 5 times (default: 3)
+       retry_delay=1.0,            # Initial delay between retries in seconds
+       backoff_factor=2.0,         # Double the delay after each failure
+       max_delay=30.0,             # Cap delay at 30 seconds
+       heartbeat_interval=10.0,    # Probe connection every 10 seconds (0=disabled)
+       on_disconnect=on_disconnect,
+       on_reconnect=on_reconnect,
+   )
+   client.connect("192.168.1.10", 0, 1)
+
+   # If the connection drops, read/write operations will automatically
+   # reconnect before retrying. The heartbeat detects silent disconnects.
+   data = client.db_read(1, 0, 10)
+
+The parameters:
+
+- **auto_reconnect**: Enable automatic reconnection on connection loss.
+- **max_retries**: Maximum reconnection attempts before raising an error.
+- **retry_delay**: Initial delay (seconds) between reconnection attempts.
+- **backoff_factor**: Multiplier applied to the delay after each failed attempt.
+- **max_delay**: Upper bound on the delay between attempts.
+- **heartbeat_interval**: Interval (seconds) for background heartbeat probes.
+  Set to ``0`` to disable (default).
+- **on_disconnect**: Callback invoked when the connection is lost.
+- **on_reconnect**: Callback invoked after a successful reconnection.
+
+
+Manual Reconnection
 -------------------
 
-Network connections to PLCs can drop due to cable issues, PLC restarts, or
-network problems. Use a reconnection pattern to handle this gracefully:
+If you need full control over reconnection behavior, you can implement it
+manually:
 
 .. code-block:: python
 
@@ -40,20 +86,6 @@ network problems. Use a reconnection pattern to handle this gracefully:
            time.sleep(1)
            connect()
            return client.db_read(db, start, size)
-
-   def safe_write(db: int, start: int, data: bytearray) -> None:
-       """Write to DB with automatic reconnection on failure."""
-       try:
-           client.db_write(db, start, data)
-       except Exception:
-           logger.warning("Write failed, attempting reconnection...")
-           try:
-               client.disconnect()
-           except Exception:
-               pass
-           time.sleep(1)
-           connect()
-           client.db_write(db, start, data)
 
 For long-running applications, wrap your main loop with reconnection logic:
 

--- a/doc/limitations.rst
+++ b/doc/limitations.rst
@@ -17,12 +17,14 @@ are **not possible** with this protocol:
      - The PLC stores only raw bytes. The structure definition lives in the TIA
        Portal project. You must define your data layout in your Python code.
    * - Discover PLCs on the network
-     - There is no S7 broadcast discovery mechanism. You must know the PLC's IP
-       address.
+     - The classic S7 protocol has no broadcast discovery mechanism. However,
+       python-snap7 provides PROFINET DCP discovery via the ``s7 discover``
+       CLI command (requires ``pip install python-snap7[discovery]``).
+       See :doc:`cli` for details.
    * - Create PLC backups
      - Full project backup requires TIA Portal. python-snap7 can upload
        individual blocks, but this is not a complete backup.
    * - Access S7-1200/1500 PLCs with S7CommPlus security
-     - PLCs configured to require S7CommPlus encrypted communication cannot be
-       accessed with the classic S7 protocol. PUT/GET must be enabled as a
-       fallback.
+     - python-snap7 supports S7CommPlus V1 and V2 (with TLS) via
+       :mod:`snap7.s7commplus`. V3 is not yet supported. For PLCs that only
+       support V3, enable PUT/GET as a fallback or use OPC UA.

--- a/doc/plc-support.rst
+++ b/doc/plc-support.rst
@@ -58,8 +58,8 @@ Supported PLCs
      - PUT/GET only
      - No
      - V2
-     - **PUT/GET only**
-     - S7CommPlus V2 support is in development.
+     - **Full** (S7CommPlus V2)
+     - S7CommPlus V2 with TLS is supported via :mod:`snap7.s7commplus`.
    * - S7-1500 (FW 3.x+)
      - ~2022
      - PUT/GET only
@@ -132,18 +132,19 @@ Siemens has evolved their PLC communication protocols over time:
      - Challenge-response
      - S7-1200 FW 4+, S7-1500 FW 1.x
    * - S7CommPlus V2
-     - Proprietary
-     - Yes
+     - TLS 1.3
+     - Challenge-response + TLS
      - S7-1500 FW 2.x
    * - S7CommPlus V3
      - TLS
      - Certificate-based
      - S7-1500 FW 3.x+
 
-python-snap7 implements the **classic S7 protocol**, which remains available
-on most PLC families via the PUT/GET mechanism. For PLCs that only support
-S7CommPlus V2 or V3 (such as the S7-1500R/H), no open-source solution
-currently exists — consider using OPC UA as an alternative.
+python-snap7 implements the **classic S7 protocol** and **S7CommPlus V1/V2**.
+The classic protocol remains available on most PLC families via the PUT/GET
+mechanism. S7CommPlus V1 and V2 (with TLS) are supported via the
+:mod:`snap7.s7commplus` package. For PLCs that require S7CommPlus V3 (such
+as the S7-1500R/H), consider using OPC UA as an alternative.
 
 
 Alternatives for Unsupported PLCs

--- a/doc/reading-writing.rst
+++ b/doc/reading-writing.rst
@@ -175,6 +175,36 @@ DWORD (4 bytes, unsigned 0--4294967295)
    snap7.util.set_dword(data, 0, 3000000000)
    client.db_write(1, 40, data)
 
+LINT (8 bytes, signed -9223372036854775808 to 9223372036854775807)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   # Read 8 bytes from DB1 at offset 60
+   data = client.db_read(1, 60, 8)
+   value = snap7.util.get_lint(data, 0)
+   print(f"LINT = {value}")
+
+   # Write (no set_lint helper -- use struct directly)
+   import struct
+   data = bytearray(struct.pack(">q", 123456789012345))
+   client.db_write(1, 60, data)
+
+ULINT (8 bytes, unsigned 0--18446744073709551615)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   # Read 8 bytes from DB1 at offset 68
+   data = client.db_read(1, 68, 8)
+   value = snap7.util.get_ulint(data, 0)
+   print(f"ULINT = {value}")
+
+   # Write (no set_ulint helper -- use struct directly)
+   import struct
+   data = bytearray(struct.pack(">Q", 9876543210))
+   client.db_write(1, 68, data)
+
 REAL (4 bytes, IEEE 754 float)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
## Summary
- Add auto-reconnect and heartbeat monitoring documentation to connection-issues.rst (the Client now supports `auto_reconnect`, `heartbeat_interval`, exponential backoff, and callbacks)
- Update limitations.rst: PROFINET DCP discovery is now available, S7CommPlus V1/V2 are supported
- Update plc-support.rst: S7CommPlus V2 status changed from "in development" to functional, fix V2 encryption description from "Proprietary" to "TLS 1.3"
- Add V2 TLS connection and password authentication examples to API/s7commplus.rst
- Add LINT (8-byte signed) and ULINT (8-byte unsigned) data type sections to reading-writing.rst

## Test plan
- [ ] Verify Sphinx docs build without warnings (`make -C doc html`)
- [ ] Review all cross-references resolve correctly
- [ ] Verify code examples are syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)