### PR TITLE
Recommend s7 as primary package in docs

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Python-snap7 is a pure Python S7 communication library for interfacing with
 Siemens S7 PLCs. It supports Python 3.10+ and runs on Windows, Linux, and macOS
 without any native dependencies.
 
-The name "python-snap7" is historical — the library originally started as a
+The name "python-snap7" is historical -- the library originally started as a
 Python wrapper around the `Snap7 <http://snap7.sourceforge.net/>`_ C library.
 As of version 3.0, the C library is no longer used, but the name is kept for
 backwards compatibility.
@@ -29,26 +29,78 @@ backwards compatibility.
 The full documentation is available on `Read The Docs <https://python-snap7.readthedocs.io/en/latest/>`_.
 
 
-Installation
-============
+Quick Start
+===========
 
 Install using pip::
 
    $ pip install python-snap7
 
-No native libraries or platform-specific dependencies are required — python-snap7
-is a pure Python package that works on all platforms.
+The recommended way to use this library is through the ``s7`` package, which
+works with **all supported PLC models** (S7-300, S7-400, S7-1200, S7-1500) and
+automatically selects the best protocol::
+
+   from s7 import Client
+
+   client = Client()
+   client.connect("192.168.1.10", 0, 1)  # auto-detects S7CommPlus vs legacy S7
+   data = client.db_read(1, 0, 4)
+   client.disconnect()
+
+The ``s7.Client`` automatically tries S7CommPlus first (for S7-1200/1500), and
+falls back to legacy S7 when needed. No native libraries or platform-specific
+dependencies are required.
+
+The legacy ``snap7`` package is still available for backwards compatibility::
+
+   import snap7
+
+   client = snap7.Client()
+   client.connect("192.168.1.10", 0, 1)
+   data = client.db_read(1, 0, 4)
+   client.disconnect()
 
 
-Version 3.0 — Pure Python Rewrite
-==================================
+Version 3.1 -- S7CommPlus Protocol Support (unreleased)
+========================================================
+
+Version 3.1 adds support for the S7CommPlus protocol (up to V2), which is
+required for communicating with newer Siemens S7-1200 and S7-1500 PLCs that
+have PUT/GET disabled. This is fully backwards compatible with 3.0.
+
+The ``s7`` package is now the recommended entry point for connecting to any
+supported S7 PLC. The existing ``snap7`` package continues to work unchanged
+for legacy S7 connections.
+
+**Help us test!** Version 3.1 needs more real-world testing before release. If
+you have access to any of the following PLCs, we would greatly appreciate
+testing and feedback:
+
+* S7-1200 (any firmware version)
+* S7-1500 (any firmware version)
+* S7-1500 with TLS enabled
+* S7-300
+* S7-400
+* S7-1200/1500 with PUT/GET disabled (S7CommPlus-only)
+* LOGO! 0BA8 and newer
+
+Please report your results -- whether it works or not -- on the
+`issue tracker <https://github.com/gijzelaerr/python-snap7/issues>`_.
+
+To install the development version::
+
+   $ pip install git+https://github.com/gijzelaerr/python-snap7.git@master
+
+
+Version 3.0 -- Pure Python Rewrite
+====================================
 
 Version 3.0 was a ground-up rewrite of python-snap7. The library no longer wraps
-the C snap7 shared library — instead, the entire S7 protocol stack (TPKT, COTP,
+the C snap7 shared library -- instead, the entire S7 protocol stack (TPKT, COTP,
 and S7) is implemented in pure Python.
 
 * **Portability**: No more platform-specific shared libraries (``.dll``, ``.so``, ``.dylib``).
-  Works on any platform that runs Python — including ARM, Alpine Linux, and other
+  Works on any platform that runs Python -- including ARM, Alpine Linux, and other
   environments where the C library was difficult or impossible to install.
 * **Easier installation**: Just ``pip install python-snap7``. No native dependencies,
   no compiler toolchains, no manual library setup.
@@ -63,44 +115,3 @@ and S7) is implemented in pure Python.
 
    Documentation for pre-3.0 versions is available at
    `Read The Docs <https://python-snap7.readthedocs.io/en/2.1.1/>`_.
-
-
-Version 3.1 — S7CommPlus Protocol Support (unreleased)
-=======================================================
-
-Version 3.1 adds support for the S7CommPlus protocol (up to V3), which is required
-for communicating with newer Siemens S7-1200 and S7-1500 PLCs that have PUT/GET
-disabled. This is fully backwards compatible with 3.0.
-
-The biggest change is the new ``s7`` module, which is now the recommended entry point
-for connecting to any supported S7 PLC::
-
-   from s7 import Client
-
-   client = Client()
-   client.connect("192.168.1.10", 0, 1)  # auto-detects S7CommPlus vs legacy S7
-   data = client.db_read(1, 0, 4)
-   client.disconnect()
-
-The ``s7.Client`` automatically tries S7CommPlus first, and falls back to legacy S7
-if the PLC does not support it. The existing ``snap7.Client`` continues to work
-unchanged for legacy S7 connections.
-
-**Help us test!** Version 3.1 needs more real-world testing before release. If you
-have access to any of the following PLCs, we would greatly appreciate testing and
-feedback:
-
-* S7-1200 (any firmware version)
-* S7-1500 (any firmware version)
-* S7-1500 with TLS enabled
-* S7-300
-* S7-400
-* S7-1200/1500 with PUT/GET disabled (S7CommPlus-only)
-* LOGO! 0BA8 and newer
-
-Please report your results — whether it works or not — on the
-`issue tracker <https://github.com/gijzelaerr/python-snap7/issues>`_.
-
-To install the development version::
-
-   $ pip install git+https://github.com/gijzelaerr/python-snap7.git@master

