### PR TITLE
Fix async get_cpu_info and extract shared SZL/block parsers

### DIFF
--- a/snap7/async_client.py
+++ b/snap7/async_client.py
@@ -21,6 +21,7 @@ from .s7protocol import S7Protocol, get_return_code_description
 from .datatypes import S7WordLen
 from .error import S7Error, S7ConnectionError, S7ProtocolError, S7TimeoutError
 from .client_base import ClientMixin
+from .szl import parse_cp_info_szl, parse_cpu_info_szl, parse_order_code_szl, parse_protection_szl
 from .type import (
     Area,
     Block,
@@ -653,18 +654,7 @@ class AsyncClient(ClientMixin):
             desc = get_return_code_description(return_code)
             raise S7ProtocolError(f"List blocks failed: {desc} (0x{return_code:02x})")
 
-        counts = self.protocol.parse_list_blocks_response(response)
-
-        block_list = BlocksList()
-        block_list.OBCount = counts.get("OBCount", 0)
-        block_list.FBCount = counts.get("FBCount", 0)
-        block_list.FCCount = counts.get("FCCount", 0)
-        block_list.SFBCount = counts.get("SFBCount", 0)
-        block_list.SFCCount = counts.get("SFCCount", 0)
-        block_list.DBCount = counts.get("DBCount", 0)
-        block_list.SDBCount = counts.get("SDBCount", 0)
-
-        return block_list
+        return self.protocol.parse_list_blocks(response)
 
     async def list_blocks_of_type(self, block_type: Block, max_count: int) -> List[int]:
         """List blocks of a specific type.
@@ -756,66 +746,17 @@ class AsyncClient(ClientMixin):
             desc = get_return_code_description(return_code)
             raise S7ProtocolError(f"Get block info failed: {desc} (0x{return_code:02x})")
 
-        info = self.protocol.parse_get_block_info_response(response)
-
-        block_info = TS7BlockInfo()
-        block_info.BlkType = info["block_type"]
-        block_info.BlkNumber = info["block_number"]
-        block_info.BlkLang = info["block_lang"]
-        block_info.BlkFlags = info["block_flags"]
-        block_info.MC7Size = info["mc7_size"]
-        block_info.LoadSize = info["load_size"]
-        block_info.LocalData = info["local_data"]
-        block_info.SBBLength = info["sbb_length"]
-        block_info.CheckSum = info["checksum"]
-        block_info.Version = info["version"]
-
-        if info["code_date"]:
-            block_info.CodeDate = info["code_date"][:10]
-        if info["intf_date"]:
-            block_info.IntfDate = info["intf_date"][:10]
-        if info["author"]:
-            block_info.Author = info["author"][:8]
-        if info["family"]:
-            block_info.Family = info["family"][:8]
-        if info["header"]:
-            block_info.Header = info["header"][:8]
-
-        return block_info
+        return self.protocol.parse_get_block_info(response)
 
     # ---------------------------------------------------------------
     # CPU info / state
     # ---------------------------------------------------------------
 
     async def get_cpu_info(self) -> S7CpuInfo:
-        """Get CPU information.
-
-        Uses read_szl(0x001C) to get component identification data. The
-        SZL 0x001C response is a sequence of (index:2, data:N) records,
-        not a flat struct, so fields sit at offsets relative to each
-        record header. See the fix in #694 for the sync client — this
-        mirrors those offsets.
-        """
+        """Get CPU component identification (SZL 0x001C)."""
         if not self.get_connected():
             raise S7ConnectionError("Not connected to PLC")
-
-        szl = await self.read_szl(0x001C, 0)
-
-        cpu_info = S7CpuInfo()
-        data = bytes(szl.Data[: szl.Header.LengthDR])
-
-        if len(data) >= 30:
-            cpu_info.ASName = data[6:30].rstrip(b"\x00")
-        if len(data) >= 64:
-            cpu_info.ModuleName = data[40:64].rstrip(b"\x00")
-        if len(data) >= 134:
-            cpu_info.Copyright = data[108:134].rstrip(b"\x00")
-        if len(data) >= 166:
-            cpu_info.SerialNumber = data[142:166].rstrip(b"\x00")
-        if len(data) >= 208:
-            cpu_info.ModuleTypeName = data[176:208].rstrip(b"\x00")
-
-        return cpu_info
+        return parse_cpu_info_szl(await self.read_szl(0x001C, 0))
 
     async def get_cpu_state(self) -> str:
         """Get CPU state (running/stopped)."""
@@ -1112,69 +1053,22 @@ class AsyncClient(ClientMixin):
     # ---------------------------------------------------------------
 
     async def get_cp_info(self) -> S7CpInfo:
-        """Get CP (Communication Processor) information."""
+        """Get communication processor info (SZL 0x0131)."""
         if not self.get_connected():
             raise S7ConnectionError("Not connected to PLC")
-
-        szl = await self.read_szl(0x0131, 0)
-
-        cp_info = S7CpInfo()
-        data = bytearray(b & 0xFF for b in szl.Data[: szl.Header.LengthDR])
-
-        if len(data) >= 2:
-            cp_info.MaxPduLength = struct.unpack(">H", data[0:2])[0]
-        if len(data) >= 4:
-            cp_info.MaxConnections = struct.unpack(">H", data[2:4])[0]
-        if len(data) >= 6:
-            cp_info.MaxMpiRate = struct.unpack(">H", data[4:6])[0]
-        if len(data) >= 8:
-            cp_info.MaxBusRate = struct.unpack(">H", data[6:8])[0]
-
-        return cp_info
+        return parse_cp_info_szl(await self.read_szl(0x0131, 0))
 
     async def get_order_code(self) -> S7OrderCode:
-        """Get order code."""
+        """Get module order code and firmware version (SZL 0x0011)."""
         if not self.get_connected():
             raise S7ConnectionError("Not connected to PLC")
-
-        szl = await self.read_szl(0x0011, 0)
-
-        order_code = S7OrderCode()
-        data = bytes(szl.Data[: szl.Header.LengthDR])
-
-        if len(data) >= 20:
-            order_code.OrderCode = data[0:20].rstrip(b"\x00")
-        if len(data) >= 21:
-            order_code.V1 = data[20]
-        if len(data) >= 22:
-            order_code.V2 = data[21]
-        if len(data) >= 23:
-            order_code.V3 = data[22]
-
-        return order_code
+        return parse_order_code_szl(await self.read_szl(0x0011, 0))
 
     async def get_protection(self) -> S7Protection:
-        """Get protection settings."""
+        """Get protection settings (SZL 0x0232)."""
         if not self.get_connected():
             raise S7ConnectionError("Not connected to PLC")
-
-        szl = await self.read_szl(0x0232, 0)
-
-        protection = S7Protection()
-        data = bytes(szl.Data[: szl.Header.LengthDR])
-
-        if len(data) >= 2:
-            protection.sch_schal = struct.unpack(">H", data[0:2])[0]
-        if len(data) >= 4:
-            protection.sch_par = struct.unpack(">H", data[2:4])[0]
-        if len(data) >= 6:
-            protection.sch_rel = struct.unpack(">H", data[4:6])[0]
-        if len(data) >= 8:
-            protection.bart_sch = struct.unpack(">H", data[6:8])[0]
-        if len(data) >= 10:
-            protection.anl_sch = struct.unpack(">H", data[8:10])[0]
-
-        return protection
+        return parse_protection_szl(await self.read_szl(0x0232, 0))
 
     async def compress(self, timeout: int) -> int:
         """Compress PLC memory."""

--- a/snap7/async_client.py
+++ b/snap7/async_client.py
@@ -788,7 +788,14 @@ class AsyncClient(ClientMixin):
     # ---------------------------------------------------------------
 
     async def get_cpu_info(self) -> S7CpuInfo:
-        """Get CPU information."""
+        """Get CPU information.
+
+        Uses read_szl(0x001C) to get component identification data. The
+        SZL 0x001C response is a sequence of (index:2, data:N) records,
+        not a flat struct, so fields sit at offsets relative to each
+        record header. See the fix in #694 for the sync client — this
+        mirrors those offsets.
+        """
         if not self.get_connected():
             raise S7ConnectionError("Not connected to PLC")
 
@@ -797,16 +804,16 @@ class AsyncClient(ClientMixin):
         cpu_info = S7CpuInfo()
         data = bytes(szl.Data[: szl.Header.LengthDR])
 
-        if len(data) >= 32:
-            cpu_info.ModuleTypeName = data[0:32].rstrip(b"\x00")
-        if len(data) >= 56:
-            cpu_info.SerialNumber = data[32:56].rstrip(b"\x00")
-        if len(data) >= 80:
-            cpu_info.ASName = data[56:80].rstrip(b"\x00")
-        if len(data) >= 106:
-            cpu_info.Copyright = data[80:106].rstrip(b"\x00")
-        if len(data) >= 130:
-            cpu_info.ModuleName = data[106:130].rstrip(b"\x00")
+        if len(data) >= 30:
+            cpu_info.ASName = data[6:30].rstrip(b"\x00")
+        if len(data) >= 64:
+            cpu_info.ModuleName = data[40:64].rstrip(b"\x00")
+        if len(data) >= 134:
+            cpu_info.Copyright = data[108:134].rstrip(b"\x00")
+        if len(data) >= 166:
+            cpu_info.SerialNumber = data[142:166].rstrip(b"\x00")
+        if len(data) >= 208:
+            cpu_info.ModuleTypeName = data[176:208].rstrip(b"\x00")
 
         return cpu_info
 

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -30,6 +30,7 @@ from .optimizer import ReadItem, ReadPacket, sort_items, merge_items, packetize,
 from .tags import Tag, _STRING_RE
 from . import util
 
+from .szl import parse_cp_info_szl, parse_cpu_info_szl, parse_order_code_szl, parse_protection_szl
 from .type import (
     Area,
     Block,
@@ -1385,20 +1386,7 @@ class Client(ClientMixin):
             desc = get_return_code_description(return_code)
             raise S7ProtocolError(f"List blocks failed: {desc} (0x{return_code:02x})")
 
-        # Parse block counts from response
-        counts = self.protocol.parse_list_blocks_response(response)
-
-        # Build BlocksList structure
-        block_list = BlocksList()
-        block_list.OBCount = counts.get("OBCount", 0)
-        block_list.FBCount = counts.get("FBCount", 0)
-        block_list.FCCount = counts.get("FCCount", 0)
-        block_list.SFBCount = counts.get("SFBCount", 0)
-        block_list.SFCCount = counts.get("SFCCount", 0)
-        block_list.DBCount = counts.get("DBCount", 0)
-        block_list.SDBCount = counts.get("SDBCount", 0)
-
-        return block_list
+        return self.protocol.parse_list_blocks(response)
 
     def list_blocks_of_type(self, block_type: Block, max_count: int) -> List[int]:
         """
@@ -1485,42 +1473,10 @@ class Client(ClientMixin):
         return block_numbers[:max_count]
 
     def get_cpu_info(self) -> S7CpuInfo:
-        """
-        Get CPU information.
-
-        Uses read_szl(0x001C) to get component identification data.
-
-        Returns:
-            CPU information structure
-        """
+        """Get CPU component identification (SZL 0x001C)."""
         if not self.get_connected():
             raise S7ConnectionError("Not connected to PLC")
-
-        # Read SZL 0x001C for component identification
-        szl = self.read_szl(0x001C, 0)
-
-        # Parse SZL data into S7CpuInfo structure
-        cpu_info = S7CpuInfo()
-        data = bytes(szl.Data[: szl.Header.LengthDR])
-
-        # S7CpuInfo field sizes (from C structure):
-        # ModuleTypeName: 32 bytes
-        # SerialNumber: 24 bytes
-        # ASName: 24 bytes
-        # Copyright: 26 bytes
-        # ModuleName: 24 bytes
-        if len(data) >= 30:
-            cpu_info.ASName = data[6:30].rstrip(b"\x00")
-        if len(data) >= 64:
-            cpu_info.ModuleName = data[40:64].rstrip(b"\x00")
-        if len(data) >= 134:
-            cpu_info.Copyright = data[108:134].rstrip(b"\x00")
-        if len(data) >= 166:
-            cpu_info.SerialNumber = data[142:166].rstrip(b"\x00")
-        if len(data) >= 208:
-            cpu_info.ModuleTypeName = data[176:208].rstrip(b"\x00")
-
-        return cpu_info
+        return parse_cpu_info_szl(self.read_szl(0x001C, 0))
 
     def get_cpu_state(self) -> str:
         """
@@ -1573,35 +1529,7 @@ class Client(ClientMixin):
             desc = get_return_code_description(return_code)
             raise S7ProtocolError(f"Get block info failed: {desc} (0x{return_code:02x})")
 
-        # Parse block info response
-        info = self.protocol.parse_get_block_info_response(response)
-
-        # Build TS7BlockInfo structure
-        block_info = TS7BlockInfo()
-        block_info.BlkType = info["block_type"]
-        block_info.BlkNumber = info["block_number"]
-        block_info.BlkLang = info["block_lang"]
-        block_info.BlkFlags = info["block_flags"]
-        block_info.MC7Size = info["mc7_size"]
-        block_info.LoadSize = info["load_size"]
-        block_info.LocalData = info["local_data"]
-        block_info.SBBLength = info["sbb_length"]
-        block_info.CheckSum = info["checksum"]
-        block_info.Version = info["version"]
-
-        # Copy date and string fields
-        if info["code_date"]:
-            block_info.CodeDate = info["code_date"][:10]
-        if info["intf_date"]:
-            block_info.IntfDate = info["intf_date"][:10]
-        if info["author"]:
-            block_info.Author = info["author"][:8]
-        if info["family"]:
-            block_info.Family = info["family"][:8]
-        if info["header"]:
-            block_info.Header = info["header"][:8]
-
-        return block_info
+        return self.protocol.parse_get_block_info(response)
 
     def upload(self, block_num: int) -> bytearray:
         """
@@ -1964,100 +1892,22 @@ class Client(ClientMixin):
         return 0
 
     def get_cp_info(self) -> S7CpInfo:
-        """
-        Get CP (Communication Processor) information.
-
-        Uses read_szl(0x0131) to get communication parameters.
-
-        Returns:
-            CP information structure
-        """
+        """Get communication processor info (SZL 0x0131)."""
         if not self.get_connected():
             raise S7ConnectionError("Not connected to PLC")
-
-        # Read SZL 0x0131 for communication parameters
-        szl = self.read_szl(0x0131, 0)
-
-        # Parse SZL data into S7CpInfo structure
-        cp_info = S7CpInfo()
-        # Use bytearray to handle c_byte (signed) values properly
-        data = bytearray(b & 0xFF for b in szl.Data[: szl.Header.LengthDR])
-
-        # S7CpInfo structure: 4 x uint16 (big-endian)
-        if len(data) >= 2:
-            cp_info.MaxPduLength = struct.unpack(">H", data[0:2])[0]
-        if len(data) >= 4:
-            cp_info.MaxConnections = struct.unpack(">H", data[2:4])[0]
-        if len(data) >= 6:
-            cp_info.MaxMpiRate = struct.unpack(">H", data[4:6])[0]
-        if len(data) >= 8:
-            cp_info.MaxBusRate = struct.unpack(">H", data[6:8])[0]
-
-        return cp_info
+        return parse_cp_info_szl(self.read_szl(0x0131, 0))
 
     def get_order_code(self) -> S7OrderCode:
-        """
-        Get order code.
-
-        Uses read_szl(0x0011) to get module identification.
-
-        Returns:
-            Order code structure
-        """
+        """Get module order code and firmware version (SZL 0x0011)."""
         if not self.get_connected():
             raise S7ConnectionError("Not connected to PLC")
-
-        # Read SZL 0x0011 for module identification
-        szl = self.read_szl(0x0011, 0)
-
-        # Parse SZL data into S7OrderCode structure
-        order_code = S7OrderCode()
-        data = bytes(szl.Data[: szl.Header.LengthDR])
-
-        # OrderCode: 20 bytes, Version: 4 bytes
-        if len(data) >= 20:
-            order_code.OrderCode = data[0:20].rstrip(b"\x00")
-        if len(data) >= 21:
-            order_code.V1 = data[20]
-        if len(data) >= 22:
-            order_code.V2 = data[21]
-        if len(data) >= 23:
-            order_code.V3 = data[22]
-
-        return order_code
+        return parse_order_code_szl(self.read_szl(0x0011, 0))
 
     def get_protection(self) -> S7Protection:
-        """
-        Get protection settings.
-
-        Uses read_szl(0x0232) to get protection level.
-
-        Returns:
-            Protection structure
-        """
+        """Get protection settings (SZL 0x0232)."""
         if not self.get_connected():
             raise S7ConnectionError("Not connected to PLC")
-
-        # Read SZL 0x0232 for protection level
-        szl = self.read_szl(0x0232, 0)
-
-        # Parse SZL data into S7Protection structure
-        protection = S7Protection()
-        data = bytes(szl.Data[: szl.Header.LengthDR])
-
-        # S7Protection structure: 5 x uint16 (big-endian)
-        if len(data) >= 2:
-            protection.sch_schal = struct.unpack(">H", data[0:2])[0]
-        if len(data) >= 4:
-            protection.sch_par = struct.unpack(">H", data[2:4])[0]
-        if len(data) >= 6:
-            protection.sch_rel = struct.unpack(">H", data[4:6])[0]
-        if len(data) >= 8:
-            protection.bart_sch = struct.unpack(">H", data[6:8])[0]
-        if len(data) >= 10:
-            protection.anl_sch = struct.unpack(">H", data[8:10])[0]
-
-        return protection
+        return parse_protection_szl(self.read_szl(0x0232, 0))
 
     def read_szl(self, ssl_id: int, index: int = 0) -> S7SZL:
         """

--- a/snap7/s7protocol.py
+++ b/snap7/s7protocol.py
@@ -12,6 +12,7 @@ from enum import IntEnum
 
 from .datatypes import S7Area, S7WordLen, S7DataTypes
 from .error import S7ProtocolError, S7StalePacketError, S7PacketLostError, get_protocol_error_message
+from .type import BlocksList, TS7BlockInfo
 
 logger = logging.getLogger(__name__)
 
@@ -1047,6 +1048,22 @@ class S7Protocol:
 
         return result
 
+    def parse_list_blocks(self, response: Dict[str, Any]) -> BlocksList:
+        """Parse list blocks response directly into a :class:`BlocksList`.
+
+        Consolidates the dict→struct conversion that used to live in both
+        the sync and async clients so the field mapping is declared once.
+        """
+        return build_blocks_list_from_dict(self.parse_list_blocks_response(response))
+
+    def parse_get_block_info(self, response: Dict[str, Any]) -> TS7BlockInfo:
+        """Parse block info response directly into a :class:`TS7BlockInfo`.
+
+        Consolidates the dict→struct conversion that used to live in both
+        the sync and async clients.
+        """
+        return build_block_info_from_dict(self.parse_get_block_info_response(response))
+
     def build_read_szl_request(self, szl_id: int, szl_index: int) -> bytes:
         """
         Build USER_DATA request for reading SZL (System Status List).
@@ -1604,3 +1621,52 @@ class S7Protocol:
                 desc = get_return_code_description(return_code)
                 raise S7ProtocolError(f"Write operation failed: {desc} (0x{return_code:02x})")
         # If no data and no header error, the write was successful (ACK without data)
+
+
+# ---------------------------------------------------------------------------
+# Dict-to-struct converters shared by sync and async clients.
+# Kept at module level so both :class:`snap7.client.Client` and
+# :class:`snap7.async_client.AsyncClient` produce identical structs from
+# the same protocol parse output (see discussion #700).
+# ---------------------------------------------------------------------------
+
+
+def build_blocks_list_from_dict(counts: Dict[str, int]) -> BlocksList:
+    """Populate a :class:`BlocksList` from the dict returned by ``parse_list_blocks_response``."""
+    block_list = BlocksList()
+    block_list.OBCount = counts.get("OBCount", 0)
+    block_list.FBCount = counts.get("FBCount", 0)
+    block_list.FCCount = counts.get("FCCount", 0)
+    block_list.SFBCount = counts.get("SFBCount", 0)
+    block_list.SFCCount = counts.get("SFCCount", 0)
+    block_list.DBCount = counts.get("DBCount", 0)
+    block_list.SDBCount = counts.get("SDBCount", 0)
+    return block_list
+
+
+def build_block_info_from_dict(info: Dict[str, Any]) -> TS7BlockInfo:
+    """Populate a :class:`TS7BlockInfo` from the dict returned by ``parse_get_block_info_response``."""
+    block_info = TS7BlockInfo()
+    block_info.BlkType = info["block_type"]
+    block_info.BlkNumber = info["block_number"]
+    block_info.BlkLang = info["block_lang"]
+    block_info.BlkFlags = info["block_flags"]
+    block_info.MC7Size = info["mc7_size"]
+    block_info.LoadSize = info["load_size"]
+    block_info.LocalData = info["local_data"]
+    block_info.SBBLength = info["sbb_length"]
+    block_info.CheckSum = info["checksum"]
+    block_info.Version = info["version"]
+
+    if info["code_date"]:
+        block_info.CodeDate = info["code_date"][:10]
+    if info["intf_date"]:
+        block_info.IntfDate = info["intf_date"][:10]
+    if info["author"]:
+        block_info.Author = info["author"][:8]
+    if info["family"]:
+        block_info.Family = info["family"][:8]
+    if info["header"]:
+        block_info.Header = info["header"][:8]
+
+    return block_info

--- a/snap7/szl.py
+++ b/snap7/szl.py
@@ -1,0 +1,115 @@
+"""Parsers for S7 System Status List (SZL) records.
+
+The SZL is the Siemens mechanism for reading diagnostic and identification
+data from an S7 CPU. Each SZL ID has its own record layout. These helpers
+take a parsed :class:`~snap7.type.S7SZL` and decode it into the
+corresponding typed structure.
+
+Both :class:`snap7.client.Client` and :class:`snap7.async_client.AsyncClient`
+use these helpers so offset and field fixes only have to be made in one
+place (see discussion #700).
+"""
+
+from __future__ import annotations
+
+import struct
+
+from .type import S7CpInfo, S7CpuInfo, S7OrderCode, S7Protection, S7SZL
+
+
+def _szl_data(szl: S7SZL) -> bytes:
+    """Extract the raw byte payload from an SZL response.
+
+    ``S7SZL.Data`` is an array of ``c_byte`` (signed), which means values
+    with the high bit set come through as negative Python ints. Calling
+    ``bytes()`` on them raises ``ValueError``, and ``struct.unpack``
+    produces wrong uint16s. Mask each byte to ``0..255`` once here so
+    callers can slice, struct-unpack, and assign to ctypes char fields
+    freely. Returning ``bytes`` (not ``bytearray``) matches what ctypes
+    ``Structure`` char-array fields expect.
+    """
+    return bytes(b & 0xFF for b in szl.Data[: szl.Header.LengthDR])
+
+
+def parse_cpu_info_szl(szl: S7SZL) -> S7CpuInfo:
+    """Decode SZL 0x001C (component identification) into an :class:`S7CpuInfo`.
+
+    Field offsets are relative to the start of the SZL data buffer and
+    match the layout produced by real S7-300/1500 CPUs. See PR #692 for
+    the offset correction and discussion #700 for context on the async
+    follow-up that made these helpers necessary.
+    """
+    info = S7CpuInfo()
+    data = _szl_data(szl)
+
+    if len(data) >= 30:
+        info.ASName = data[6:30].rstrip(b"\x00")
+    if len(data) >= 64:
+        info.ModuleName = data[40:64].rstrip(b"\x00")
+    if len(data) >= 134:
+        info.Copyright = data[108:134].rstrip(b"\x00")
+    if len(data) >= 166:
+        info.SerialNumber = data[142:166].rstrip(b"\x00")
+    if len(data) >= 208:
+        info.ModuleTypeName = data[176:208].rstrip(b"\x00")
+
+    return info
+
+
+def parse_cp_info_szl(szl: S7SZL) -> S7CpInfo:
+    """Decode SZL 0x0131 (communication processor info) into an :class:`S7CpInfo`.
+
+    Layout: four big-endian ``uint16`` fields.
+    """
+    info = S7CpInfo()
+    data = _szl_data(szl)
+
+    if len(data) >= 2:
+        info.MaxPduLength = struct.unpack(">H", data[0:2])[0]
+    if len(data) >= 4:
+        info.MaxConnections = struct.unpack(">H", data[2:4])[0]
+    if len(data) >= 6:
+        info.MaxMpiRate = struct.unpack(">H", data[4:6])[0]
+    if len(data) >= 8:
+        info.MaxBusRate = struct.unpack(">H", data[6:8])[0]
+
+    return info
+
+
+def parse_order_code_szl(szl: S7SZL) -> S7OrderCode:
+    """Decode SZL 0x0011 (module order code + firmware version) into :class:`S7OrderCode`."""
+    order_code = S7OrderCode()
+    data = _szl_data(szl)
+
+    if len(data) >= 20:
+        order_code.OrderCode = data[0:20].rstrip(b"\x00")
+    if len(data) >= 21:
+        order_code.V1 = data[20]
+    if len(data) >= 22:
+        order_code.V2 = data[21]
+    if len(data) >= 23:
+        order_code.V3 = data[22]
+
+    return order_code
+
+
+def parse_protection_szl(szl: S7SZL) -> S7Protection:
+    """Decode SZL 0x0232 (protection level) into an :class:`S7Protection`.
+
+    Layout: five big-endian ``uint16`` fields.
+    """
+    protection = S7Protection()
+    data = _szl_data(szl)
+
+    if len(data) >= 2:
+        protection.sch_schal = struct.unpack(">H", data[0:2])[0]
+    if len(data) >= 4:
+        protection.sch_par = struct.unpack(">H", data[2:4])[0]
+    if len(data) >= 6:
+        protection.sch_rel = struct.unpack(">H", data[4:6])[0]
+    if len(data) >= 8:
+        protection.bart_sch = struct.unpack(">H", data[6:8])[0]
+    if len(data) >= 10:
+        protection.anl_sch = struct.unpack(">H", data[8:10])[0]
+
+    return protection

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -320,8 +320,22 @@ async def test_get_cpu_state(client: AsyncClient) -> None:
 
 @pytest.mark.asyncio
 async def test_get_cpu_info(client: AsyncClient) -> None:
+    """AsyncClient.get_cpu_info must parse the same SZL offsets as sync client.
+
+    Regression guard for discussion #700 where the async implementation
+    kept the pre-#692 offsets (starting at 0) and returned empty fields
+    against a real PLC and the fixed server emulator.
+    """
     info = await client.get_cpu_info()
-    assert hasattr(info, "ModuleTypeName")
+    expected = (
+        ("ModuleTypeName", "CPU 315-2 PN/DP"),
+        ("SerialNumber", "S C-C2UR28922012"),
+        ("ASName", "SNAP7-SERVER"),
+        ("Copyright", "Original Siemens Equipment"),
+        ("ModuleName", "CPU 315-2 PN/DP"),
+    )
+    for field_name, value in expected:
+        assert getattr(info, field_name).decode("utf-8") == value
 
 
 @pytest.mark.asyncio

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -308,8 +308,12 @@ def test_get_param_non_client_raises() -> None:
 
 @pytest.mark.asyncio
 async def test_list_blocks(client: AsyncClient) -> None:
+    """AsyncClient.list_blocks must decode the same block-count struct as sync."""
     result = await client.list_blocks()
-    assert hasattr(result, "DBCount")
+    # Server registers DB 0, 1 and various other areas; block counts match
+    # what the sync test_client.test_list_blocks_server test observes.
+    assert isinstance(result.DBCount, int)
+    assert result.DBCount >= 2
 
 
 @pytest.mark.asyncio
@@ -336,6 +340,43 @@ async def test_get_cpu_info(client: AsyncClient) -> None:
     )
     for field_name, value in expected:
         assert getattr(info, field_name).decode("utf-8") == value
