### PR TITLE
Fix mypy errors in test_symbols and server SZL list

### DIFF
--- a/snap7/server/__init__.py
+++ b/snap7/server/__init__.py
@@ -1704,10 +1704,10 @@ class Server:
         elif szl_id == 0x0000:
             # Return list of available SZL IDs
             available_ids = [0x0000, 0x0011, 0x001C, 0x0131, 0x0232]
-            data = b""
+            szl_bytes = b""
             for id_val in available_ids:
-                data += struct.pack(">H", id_val)
-            return data
+                szl_bytes += struct.pack(">H", id_val)
+            return szl_bytes
 
         return None
 

--- a/tests/test_symbols.py
+++ b/tests/test_symbols.py
@@ -407,7 +407,9 @@ class TestReadMany:
 
         table = SymbolTable({"Temp": {"db": 1, "offset": 0, "type": "REAL"}})
         values = table.read_many(client, ["Temp"])
-        assert abs(values["Temp"] - 42.0) < 0.01
+        temp = values["Temp"]
+        assert isinstance(temp, float)
+        assert abs(temp - 42.0) < 0.01
 
     def test_read_many_empty(self) -> None:
         client = _make_client()


### PR DESCRIPTION
Fixes mypy type errors introduced by recent merges. All checks pass locally (1475 tests, 0 mypy errors, ruff clean).