--- a/doc/API/async_client.rst
+++ b/doc/API/async_client.rst
@@ -1,11 +1,9 @@
-AsyncClient
-===========
+AsyncClient (legacy)
+====================
 
-.. warning::
-
-   The ``AsyncClient`` is **experimental**. The API may change in future
-   releases. If you encounter problems, please `open an issue
-   <https://github.com/gijzelaerr/python-snap7/issues>`_.
+The :class:`~snap7.async_client.AsyncClient` is the legacy async S7 client.
+For new projects, we recommend using ``s7.AsyncClient`` instead --
+see :doc:`s7commplus`.
 
 The :class:`~snap7.async_client.AsyncClient` provides a native ``asyncio``
 interface for communicating with Siemens S7 PLCs.  It has feature parity with
@@ -18,10 +16,10 @@ Quick start
 .. code-block:: python
 
    import asyncio
-   import snap7
+   from s7 import AsyncClient
 
    async def main():
-       async with snap7.AsyncClient() as client:
+       async with AsyncClient() as client:
            await client.connect("192.168.1.10", 0, 1)
            data = await client.db_read(1, 0, 4)
            print(data)

--- a/doc/API/client.rst
+++ b/doc/API/client.rst
@@ -1,5 +1,11 @@
-Client
-======
+Client (legacy)
+===============
+
+The ``snap7.Client`` is the legacy S7 protocol client. It supports S7-300,
+S7-400, S7-1200 and S7-1500 PLCs via the classic PUT/GET interface.
+
+For new projects, we recommend using :doc:`s7commplus` (``s7.Client``) instead,
+which works with all PLC models and automatically selects the best protocol.
 
 .. automodule:: snap7.client
    :members:

--- a/doc/API/s7commplus.rst
+++ b/doc/API/s7commplus.rst
@@ -1,15 +1,10 @@
-S7CommPlus (S7-1200/1500)
-=========================
+S7 Client (recommended)
+=======================
 
-.. warning::
-
-   S7CommPlus support is **experimental**. The API may change in future
-   releases. If you encounter problems, please `open an issue
-   <https://github.com/gijzelaerr/python-snap7/issues>`_.
-
-The ``s7`` package provides a unified client for Siemens S7-1200 and S7-1500
-PLCs. It automatically tries the S7CommPlus protocol first and falls back to
-the legacy S7 protocol when needed.
+The ``s7`` package is the recommended entry point for communicating with any
+supported Siemens S7 PLC. It provides a unified client that works with all
+PLC models -- S7-300, S7-400, S7-1200 and S7-1500 -- and automatically
+selects the best protocol (S7CommPlus or legacy S7).
 
 Synchronous client
 ------------------

--- a/doc/API/server.rst
+++ b/doc/API/server.rst
@@ -1,22 +1,36 @@
 Server
 ======
 
-The pure Python server implementation provides a simulated S7 server for testing.
-
-To start a server programmatically:
+The ``s7.Server`` is the recommended server for testing. It wraps both a
+legacy S7 server and an S7CommPlus server, so test environments can serve
+both protocol stacks simultaneously.
 
 .. code:: python
 
-   from snap7.server import Server, mainloop
+   from s7 import Server
 
-   # Quick start with mainloop helper
+   server = Server()
+   server.start(tcp_port=1102)
+
+For quick testing with the legacy server, you can also use the ``mainloop``
+helper:
+
+.. code:: python
+
+   from snap7.server import mainloop
+
    mainloop(tcp_port=1102)
 
-   # Or create and configure manually
-   server = Server()
-   server.start(port=1102)
-
 ----
+
+s7.Server
+---------
+
+.. automodule:: s7.server
+   :members:
+
+snap7.Server (legacy)
+---------------------
 
 .. automodule:: snap7.server
    :members:

--- a/doc/API/util.rst
+++ b/doc/API/util.rst
@@ -1,5 +1,15 @@
 Util
 ====
 
+Data type conversion helpers for reading and writing S7 data types (BOOL, INT,
+REAL, STRING, etc.). Available as ``s7.util`` or ``snap7.util``:
+
+.. code-block:: python
+
+   from s7 import util
+
+   data = client.db_read(1, 0, 4)
+   value = util.get_real(data, 0)
+
 .. automodule:: snap7.util
    :members:

--- a/doc/connecting.rst
+++ b/doc/connecting.rst
@@ -2,7 +2,8 @@ Connecting to PLCs
 ==================
 
 This page shows how to connect to different Siemens PLC models using
-python-snap7.
+python-snap7. All examples use the recommended ``s7`` package, which works
+with every supported PLC model.
 
 .. contents:: On this page
    :local:
@@ -31,21 +32,24 @@ Rack/Slot Reference
    * - S7-1200
      - 0
      - 1
-     - PUT/GET access must be enabled in TIA Portal
+     - PUT/GET access must be enabled in TIA Portal (or use S7CommPlus)
    * - S7-1500
      - 0
      - 1
-     - PUT/GET access must be enabled in TIA Portal
+     - PUT/GET access must be enabled in TIA Portal (or use S7CommPlus)
    * - S7-200 / Logo
      - --
      - --
-     - Use ``set_connection_params`` with TSAP addressing
+     - Use ``set_connection_params`` with TSAP addressing (legacy ``snap7`` package)
 
 .. warning::
 
    S7-1200 and S7-1500 PLCs ship with PUT/GET communication disabled by
