### PR TITLE
Replace random.randint port picks with OS-assigned ephemeral ports

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,30 @@
 """Pytest configuration for python-snap7 tests."""
 
+import socket
 import sys
+
 import pytest
+
+
+def get_free_tcp_port() -> int:
+    """Return a TCP port that is free *right now* on 127.0.0.1.
+
+    Bind a throwaway socket to port 0, let the OS pick an ephemeral port,
+    read it back, then close the socket. Preferred over ``random.randint``
+    for test servers: the OS guarantees the port is currently unused, and
+    the collision window is vanishingly small (the ephemeral range is tens
+    of thousands of ports wide) instead of 1-in-5000 from a random pick
+    that drifts toward collision under pytest-xdist or repeated reruns.
+
+    There is a tiny TOCTOU race between closing this socket and the test
+    server binding, but the pool is large enough that it is not observed
+    in practice. Servers that set ``SO_REUSEADDR`` tolerate lingering
+    TIME_WAIT sockets too.
+    """
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        port: int = s.getsockname()[1]
+        return port
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import random
 import time
+
+from .conftest import get_free_tcp_port
 from ctypes import c_char
 from typing import TYPE_CHECKING
 
@@ -258,7 +259,7 @@ class TestMultiReadServer:
         db2_array = (c_char * 100).from_buffer(cls.db2_data)
         cls.server.register_area(SrvArea.DB, 2, db2_array)
 
-        port = random.randint(20000, 40000)
+        port = get_free_tcp_port()
         cls.server.start(tcp_port=port)
         time.sleep(0.2)
 

--- a/tests/test_s7_unified.py
+++ b/tests/test_s7_unified.py
@@ -4,7 +4,6 @@ No real PLC is needed — these tests exercise the full s7 package using the
 built-in S7CommPlus and legacy server emulators.
 """
 
-import random
 import struct
 import time
 from ctypes import c_char
@@ -15,13 +14,15 @@ from s7 import Client, Server, Protocol
 from s7._protocol import Protocol as Proto
 from snap7.type import SrvArea
 
+from .conftest import get_free_tcp_port
+
 
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
 
-LEGACY_PORT = random.randint(20000, 30000)
-S7PLUS_PORT = random.randint(30001, 40000)
+LEGACY_PORT = get_free_tcp_port()
+S7PLUS_PORT = get_free_tcp_port()
 
 
 @pytest.fixture(scope="module")
@@ -337,7 +338,7 @@ class TestUnifiedClientS7CommPlus:
     def test_force_s7commplus_fails_without_server(self) -> None:
         """Forcing S7CommPlus when no server is available raises."""
         client = Client()
-        port = random.randint(40001, 50000)
+        port = get_free_tcp_port()
         with pytest.raises(Exception):
             client.connect("127.0.0.1", 0, 0, port, protocol=Protocol.S7COMMPLUS)
 
@@ -380,7 +381,7 @@ class TestUnifiedServer:
     """Test s7.Server features."""
 
     def test_server_context_manager(self) -> None:
-        port = random.randint(50001, 55000)
+        port = get_free_tcp_port()
         with Server() as srv:
             srv.legacy_server.register_area(SrvArea.DB, 1, (c_char * 10).from_buffer(bytearray(10)))
             srv.start(tcp_port=port)

--- a/tests/test_stress.py
+++ b/tests/test_stress.py
@@ -4,7 +4,6 @@ Verify that multiple clients hitting the same server simultaneously
 don't cause cross-talk, data corruption, or crashes.
 """
 
-import random
 import struct
 import threading
 import time
@@ -16,7 +15,9 @@ from snap7.client import Client
 from snap7.server import Server
 from snap7.type import SrvArea
 
-STRESS_PORT = random.randint(20000, 30000)
+from .conftest import get_free_tcp_port
+
+STRESS_PORT = get_free_tcp_port()
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
## Summary

Fixes the `Errno 98: Address already in use` flake that bit `test_server_context_manager` in the post-merge CI run for #701. Root cause: test fixtures picked TCP ports via `random.randint` over narrow ranges (5k-20k ports wide) with no free-check. Under concurrent server starts or rapid re-runs the draw collides.

**Fix:** bind a throwaway socket to port 0, read the OS-assigned ephemeral port, close it, and pass the number to the test server. The ephemeral pool is tens of thousands wide and the OS guarantees the port was free at pick time — much smaller collision window than the previous random draws. `snap7.server` already sets `SO_REUSEADDR`, so TIME_WAIT lingers from a prior run don't bite either.

One helper (`get_free_tcp_port`) lives in `tests/conftest.py` and is reused by `test_s7_unified`, `test_optimizer`, and `test_stress`. Added an empty `tests/__init__.py` so `from .conftest import get_free_tcp_port` works (the directory was already treated as a package by pytest; this just makes the relative import legal).

## Test plan

- [x] Full suite: 1501 passed, 91 skipped
- [x] `test_server_context_manager` run 10 times in a row — 10/10 pass
- [x] mypy + ruff + pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
