### PR TITLE
Fixed "get_cpu_info" and "__str__" in structure "S7SZL"

### DIFF
--- a/snap7/client.py
+++ b/snap7/client.py
@@ -1213,7 +1213,7 @@ class Client(ClientMixin):
             cpu_info.Copyright = data[108:134].rstrip(b"\x00")
         if len(data) >= 166:
             cpu_info.SerialNumber = data[142:166].rstrip(b"\x00")
-        if len(data) >= 130:
+        if len(data) >= 208:
             cpu_info.ModuleTypeName = data[176:208].rstrip(b"\x00")
 
         return cpu_info

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -1205,16 +1205,16 @@ class Client(ClientMixin):
         # ASName: 24 bytes
         # Copyright: 26 bytes
         # ModuleName: 24 bytes
-        if len(data) >= 32:
-            cpu_info.ModuleTypeName = data[0:32].rstrip(b"\x00")
-        if len(data) >= 56:
-            cpu_info.SerialNumber = data[32:56].rstrip(b"\x00")
-        if len(data) >= 80:
-            cpu_info.ASName = data[56:80].rstrip(b"\x00")
-        if len(data) >= 106:
-            cpu_info.Copyright = data[80:106].rstrip(b"\x00")
+        if len(data) >= 30:
+            cpu_info.ASName = data[6:30].rstrip(b"\x00")
+        if len(data) >= 64:
+            cpu_info.ModuleName = data[40:64].rstrip(b"\x00")
+        if len(data) >= 134:
+            cpu_info.Copyright = data[108:134].rstrip(b"\x00")
+        if len(data) >= 166:
+            cpu_info.SerialNumber = data[142:166].rstrip(b"\x00")
         if len(data) >= 130:
-            cpu_info.ModuleName = data[106:130].rstrip(b"\x00")
+            cpu_info.ModuleTypeName = data[176:208].rstrip(b"\x00")
 
         return cpu_info
 

--- a/snap7/type.py
+++ b/snap7/type.py
@@ -341,7 +341,7 @@ class S7SZL(Structure):
     _fields_ = [("Header", S7SZLHeader), ("Data", c_ubyte * (0x4000 - 4))]
 
     def __str__(self) -> str:
-        return f"<S7SZL Header: {self.S7SZHeader}, Data: {self.Data}>"
+        return f"<S7SZL Header: {self.Header}, Data: {self.Data}>"
 
 
 class S7SZLList(Structure):


### PR DESCRIPTION
- Fix in structure "S7SZL" function "\_\_str\_\_" in file "snap7/type.py", previously gave error "AttributeError: 'S7SZL' object has no attribute 'S7SZHeader'"

- Fixed function get_cpu_info in file "snap7/client.py", it returned all the field empty.

Now tested working on s7-300 and s7-1500, same output as the old python-snap7 2.1.1.