### PR TITLE
Set TCP_NODELAY and SO_KEEPALIVE on all S7 sockets

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,22 +36,7 @@ Install using pip::
 
    $ pip install python-snap7
 
-The recommended way to use this library is through the ``s7`` package, which
-works with **all supported PLC models** (S7-300, S7-400, S7-1200, S7-1500) and
-automatically selects the best protocol::
-
-   from s7 import Client
-
-   client = Client()
-   client.connect("192.168.1.10", 0, 1)  # auto-detects S7CommPlus vs legacy S7
-   data = client.db_read(1, 0, 4)
-   client.disconnect()
-
-The ``s7.Client`` automatically tries S7CommPlus first (for S7-1200/1500), and
-falls back to legacy S7 when needed. No native libraries or platform-specific
-dependencies are required.
-
-The legacy ``snap7`` package is still available for backwards compatibility::
+Connect to any S7 PLC::
 
    import snap7
 
@@ -60,19 +45,35 @@ The legacy ``snap7`` package is still available for backwards compatibility::
    data = client.db_read(1, 0, 4)
    client.disconnect()
 
+No native libraries or platform-specific dependencies are required.
 
-Version 3.1 -- S7CommPlus Protocol Support (unreleased)
-========================================================
 
-Version 3.1 adds support for the S7CommPlus protocol (up to V2), which is
-required for communicating with newer Siemens S7-1200 and S7-1500 PLCs that
-have PUT/GET disabled. This is fully backwards compatible with 3.0.
+Version 4.0 -- New ``s7`` Package (unreleased)
+===============================================
 
-The ``s7`` package is now the recommended entry point for connecting to any
-supported S7 PLC. The existing ``snap7`` package continues to work unchanged
-for legacy S7 connections.
+.. note::
 
-**Help us test!** Version 3.1 needs more real-world testing before release. If
+   Version 4.0 is **not yet released**. Installing with ``pip install python-snap7``
+   gives you version 3.0, which uses the ``snap7`` package shown above.
+   To try 4.0 early, install from the development branch (see below).
+
+Version 4.0 introduces the new ``s7`` package as the standard entry point. It
+works with **all supported PLC models** (S7-300, S7-400, S7-1200, S7-1500),
+adds S7CommPlus protocol support (required for S7-1200/1500 with PUT/GET
+disabled), and automatically selects the best protocol::
+
+   from s7 import Client
+
+   client = Client()
+   client.connect("192.168.1.10", 0, 1)  # auto-detects S7CommPlus vs legacy S7
+   data = client.db_read(1, 0, 4)
+   client.disconnect()
+
+The ``s7.Client`` automatically tries S7CommPlus first (for S7-1200/1500) and
+falls back to legacy S7 when needed. The existing ``snap7`` package continues
+to work unchanged.
+
+**Help us test!** Version 4.0 needs more real-world testing before release. If
 you have access to any of the following PLCs, we would greatly appreciate
 testing and feedback:
 

--- a/s7/_s7commplus_server.py
+++ b/s7/_s7commplus_server.py
@@ -337,6 +337,8 @@ class S7CommPlusServer:
                 if self._server_socket is None:
                     break
                 client_sock, address = self._server_socket.accept()
+                client_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                client_sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
                 logger.info(f"Client connected from {address}")
                 t = threading.Thread(
                     target=self._handle_client,

--- a/snap7/connection.py
+++ b/snap7/connection.py
@@ -205,6 +205,15 @@ class ISOTCPConnection:
         self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
         # Enable TCP keepalive to detect dead connections during idle periods.
         self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
+        # Configure keepalive timing so failures are detected in ~90s of idle
+        # rather than the OS default of ~2 hours (Linux: 7200s idle + 9x75s probes).
+        # TCP_KEEPIDLE/TCP_KEEPINTVL are available on Linux and macOS 10.15+.
+        if hasattr(socket, "TCP_KEEPIDLE"):
+            self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPIDLE, 60)
+        if hasattr(socket, "TCP_KEEPINTVL"):
+            self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPINTVL, 10)
+        if hasattr(socket, "TCP_KEEPCNT"):
+            self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_KEEPCNT, 3)
         self.socket.settimeout(self.timeout)
 
         try:

--- a/snap7/connection.py
+++ b/snap7/connection.py
@@ -200,6 +200,11 @@ class ISOTCPConnection:
     def _tcp_connect(self) -> None:
         """Establish TCP connection."""
         self.socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        # Disable Nagle's algorithm: S7 is request/response with complete PDUs,
+        # so buffering only adds latency (confirmed 100-150ms savings on S7-1500).
+        self.socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+        # Enable TCP keepalive to detect dead connections during idle periods.
+        self.socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
         self.socket.settimeout(self.timeout)
 
         try:

--- a/snap7/partner.py
+++ b/snap7/partner.py
@@ -683,6 +683,8 @@ class Partner:
         while self.running and not self._stop_event.is_set():
             try:
                 client_sock, addr = self._server_socket.accept()
+                client_sock.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                client_sock.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
 
                 # Create connection object
                 self._socket = client_sock

