### PR TITLE
Clean exit on garbage collection for Client, Server, Partner

### DIFF
--- a/snap7/client.py
+++ b/snap7/client.py
@@ -10,6 +10,7 @@ import copy
 import logging
 import random
 import struct
+import sys
 import threading
 import time
 from typing import List, Any, Optional, Tuple, Union, Callable, cast
@@ -2656,5 +2657,12 @@ class Client(ClientMixin):
         self.disconnect()
 
     def __del__(self) -> None:
-        """Destructor."""
-        self.disconnect()
+        # Best-effort cleanup on garbage collection. Prefer disconnect()
+        # or a `with` block; during interpreter shutdown module globals
+        # may already be None, so we skip finalization and swallow errors.
+        if sys.is_finalizing():
+            return
+        try:
+            self.disconnect()
+        except Exception:
+            pass

--- a/snap7/partner.py
+++ b/snap7/partner.py
@@ -9,6 +9,7 @@ partners have equal rights and can send data asynchronously.
 import socket
 import struct
 import logging
+import sys
 import threading
 from typing import Optional, Tuple, Callable, Type
 from queue import Queue, Empty
@@ -1097,7 +1098,11 @@ class Partner:
         self.destroy()
 
     def __del__(self) -> None:
-        """Destructor."""
+        # Best-effort cleanup on garbage collection. Prefer stop() or a
+        # `with` block; during interpreter shutdown module globals may
+        # already be None, so we skip finalization and swallow errors.
+        if sys.is_finalizing():
+            return
         try:
             self.stop()
         except Exception:

--- a/snap7/server/__init__.py
+++ b/snap7/server/__init__.py
@@ -8,6 +8,7 @@ S7CommPlus clients.
 
 import socket
 import struct
+import sys
 import threading
 import time
 import logging
@@ -2486,6 +2487,17 @@ class Server:
     ) -> None:
         """Context manager exit."""
         self.destroy()
+
+    def __del__(self) -> None:
+        # Best-effort cleanup on garbage collection. Prefer destroy() or
+        # a `with` block; during interpreter shutdown module globals may
+        # already be None, so we skip finalization and swallow errors.
+        if sys.is_finalizing():
+            return
+        try:
+            self.destroy()
+        except Exception:
+            pass
 
 
 class ServerISOConnection:

--- a/tests/test_finalize.py
+++ b/tests/test_finalize.py
@@ -1,0 +1,33 @@
+"""Destructors must tolerate module globals being cleared during shutdown."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from snap7.client import Client
+from snap7.partner import Partner
+from snap7.server import Server
+
+
+def test_client_del_with_logger_cleared_does_not_raise() -> None:
+    import snap7.client as client_mod
+
+    c = Client()
+    with patch.object(client_mod, "logger", None):
+        c.__del__()  # noqa: PLC2801
+
+
+def test_partner_del_with_logger_cleared_does_not_raise() -> None:
+    import snap7.partner as partner_mod
+
+    p = Partner()
+    with patch.object(partner_mod, "logger", None):
+        p.__del__()  # noqa: PLC2801
+
+
+def test_server_del_with_logger_cleared_does_not_raise() -> None:
+    import snap7.server as server_mod
+
+    s = Server()
+    with patch.object(server_mod, "logger", None):
+        s.__del__()  # noqa: PLC2801


### PR DESCRIPTION
Give `Client`, `Partner`, and `Server` the same best-effort destructor so the program exits cleanly when these objects are collected by the garbage collector — even during interpreter shutdown, where module globals can already be `None` and any logging call would raise `AttributeError`.

Same four-line pattern in all three classes: early-return under `sys.is_finalizing()`, call the existing cleanup method (`disconnect()` / `stop()` / `destroy()`), swallow exceptions.

## Test plan

- [x] `tests/test_finalize.py` — each destructor is exercised with the module-level logger patched to `None`; fails on master without the fix, passes with it.
- [x] Full suite: 1546 passed, 88 skipped.
- [x] mypy + ruff + pre-commit clean.
