### PR TITLE
Replace pip with uv across all CI workflows

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -26,9 +26,7 @@ jobs:
         with:
           enable-cache: true
       - name: Install dependencies
-        run: |
-          uv venv
-          uv pip install ".[doc,cli]"
+        run: uv sync --extra doc --extra cli
       - name: Build documentation
         run: uv run sphinx-build -N -bhtml doc/ doc/_build -W
       - name: Upload Pages artifact

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -17,10 +17,12 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - name: Install build
-        run: pip install build
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
       - name: Build distribution
-        run: python -m build
+        run: uv build
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -16,10 +16,12 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
-      - name: Install build
-        run: pip install build
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
       - name: Build distribution
-        run: python -m build
+        run: uv build
       - name: Upload artifact
         uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/source-build.yml
+++ b/.github/workflows/source-build.yml
@@ -23,13 +23,9 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-      - name: Install build tools
-        run: |
-          uv venv
-          uv pip install build
       - name: Create source tarball
         run: |
-           uv run python -m build . --sdist
+           uv build --sdist
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v7

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,8 +28,6 @@ jobs:
         with:
           enable-cache: true
       - name: Install dependencies
-        run: |
-          uv venv --python python${{ matrix.python-version }}
-          uv pip install ".[test,s7commplus]"
+        run: uv sync --extra test --extra s7commplus --python python${{ matrix.python-version }}
       - name: Run pytest
         run: uv run pytest --cov=snap7 --cov-report=term


### PR DESCRIPTION
## Summary

- Replace bare `pip install` and `python -m build` with `uv build` and `uv sync` across all CI workflows
- `uv venv` does not include `pip`, so `python -m build` (which needs pip to install build deps in its isolated env) fails
- This broke the source-build workflow today

## Changes

| Workflow | Before | After |
|----------|--------|-------|
| **source-build.yml** | `uv venv` + `uv pip install build` + `python -m build --sdist` | `uv build --sdist` |
| **publish-pypi.yml** | `pip install build` + `python -m build` | `uv build` |
| **publish-test-pypi.yml** | `pip install build` + `python -m build` | `uv build` |
| **test.yml** | `uv venv` + `uv pip install` | `uv sync --extra` |
| **doc.yml** | `uv venv` + `uv pip install` | `uv sync --extra` |

No `--system`, no bare `pip`, all venv-based.

## Test plan

- [ ] source-build workflow passes (was failing before this fix)
- [ ] test workflow passes across all OS/Python matrix
- [ ] doc workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)