+
+
+@pytest.mark.asyncio
+async def test_get_cp_info(client: AsyncClient) -> None:
+    """Mirrors sync test_client.test_get_cp_info — guards SZL 0x0131 decoding."""
+    result = await client.get_cp_info()
+    assert result.MaxPduLength == 480
+    assert result.MaxConnections == 32
+    assert result.MaxMpiRate == 12
+    assert result.MaxBusRate == 12
+
+
+@pytest.mark.asyncio
+async def test_get_order_code(client: AsyncClient) -> None:
+    """Mirrors sync test — guards SZL 0x0011 decoding."""
+    result = await client.get_order_code()
+    assert b"6ES7" in result.OrderCode
+
+
+@pytest.mark.asyncio
+async def test_get_protection(client: AsyncClient) -> None:
+    """Mirrors sync test — guards SZL 0x0232 decoding."""
+    result = await client.get_protection()
+    assert result.sch_schal == 1
+    assert result.sch_par == 0
+    assert result.sch_rel == 0
+    assert result.bart_sch == 0
+    assert result.anl_sch == 0
+
+
+@pytest.mark.asyncio
+async def test_get_block_info(client: AsyncClient) -> None:
+    """Mirrors sync test — guards get_block_info dict→TS7BlockInfo conversion."""
+    from snap7.type import Block
+
+    info = await client.get_block_info(Block.DB, 1)
+    assert info.BlkNumber == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Closes #700 and removes the duplication that caused it.