-   default. Enable it in TIA Portal under the CPU properties before
-   connecting. See :doc:`tia-portal-config` for step-by-step instructions.
+   default. When using ``s7.Client``, the library automatically tries the
+   S7CommPlus protocol first, which does not require PUT/GET to be enabled.
+   If you need to use the legacy protocol, enable PUT/GET in TIA Portal
+   under the CPU properties. See :doc:`tia-portal-config` for step-by-step
+   instructions.
 
 
 S7-300
@@ -53,9 +57,9 @@ S7-300
 
 .. code-block:: python
 
-   import snap7
+   from s7 import Client
 
-   client = snap7.Client()
+   client = Client()
    client.connect("192.168.1.10", 0, 2)
 
 S7-400
@@ -63,9 +67,9 @@ S7-400
 
 .. code-block:: python
 
-   import snap7
+   from s7 import Client
 
-   client = snap7.Client()
+   client = Client()
    client.connect("192.168.1.10", 0, 3)
 
 S7-1200 / S7-1500
@@ -73,27 +77,32 @@ S7-1200 / S7-1500
 
 .. code-block:: python
 
-   import snap7
+   from s7 import Client
 
-   client = snap7.Client()
+   client = Client()
    client.connect("192.168.1.10", 0, 1)
+   print(client.protocol)  # Protocol.S7COMMPLUS or Protocol.LEGACY
 
-.. tip::
+The client automatically tries S7CommPlus first and falls back to legacy S7
+when needed. You can also force a specific protocol:
 
-   For S7-1200/1500 PLCs you can also use the **experimental** ``s7`` package,
-   which automatically tries the newer S7CommPlus protocol and falls back to
-   legacy S7 when needed::
+.. code-block:: python
 
-      from s7 import Client
+   from s7 import Client, Protocol
 
-      client = Client()
-      client.connect("192.168.1.10", 0, 1)
-      print(client.protocol)  # Protocol.S7COMMPLUS or Protocol.LEGACY
+   client = Client()
+   # Force legacy S7 only (requires PUT/GET enabled)
+   client.connect("192.168.1.10", 0, 1, protocol=Protocol.LEGACY)
 
-   See :doc:`API/s7commplus` for full details.
+   # Force S7CommPlus (raises on failure)
+   client.connect("192.168.1.10", 0, 1, protocol=Protocol.S7COMMPLUS)
+
+See :doc:`API/s7commplus` for details on TLS and password authentication.
 
 S7-200 / Logo (TSAP Connection)
 --------------------------------
+
+S7-200 and Logo PLCs require TSAP addressing via the legacy ``snap7`` package:
 
 .. code-block:: python
 
@@ -108,7 +117,20 @@ Using a Non-Standard Port
 
 .. code-block:: python
 
+   from s7 import Client
+
+   client = Client()
+   client.connect("192.168.1.10", 0, 1, tcp_port=1102)
+
+Legacy ``snap7`` Package
+-------------------------
+
+If you have existing code using ``snap7.Client``, it continues to work
+unchanged:
+
+.. code-block:: python
+
    import snap7
 
    client = snap7.Client()
-   client.connect("192.168.1.10", 0, 1, tcp_port=1102)
+   client.connect("192.168.1.10", 0, 1)

--- a/doc/connection-issues.rst
+++ b/doc/connection-issues.rst
@@ -11,19 +11,29 @@ Connection Issues
 Automatic Reconnection
 ----------------------
 
-The :class:`~snap7.client.Client` has built-in auto-reconnect with exponential
-backoff and optional heartbeat monitoring. This is the recommended approach for
-long-running applications:
+The :class:`~snap7.client.Client` (used internally by ``s7.Client``) has
+built-in auto-reconnect with exponential backoff and optional heartbeat
+monitoring. This is the recommended approach for long-running applications:
 
 .. code-block:: python
 
-   import snap7
+   from s7 import Client
 
    def on_disconnect():
        print("Connection lost!")
 
    def on_reconnect():
        print("Reconnected!")
