### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,17 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically enables squash-merge on Dependabot PRs once all CI checks pass. This uses GitHub's native auto-merge feature, so branch protection rules are still respected — the PR only merges after all required checks are green.

No more manual merging of dependency bumps.

## How it works

1. Dependabot opens a PR
2. This workflow runs and calls `gh pr merge --auto --squash`
3. GitHub waits for all required status checks to pass
4. PR is automatically squash-merged

**Note:** This requires "Allow auto-merge" to be enabled in the repository settings (Settings > General > Pull Requests > Allow auto-merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)