**The bug:** `AsyncClient.get_cpu_info()` returned empty fields against real PLCs and the server emulator. PR #692 fixed the SZL 0x001C offsets in the sync `Client`; `async_client.py` was never touched and kept the pre-#692 layout. First commit ports the fix; strengthens the async test from `hasattr()` to value assertions (the smoke test was too weak to catch the bug — that's how it survived).

**The root cause fix:** SZL parsing logic and the block-info dict→struct copy lived inline in *both* clients. A one-sided fix to either side silently drifted. Second commit extracts those:

- New `snap7/szl.py` module with `parse_{cpu_info,cp_info,order_code,protection}_szl(szl)` helpers. Both clients call them; offsets and field definitions exist in exactly one place.
- Two non-SZL converters live alongside the existing protocol parsers in `s7protocol.py` (`build_blocks_list_from_dict`, `build_block_info_from_dict`), exposed as `S7Protocol.parse_list_blocks` / `S7Protocol.parse_get_block_info`. The dict→struct copy disappears from both clients.
- Strengthened async tests for `list_blocks`, `get_cp_info`, `get_order_code`, `get_protection`, `get_block_info` — all previously did only `hasattr()` checks. Now assert the same concrete values the sync suite asserts.

Net: clients shrink by ~280 lines, parsing surface is unified, and the async tests carry the same safety net as sync.

## Why `szl.py` (not `_parsers.py` / `decoders.py`)

Audited every method duplicated between the two clients. 4 of 5 parser-shaped duplicates are SZL (cpu_info, cp_info, order_code, protection). The remaining one — `get_block_info`'s dict→struct — belongs in `protocol.py` next to the rest of its parsing logic, not in a grab-bag module. `get_plc_datetime` / `get_cpu_state` were already shared via `self.protocol`. So `szl.py` is honestly scoped; no `_parsers.py` junk drawer needed.

## Test plan

- [x] Reverting just the async `get_cpu_info` offset fix (keeping the strengthened test) reproduces the bug as `AssertionError: assert '' == 'CPU 315-2 PN/DP'`. With the fix it passes.
- [x] Full suite: 1501 passed, 91 skipped (+4 new async tests)
- [x] mypy + ruff + pre-commit clean

Fixes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)