--- a/snap7/server/__init__.py
+++ b/snap7/server/__init__.py
@@ -572,6 +572,8 @@ class Server:
                 try:
                     self.server_socket.settimeout(0.1)  # Short timeout for responsive shutdown
                     client_socket, address = self.server_socket.accept()
+                    client_socket.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+                    client_socket.setsockopt(socket.SOL_SOCKET, socket.SO_KEEPALIVE, 1)
 
                     logger.info(f"Client connected from {address}")
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -488,7 +488,7 @@ class TestTCPConnect:
         mock_socket_mod.SO_KEEPALIVE = _socket.SO_KEEPALIVE
         mock_socket_mod.IPPROTO_TCP = _socket.IPPROTO_TCP
         mock_socket_mod.TCP_NODELAY = _socket.TCP_NODELAY
-        mock_socket_mod.TCP_KEEPIDLE = 4   # simulate attribute present
+        mock_socket_mod.TCP_KEEPIDLE = 4  # simulate attribute present
         mock_socket_mod.TCP_KEEPINTVL = 5
         mock_socket_mod.TCP_KEEPCNT = 6
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -475,6 +475,33 @@ class TestTCPConnect:
         conn._tcp_connect()
         mock_sock.setsockopt.assert_any_call(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)
 
+    @patch("snap7.connection.socket.socket")
+    @patch("snap7.connection.socket")
+    def test_tcp_connect_sets_keepalive_timing(self, mock_socket_mod: MagicMock, mock_socket_cls: MagicMock) -> None:
+        """Keepalive timing parameters must be set when the platform supports them."""
+        import socket as _socket
+
+        # Simulate a platform that has all three timing attributes
+        mock_socket_mod.AF_INET = _socket.AF_INET
+        mock_socket_mod.SOCK_STREAM = _socket.SOCK_STREAM
+        mock_socket_mod.SOL_SOCKET = _socket.SOL_SOCKET
+        mock_socket_mod.SO_KEEPALIVE = _socket.SO_KEEPALIVE
+        mock_socket_mod.IPPROTO_TCP = _socket.IPPROTO_TCP
+        mock_socket_mod.TCP_NODELAY = _socket.TCP_NODELAY
+        mock_socket_mod.TCP_KEEPIDLE = 4   # simulate attribute present
+        mock_socket_mod.TCP_KEEPINTVL = 5
+        mock_socket_mod.TCP_KEEPCNT = 6
+
+        mock_sock = MagicMock()
+        mock_socket_mod.socket.return_value = mock_sock
+
+        conn = ISOTCPConnection("1.2.3.4")
+        conn._tcp_connect()
+
+        mock_sock.setsockopt.assert_any_call(_socket.IPPROTO_TCP, 4, 60)
+        mock_sock.setsockopt.assert_any_call(_socket.IPPROTO_TCP, 5, 10)
+        mock_sock.setsockopt.assert_any_call(_socket.IPPROTO_TCP, 6, 3)
+
 
 class TestISOConnect:
     """Test _iso_connect()."""

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -453,6 +453,28 @@ class TestTCPConnect:
         mock_sock.settimeout.assert_called_once()
         mock_sock.connect.assert_called_once_with(("1.2.3.4", 102))
 
+    @patch("snap7.connection.socket.socket")
+    def test_tcp_connect_sets_tcp_nodelay(self, mock_socket_cls: MagicMock) -> None:
+        """TCP_NODELAY must be set to eliminate Nagle buffering latency."""
+        import socket as _socket
+
+        mock_sock = MagicMock()
+        mock_socket_cls.return_value = mock_sock
+        conn = ISOTCPConnection("1.2.3.4")
+        conn._tcp_connect()
+        mock_sock.setsockopt.assert_any_call(_socket.IPPROTO_TCP, _socket.TCP_NODELAY, 1)
+
+    @patch("snap7.connection.socket.socket")
+    def test_tcp_connect_sets_so_keepalive(self, mock_socket_cls: MagicMock) -> None:
+        """SO_KEEPALIVE must be set to detect dead connections during idle periods."""
+        import socket as _socket
+
+        mock_sock = MagicMock()
+        mock_socket_cls.return_value = mock_sock
+        conn = ISOTCPConnection("1.2.3.4")
+        conn._tcp_connect()
+        mock_sock.setsockopt.assert_any_call(_socket.SOL_SOCKET, _socket.SO_KEEPALIVE, 1)
+
 
 class TestISOConnect:
     """Test _iso_connect()."""


### PR DESCRIPTION
## Summary

- Set `TCP_NODELAY` on all sockets (client, server, partner, S7CommPlus server) to eliminate 100-150ms Nagle's algorithm delay
- Set `SO_KEEPALIVE` on all sockets to detect dead connections during idle periods
- Configure keepalive timing (60s idle, 10s interval, 3 probes = ~90s detection) on platforms that support it (Linux, macOS 10.15+)
- Applied to both outgoing connections (`_tcp_connect`) and accepted connections (server/partner `accept()`)

Closes #673. Based on feedback from real PLC testing in #668.

## Test plan

- [x] New unit tests for socket options in `tests/test_connection.py`
- [ ] Verify no regressions on all platforms (Linux, macOS, Windows)
- [ ] Confirm latency improvement with real PLC

🤖 Generated with [Claude Code](https://claude.com/claude-code)