+
+   client = Client()
+   client.connect("192.168.1.10", 0, 1)
+
+For finer control over reconnection parameters, use the legacy ``snap7.Client``
+directly:
+
+.. code-block:: python
+
+   import snap7
 
    client = snap7.Client(
        auto_reconnect=True,        # Enable automatic reconnection
@@ -62,13 +72,13 @@ manually:
 
 .. code-block:: python
 
-   import snap7
+   from s7 import Client
    import time
    import logging
 
    logger = logging.getLogger(__name__)
 
-   client = snap7.Client()
+   client = Client()
 
    def connect(address: str = "192.168.1.10", rack: int = 0, slot: int = 1) -> None:
        client.connect(address, rack, slot)
@@ -109,9 +119,9 @@ the underlying connection object:
 
 .. code-block:: python
 
-   import snap7
+   from s7 import Client
 
-   client = snap7.Client()
+   client = Client()
 
    # Connect with a custom timeout (in seconds)
    client.connect("192.168.1.10", 0, 1)
@@ -120,12 +130,11 @@ the underlying connection object:
    # Default is 5.0 seconds
    client.connection.timeout = 10.0  # Set to 10 seconds
 
-To set the timeout **before** connecting, use ``set_connection_params`` and then
-connect manually, or simply reconnect after adjusting:
+To set the timeout **before** connecting, connect first and then adjust:
 
 .. code-block:: python
 
-   client = snap7.Client()
+   client = Client()
    client.connect("192.168.1.10", 0, 1)
 
    # Adjust timeout for slow networks

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -39,9 +39,9 @@ Welcome to python-snap7's documentation!
    :maxdepth: 2
    :caption: API Reference
 
+   API/s7commplus
    API/client
    API/async_client
-   API/s7commplus
    API/server
    API/partner
    API/logo

--- a/doc/introduction.rst
+++ b/doc/introduction.rst
@@ -4,7 +4,7 @@ Introduction
 python-snap7 is a pure Python S7 communication library for interfacing
 natively with Siemens S7 PLCs. The library implements the complete S7
 protocol stack including TPKT (RFC 1006), COTP (ISO 8073), and S7
-protocol layers.
+protocol layers, as well as the S7CommPlus protocol for newer PLCs.
 
 The name "python-snap7" is historical: the library originally started as a
 Python wrapper around the `Snap7 <http://snap7.sourceforge.net/>`_ C library.
@@ -14,19 +14,33 @@ backwards compatibility.
 python-snap7 requires Python 3.10+ and runs on Windows, macOS and Linux
 without any native dependencies.
 
-The library provides two packages:
+The ``s7`` package
+------------------
 
-- **snap7** -- the original S7 protocol implementation, supporting S7-300,
-  S7-400, S7-1200 and S7-1500 PLCs via the classic PUT/GET interface.
-- **s7** -- a newer unified client that automatically tries the S7CommPlus
-  protocol (used natively by S7-1200/1500) and falls back to legacy S7 when
-  needed. ``s7.Client`` is a drop-in replacement for ``snap7.Client``.
+The recommended way to use this library is through the ``s7`` package. It
+provides a unified client that works with **all supported PLC models** --
+S7-300, S7-400, S7-1200 and S7-1500. For newer PLCs (S7-1200/1500) it
+automatically tries the S7CommPlus protocol and falls back to legacy S7 when
+needed:
 
-.. note::
+.. code-block:: python
 
-   The ``s7`` package and its S7CommPlus support are **experimental**.
-   The legacy ``snap7`` package remains fully supported and is the safe choice
-   for production use. See :doc:`API/s7commplus` for details.
+   from s7 import Client
+
+   client = Client()
+   client.connect("192.168.1.10", 0, 1)
+   data = client.db_read(1, 0, 4)
+   client.disconnect()
+
+The ``snap7`` package (legacy)
+------------------------------
+
+The ``snap7`` package is the original S7 protocol implementation. It remains
+fully functional and is kept for backwards compatibility. It supports
+S7-300, S7-400, S7-1200 and S7-1500 PLCs via the classic PUT/GET interface.
+
+If you have existing code that uses ``snap7.Client``, it will continue to work
+unchanged. For new projects, we recommend using ``s7.Client`` instead.
 
 .. note::
 

--- a/doc/limitations.rst
+++ b/doc/limitations.rst
@@ -24,7 +24,7 @@ are **not possible** with this protocol:
    * - Create PLC backups
      - Full project backup requires TIA Portal. python-snap7 can upload
        individual blocks, but this is not a complete backup.
-   * - Access S7-1200/1500 PLCs with S7CommPlus security
-     - python-snap7 supports S7CommPlus V1 and V2 (with TLS) via
-       the ``s7`` package. V3 is not yet supported. For PLCs that only
-       support V3, enable PUT/GET as a fallback or use OPC UA.
+   * - S7CommPlus V3
+     - python-snap7 supports S7CommPlus V1 and V2 (with TLS) via the ``s7``
+       package. V3 is not yet supported. For PLCs that only support V3, enable
+       PUT/GET as a fallback or use OPC UA.

--- a/doc/multi-variable.rst
+++ b/doc/multi-variable.rst
@@ -6,11 +6,11 @@ request, which is significantly faster than individual reads.
 
 .. code-block:: python
 
-   import snap7
-   from snap7.type import Area, WordLen, S7DataItem
+   from s7 import Client, Area, WordLen
+   from snap7.type import S7DataItem
    from ctypes import c_uint8, cast, POINTER
 
-   client = snap7.Client()
+   client = Client()
    client.connect("192.168.1.10", 0, 1)
 
    # Prepare items to read

--- a/doc/plc-support.rst
+++ b/doc/plc-support.rst
@@ -24,14 +24,14 @@ Supported PLCs
      - No
      - No
      - **Full**
-     - Works out of the box.
+     - Works out of the box with ``s7.Client``.
    * - S7-400
      - ~1996
      - Yes
      - No
      - No
      - **Full**
-     - Works out of the box.
+     - Works out of the box with ``s7.Client``.
    * - S7-1200 (FW ≤3)
      - 2009
      - Yes
@@ -45,21 +45,21 @@ Supported PLCs
      - Yes
      - No
      - **Full**
-     - Enable PUT/GET access in TIA Portal. Uses classic S7.
+     - ``s7.Client`` auto-detects the best protocol.
    * - S7-1500 (FW 1.x)
      - 2012
      - PUT/GET only
      - Yes
      - No
-     - **Full** (experimental S7CommPlus)
-     - S7CommPlus V1 session + legacy S7 fallback for data.
+     - **Full**
+     - ``s7.Client`` uses S7CommPlus V1 with legacy S7 fallback.
    * - S7-1500 (FW 2.x)
      - ~2016
      - PUT/GET only
      - No
      - V2
-     - **Full** (S7CommPlus V2)
-     - S7CommPlus V2 with TLS is supported via the ``s7`` package.
+     - **Full**
+     - ``s7.Client`` supports S7CommPlus V2 with TLS.
    * - S7-1500 (FW 3.x+)
      - ~2022
      - PUT/GET only
@@ -104,6 +104,10 @@ For S7-1200 and S7-1500 PLCs, classic S7 protocol access requires the
 **PUT/GET** option to be enabled. See :doc:`tia-portal-config` for
 step-by-step instructions.
 
+When using ``s7.Client``, the library automatically tries S7CommPlus first,
+which does **not** require PUT/GET to be enabled. PUT/GET is only needed if
+you force the legacy protocol or use ``snap7.Client`` directly.
+
 .. warning::
 
    PUT/GET access provides unauthenticated read/write access to PLC memory.
@@ -141,10 +145,11 @@ Siemens has evolved their PLC communication protocols over time:
      - S7-1500 FW 3.x+
 
 python-snap7 implements the **classic S7 protocol** and **S7CommPlus V1/V2**.
-The classic protocol remains available on most PLC families via the PUT/GET
-mechanism. S7CommPlus V1 and V2 (with TLS) are supported via the
-``s7`` package. For PLCs that require S7CommPlus V3 (such
-as the S7-1500R/H), consider using OPC UA as an alternative.
+The ``s7`` package is the recommended entry point -- it automatically selects
+the best protocol for your PLC. The classic protocol remains available on most
+PLC families via the PUT/GET mechanism. S7CommPlus V3 is not yet supported;
+for PLCs that require it (such as the S7-1500R/H), consider using OPC UA as
+an alternative.
 
 
 Alternatives for Unsupported PLCs

--- a/doc/reading-writing.rst
+++ b/doc/reading-writing.rst
@@ -2,15 +2,15 @@ Reading & Writing Data
 ======================
 
 This page covers address mapping, data type conversions, memory area access,
-and analog I/O — everything you need for reading from and writing to a PLC.
+and analog I/O -- everything you need for reading from and writing to a PLC.
 
 All examples assume you have a connected client:
 
 .. code-block:: python
 
-   import snap7
+   from s7 import Client
 
-   client = snap7.Client()
+   client = Client()
    client.connect("192.168.1.10", 0, 1)
 
 .. contents:: On this page
@@ -29,7 +29,7 @@ as follows.
    :widths: 25 40 35
 
    * - PLC Address
-     - python-snap7 Call
+     - API Call
      - Explanation
    * - DB1.DBB0
      - ``db_read(1, 0, 1)``
@@ -58,7 +58,7 @@ as follows.
 
 .. important::
 
-   The ``byte_index`` parameter in all ``snap7.util`` getter/setter functions
+   The ``byte_index`` parameter in all ``s7.util`` getter/setter functions
    is **relative to the returned bytearray**, not the absolute PLC address.
 
    For example, to read DB1.DBX10.3:
@@ -66,7 +66,8 @@ as follows.
    .. code-block:: python
 
       data = client.db_read(1, 10, 1)  # Read 1 byte starting at offset 10
-      value = snap7.util.get_bool(data, 0, 3)  # byte_index=0, NOT 10
+      from s7.util import get_bool
+      value = get_bool(data, 0, 3)  # byte_index=0, NOT 10
 
    You read from PLC offset 10, but ``data[0]`` *is* byte 10 from the PLC.
 
@@ -74,7 +75,8 @@ as follows.
 Data Types
 ----------
 
-Each example below shows a complete read and write cycle.
+Each example below shows a complete read and write cycle. Data conversion
+helpers live in ``s7.util`` and work with any client.
 
 BOOL
 ^^^^
@@ -85,14 +87,16 @@ the whole byte back.
 
 .. code-block:: python
 
+   from s7 import util
+
    # Read DB1.DBX0.3 (bit 3 of byte 0)
    data = client.db_read(1, 0, 1)
-   value = snap7.util.get_bool(data, 0, 3)
+   value = util.get_bool(data, 0, 3)
    print(f"DB1.DBX0.3 = {value}")
 
    # Write DB1.DBX0.3 -- read first, then modify, then write
    data = client.db_read(1, 0, 1)
-   snap7.util.set_bool(data, 0, 3, True)
+   util.set_bool(data, 0, 3, True)
    client.db_write(1, 0, data)
 
 .. warning::
@@ -105,14 +109,16 @@ BYTE (1 byte, unsigned 0--255)
 
 .. code-block:: python
 
+   from s7 import util
+
    # Read DB1.DBB0 (1 byte at offset 0)
    data = client.db_read(1, 0, 1)
-   value = snap7.util.get_byte(data, 0)
+   value = util.get_byte(data, 0)
    print(f"DB1.DBB0 = {value}")
 
    # Write
    data = bytearray(1)
-   snap7.util.set_byte(data, 0, 200)
+   util.set_byte(data, 0, 200)
    client.db_write(1, 0, data)
 
 INT (2 bytes, signed -32768 to 32767)
@@ -120,14 +126,16 @@ INT (2 bytes, signed -32768 to 32767)
 
 .. code-block:: python
 
+   from s7 import util
+
    # Read DB1.DBW10
    data = client.db_read(1, 10, 2)
-   value = snap7.util.get_int(data, 0)
+   value = util.get_int(data, 0)
    print(f"DB1.DBW10 = {value}")
 
    # Write
    data = bytearray(2)
-   snap7.util.set_int(data, 0, -1234)
+   util.set_int(data, 0, -1234)
    client.db_write(1, 10, data)
 
 WORD (2 bytes, unsigned 0--65535)
@@ -135,14 +143,16 @@ WORD (2 bytes, unsigned 0--65535)
 
 .. code-block:: python
 
+   from s7 import util
+
    # Read DB1.DBW20
    data = client.db_read(1, 20, 2)
-   value = snap7.util.get_word(data, 0)
+   value = util.get_word(data, 0)
    print(f"DB1.DBW20 = {value}")
 
    # Write
    data = bytearray(2)
-   snap7.util.set_word(data, 0, 50000)
+   util.set_word(data, 0, 50000)
    client.db_write(1, 20, data)
 
 DINT (4 bytes, signed -2147483648 to 2147483647)
@@ -150,14 +160,16 @@ DINT (4 bytes, signed -2147483648 to 2147483647)
 
 .. code-block:: python
 
+   from s7 import util
+
    # Read DB1.DBD30
    data = client.db_read(1, 30, 4)
-   value = snap7.util.get_dint(data, 0)
+   value = util.get_dint(data, 0)
    print(f"DB1.DBD30 = {value}")
 
    # Write
    data = bytearray(4)
-   snap7.util.set_dint(data, 0, 100000)
+   util.set_dint(data, 0, 100000)
    client.db_write(1, 30, data)
 
 DWORD (4 bytes, unsigned 0--4294967295)
@@ -165,14 +177,16 @@ DWORD (4 bytes, unsigned 0--4294967295)
 
 .. code-block:: python
 
+   from s7 import util
+
    # Read DB1.DBD40
    data = client.db_read(1, 40, 4)
-   value = snap7.util.get_dword(data, 0)
+   value = util.get_dword(data, 0)
    print(f"DB1.DBD40 = {value}")
 
    # Write
    data = bytearray(4)
-   snap7.util.set_dword(data, 0, 3000000000)
+   util.set_dword(data, 0, 3000000000)
    client.db_write(1, 40, data)
 
 LINT (8 bytes, signed -9223372036854775808 to 9223372036854775807)
@@ -180,9 +194,11 @@ LINT (8 bytes, signed -9223372036854775808 to 9223372036854775807)
 
 .. code-block:: python
 
+   from s7 import util
+
    # Read 8 bytes from DB1 at offset 60
    data = client.db_read(1, 60, 8)
-   value = snap7.util.get_lint(data, 0)
+   value = util.get_lint(data, 0)
    print(f"LINT = {value}")
 
    # Write (no set_lint helper -- use struct directly)
@@ -195,9 +211,11 @@ ULINT (8 bytes, unsigned 0--18446744073709551615)
 
 .. code-block:: python
 
+   from s7 import util
+
    # Read 8 bytes from DB1 at offset 68
    data = client.db_read(1, 68, 8)
-   value = snap7.util.get_ulint(data, 0)
+   value = util.get_ulint(data, 0)
    print(f"ULINT = {value}")
 
    # Write (no set_ulint helper -- use struct directly)
@@ -210,14 +228,16 @@ REAL (4 bytes, IEEE 754 float)
 
 .. code-block:: python
 
+   from s7 import util
+
    # Read DB1.DBD50
    data = client.db_read(1, 50, 4)
-   value = snap7.util.get_real(data, 0)
+   value = util.get_real(data, 0)
    print(f"DB1.DBD50 = {value}")
 
    # Write
    data = bytearray(4)
-   snap7.util.set_real(data, 0, 3.14)
+   util.set_real(data, 0, 3.14)
    client.db_write(1, 50, data)
 
 LREAL (8 bytes, IEEE 754 double)
@@ -225,14 +245,16 @@ LREAL (8 bytes, IEEE 754 double)
 
 .. code-block:: python
 
+   from s7 import util
+
    # Read DB1, offset 60, 8 bytes
    data = client.db_read(1, 60, 8)
-   value = snap7.util.get_lreal(data, 0)
+   value = util.get_lreal(data, 0)
    print(f"LREAL = {value}")
 
    # Write
    data = bytearray(8)
-   snap7.util.set_lreal(data, 0, 3.141592653589793)
+   util.set_lreal(data, 0, 3.141592653589793)
    client.db_write(1, 60, data)
 
 STRING (2 header bytes + characters)
@@ -248,15 +270,17 @@ When reading, always request ``max_length + 2`` bytes to include the header.
 
 .. code-block:: python
 
+   from s7 import util
+
    # Read a string at DB1, offset 10, declared as STRING[20] in the PLC
    max_length = 20
    data = client.db_read(1, 10, max_length + 2)  # 20 + 2 header bytes = 22
-   text = snap7.util.get_string(data, 0)
+   text = util.get_string(data, 0)
    print(f"String = '{text}'")
 
    # Write a string
    data = client.db_read(1, 10, max_length + 2)
-   snap7.util.set_string(data, 0, "Hello", max_length)
+   util.set_string(data, 0, "Hello", max_length)
    client.db_write(1, 10, data)
 
 .. note::
@@ -270,11 +294,12 @@ DATE_AND_TIME (8 bytes, BCD encoded)
 
 .. code-block:: python
 
+   from s7 import util
    from datetime import datetime
 
    # Read DATE_AND_TIME at DB1, offset 70 (returns ISO 8601 string)
    data = client.db_read(1, 70, 8)
-   dt_string = snap7.util.get_dt(data, 0)
+   dt_string = util.get_dt(data, 0)
    print(f"DATE_AND_TIME = {dt_string}")  # e.g. '2024-06-15T14:30:00.000000'
 
    # Parse to Python datetime if needed
@@ -282,7 +307,7 @@ DATE_AND_TIME (8 bytes, BCD encoded)
 
    # Write DATE_AND_TIME
    data = client.db_read(1, 70, 8)
-   snap7.util.set_dt(data, 0, datetime(2024, 6, 15, 14, 30, 0))
+   util.set_dt(data, 0, datetime(2024, 6, 15, 14, 30, 0))
    client.db_write(1, 70, data)
 
 
@@ -319,7 +344,7 @@ Inputs (I / E)
 
 .. code-block:: python
 
-   from snap7.type import Area
+   from s7 import Area
 
    # Read 2 input bytes starting at IB0
    data = client.read_area(Area.PE, 0, 0, 2)
@@ -329,7 +354,7 @@ Outputs (Q / A)
 
 .. code-block:: python
 
-   from snap7.type import Area
+   from s7 import Area
 
    # Read 2 output bytes starting at QB0
    data = client.read_area(Area.PA, 0, 0, 2)
@@ -342,7 +367,7 @@ Timers (T)
 
 .. code-block:: python
 
-   from snap7.type import Area
+   from s7 import Area
 
    # Read timer T0 (1 timer = 2 bytes)
    data = client.read_area(Area.TM, 0, 0, 1)
@@ -352,7 +377,7 @@ Counters (C)
 
 .. code-block:: python
 
-   from snap7.type import Area
+   from s7 import Area
 
    # Read counter C0 (1 counter = 2 bytes)
    data = client.read_area(Area.CT, 0, 0, 1)
@@ -370,15 +395,15 @@ Reading Analog Inputs
 
 .. code-block:: python
 
-   import snap7
-   from snap7.type import Area
+   from s7 import util
+   from s7 import Client, Area
 
-   client = snap7.Client()
+   client = Client()
    client.connect("192.168.1.10", 0, 1)
 
    # Read AIW0 (analog input word at address 0)
    data = client.read_area(Area.PE, 0, 0, 2)
-   raw_value = snap7.util.get_int(data, 0)
+   raw_value = util.get_int(data, 0)
    print(f"Raw value: {raw_value}")
 
    # Scale to engineering units
@@ -390,18 +415,19 @@ Reading Analog Inputs
 
    # Read AIW2 (second analog input)
    data = client.read_area(Area.PE, 0, 2, 2)
-   raw_value = snap7.util.get_int(data, 0)
+   raw_value = util.get_int(data, 0)
 
 Writing Analog Outputs
 ^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: python
 
-   from snap7.type import Area
+   from s7 import util
+   from s7 import Area
 
    # Write to AQW0 (analog output word at address 0)
    data = bytearray(2)
-   snap7.util.set_int(data, 0, 13824)  # ~50% of 27648
+   util.set_int(data, 0, 13824)  # ~50% of 27648
    client.write_area(Area.PA, 0, 0, data)
 
 .. note::

--- a/doc/server.rst
+++ b/doc/server.rst
@@ -13,8 +13,7 @@ Basic Server Example
 
 .. code-block:: python
 
-   from snap7.server import Server
-   from snap7.type import SrvArea
+   from s7 import Server, SrvArea
    from ctypes import c_char
 
    # Create and configure the server
@@ -35,9 +34,7 @@ Client-Server Round Trip
 
 .. code-block:: python
 
-   import snap7
-   from snap7.server import Server
-   from snap7.type import SrvArea
+   from s7 import Client, Server, SrvArea
    from ctypes import c_char
 
    # --- Server setup ---
@@ -49,7 +46,7 @@ Client-Server Round Trip
    server.start(tcp_port=1102)
 
    # --- Client connection ---
-   client = snap7.Client()
+   client = Client()
    client.connect("127.0.0.1", 0, 1, tcp_port=1102)
 
    # Write data
@@ -69,8 +66,7 @@ Registering Multiple Areas
 
 .. code-block:: python
 
-   from snap7.server import Server
-   from snap7.type import SrvArea
+   from s7 import Server, SrvArea
    from ctypes import c_char
 
    server = Server()
@@ -102,8 +98,8 @@ Registering Multiple Areas
 Using the Mainloop Helper
 --------------------------
 
-For quick testing, the ``mainloop`` function starts a server with common
-data blocks pre-registered:
+For quick testing, the ``mainloop`` function from the legacy ``snap7`` package
+starts a server with common data blocks pre-registered:
 
 .. code-block:: python
 

--- a/doc/thread-safety.rst
+++ b/doc/thread-safety.rst
@@ -10,10 +10,10 @@ and cause unpredictable errors.
 .. code-block:: python
 
    import threading
-   import snap7
+   from s7 import Client
 
    def worker(address: str, rack: int, slot: int) -> None:
-       client = snap7.Client()
+       client = Client()
        client.connect(address, rack, slot)
        data = client.db_read(1, 0, 10)
        client.disconnect()
@@ -28,9 +28,9 @@ and cause unpredictable errors.
 .. code-block:: python
 
    import threading
-   import snap7
+   from s7 import Client
 
-   client = snap7.Client()
+   client = Client()
    client.connect("192.168.1.10", 0, 1)
    lock = threading.Lock()
 

--- a/s7/util.py
+++ b/s7/util.py
@@ -1,0 +1,10 @@
+"""S7 data type conversion utilities.
+
+Re-exports all getter and setter helpers from :mod:`snap7.util` so that
+users of the ``s7`` package do not need to import ``snap7`` directly::
+
+    from s7.util import get_bool, set_bool
+"""
+
+from snap7.util import *  # noqa: F401, F403
+from snap7.util import __all__  # noqa: F401

--- a/snap7/__init__.py
+++ b/snap7/__init__.py
@@ -1,8 +1,16 @@
 """
-The Snap7 Python library.
+The snap7 package (legacy).
 
-Pure Python implementation of the S7 protocol for communicating with
-Siemens S7 PLCs without requiring the native Snap7 C library.
+Pure Python implementation of the classic S7 protocol for communicating with
+Siemens S7 PLCs. This package is kept for backwards compatibility. For new
+projects, use the ``s7`` package instead, which supports all PLC models and
+automatically selects the best protocol (S7CommPlus or legacy S7)::
+
+    from s7 import Client
+
+    client = Client()
+    client.connect("192.168.1.10", 0, 1)
+    data = client.db_read(1, 0, 4)
 """
 
 from importlib.metadata import version, PackageNotFoundError

--- a/snap7/async_client.py
+++ b/snap7/async_client.py
@@ -1,8 +1,11 @@
 """
-Native async S7 client implementation.
+Legacy async S7 client implementation.
 
 Uses asyncio streams for non-blocking I/O with an asyncio.Lock() to serialize
 send/receive cycles, ensuring safe concurrent use via asyncio.gather().
+
+For new projects, use :class:`s7.AsyncClient` instead, which supports all PLC
+models and automatically selects the best protocol.
 """
 
 import asyncio
@@ -277,15 +280,17 @@ class AsyncISOTCPConnection:
 
 class AsyncClient(ClientMixin):
     """
-    Native async S7 client implementation.
+    Legacy async S7 client for classic PUT/GET communication.
 
     Uses asyncio streams for non-blocking I/O. An internal asyncio.Lock
     serializes each send+receive cycle so that concurrent coroutines
     (e.g. via asyncio.gather) never interleave on the same TCP socket.
 
+    For new projects, use :class:`s7.AsyncClient` instead.
+
     Examples:
-        >>> import snap7
-        >>> async with snap7.AsyncClient() as client:
+        >>> from s7 import AsyncClient
+        >>> async with AsyncClient() as client:
         ...     await client.connect("192.168.1.10", 0, 1)
         ...     data = await client.db_read(1, 0, 4)
     """

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -1,7 +1,9 @@
 """
-Pure Python S7 client implementation.
+Legacy S7 client implementation.
 
-Drop-in replacement for the ctypes-based client with native Python implementation.
+Pure Python implementation of the classic S7 protocol. For new projects,
+use :class:`s7.Client` instead, which supports all PLC models and
+automatically selects the best protocol.
 """
 
 import logging
@@ -45,14 +47,15 @@ logger = logging.getLogger(__name__)
 
 class Client(ClientMixin):
     """
-    Pure Python S7 client implementation.
+    Legacy S7 client for classic PUT/GET communication.
 
-    Drop-in replacement for the ctypes-based client that provides native Python
-    communication with Siemens S7 PLCs without requiring the Snap7 C library.
+    Supports S7-300, S7-400, S7-1200 and S7-1500 PLCs via the classic S7
+    protocol. For new projects, use :class:`s7.Client` instead, which
+    automatically selects the best protocol for any supported PLC.
 
     Examples:
-        >>> import snap7
-        >>> client = snap7.Client()
+        >>> from s7 import Client
+        >>> client = Client()
         >>> client.connect("192.168.1.10", 0, 1)
         >>> data = client.db_read(1, 0, 4)
         >>> client.disconnect()

--- a/snap7/server/__init__.py
+++ b/snap7/server/__init__.py
@@ -1,7 +1,9 @@
 """
-Pure Python S7 server implementation.
+Legacy S7 server implementation.
 
-Provides a complete S7 server emulator without dependencies on the Snap7 C library.
+Provides a complete S7 server emulator for the classic S7 protocol. For new
+projects, use :class:`s7.Server` instead, which supports both legacy S7 and
+S7CommPlus clients.
 """
 
 import socket
@@ -40,13 +42,14 @@ class CPUState(IntEnum):
 
 class Server:
     """
-    Pure Python S7 server implementation.
+    Legacy S7 server implementation.
 
     Emulates a Siemens S7 PLC for testing and development purposes.
+    For new projects, use :class:`s7.Server` instead.
 
     Examples:
-        >>> import snap7
-        >>> server = snap7.Server()
+        >>> from s7 import Server
+        >>> server = Server()
         >>> server.start()
         >>> # ... register areas and handle clients
         >>> server.stop()


### PR DESCRIPTION
## Summary
- Update all documentation and code examples to recommend `s7` as the primary package for all PLC models (S7-300/400/1200/1500), with `snap7` kept for backwards compatibility
- Add `s7.util` module that re-exports all `snap7.util` helpers, so users never need to import `snap7` directly
- Update source docstrings in `snap7` package to mark classes as legacy and point to `s7` equivalents
- Restructure API reference: `s7.Client` docs listed first, `snap7.Client` docs labeled as legacy

## Changes
- **README.rst**: Quick Start uses `s7.Client`, legacy example shown separately
- **doc/**: All 12 prose pages updated (introduction, connecting, reading-writing, server, multi-variable, connection-issues, thread-safety, plc-support, limitations, etc.)
- **doc/API/**: Restructured — s7commplus.rst is now "S7 Client (recommended)", client.rst/async_client.rst labeled "(legacy)", server.rst documents both
- **s7/util.py**: New module re-exporting `snap7.util.*`
- **snap7/__init__.py, client.py, async_client.py, server/__init__.py**: Docstrings updated to say "legacy" and point to `s7`

## Test plan
- [x] Sphinx docs build with `-W` (warnings-as-errors) — no errors
- [x] `ruff check` passes on all changed files
- [x] `mypy` passes on `s7/util.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)