### PR TITLE
Fix demo's primary-IP guess with VPN/tunnel interfaces

### DIFF
--- a/snap7/demo.py
+++ b/snap7/demo.py
@@ -358,14 +358,42 @@ def _rich_available() -> bool:
         return False
 
 
+_TUNNEL_NAME_PREFIXES = ("utun", "tun", "tap", "wg", "tailscale", "zt")
+
+
 def _primary_ip() -> str:
-    """Best-effort local IP for the on-screen banner (localhost fallback on failure)."""
+    """Best-effort local IPv4 for the on-screen banner.
+
+    The older UDP-connect-to-8.8.8.8 trick picked whichever interface
+    owned the default route, which on a machine with Tailscale / other
+    VPN tunnels is the tunnel address — useless for a LAN client to
+    reach us on. Instead enumerate all interfaces via psutil, skip
+    loopback / link-local / tunnel-looking names, and prefer an
+    RFC1918 private address.
+    """
     try:
-        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as s:
-            s.connect(("8.8.8.8", 80))
-            return str(s.getsockname()[0])
-    except OSError:
+        import psutil
+    except ImportError:
         return "127.0.0.1"
+
+    candidates: list[str] = []
+    for iface, addrs in psutil.net_if_addrs().items():
+        if iface.startswith(_TUNNEL_NAME_PREFIXES):
+            continue
+        for a in addrs:
+            if getattr(a, "family", None) != socket.AF_INET:
+                continue
+            ip = a.address
+            if ip.startswith(("127.", "169.254.", "0.")):
+                continue
+            candidates.append(ip)
+
+    # Prefer RFC1918 private-range addresses — those are the ones a LAN
+    # peer is most likely to reach us on.
+    for ip in candidates:
+        if ip.startswith(("10.", "192.168.")) or (ip.startswith("172.") and 16 <= int(ip.split(".")[1]) <= 31):
+            return ip
+    return candidates[0] if candidates else "127.0.0.1"
 
 
 def _run_plain_loop(

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -14,6 +14,9 @@ import pytest
 
 pytest.importorskip("psutil")
 
+import socket  # noqa: E402
+from unittest.mock import patch  # noqa: E402
+
 from snap7.demo import (  # noqa: E402
     _CONTROL_BOOLS,
     _CONTROL_LAYOUT,
@@ -24,6 +27,7 @@ from snap7.demo import (  # noqa: E402
     MetricCollector,
     Metrics,
     _encode_sensors,
+    _primary_ip,
 )
 
 
@@ -114,3 +118,46 @@ def test_control_watcher_detects_int_change() -> None:
     struct.pack_into(">h", buffer, offset, 200)
     watcher.tick()
     assert ("brightness", "200") in changes
+
+
+class _FakeAddr:
+    """Duck-typed stand-in for a psutil snicaddr IPv4 entry."""
+
+    def __init__(self, ip: str) -> None:
+        self.family = socket.AF_INET
+        self.address = ip
+
+
+def _addrs(*ips: str) -> list[_FakeAddr]:
+    return [_FakeAddr(ip) for ip in ips]
+
+
+def test_primary_ip_skips_tunnel_interfaces() -> None:
+    """A Tailscale / VPN-shaped address on a tunnel iface must be filtered out."""
+    import psutil
+
+    fake = {
+        "en0": _addrs("192.168.1.207"),
+        "utun3": _addrs("172.21.32.206"),  # Tailscale
+        "lo0": _addrs("127.0.0.1"),
+    }
+    with patch.object(psutil, "net_if_addrs", return_value=fake):
+        assert _primary_ip() == "192.168.1.207"
+
+
+def test_primary_ip_prefers_rfc1918_over_public() -> None:
+    import psutil
+
+    fake = {
+        "en0": _addrs("203.0.113.5"),  # TEST-NET-3 (public)
+        "en1": _addrs("192.168.1.207"),
+    }
+    with patch.object(psutil, "net_if_addrs", return_value=fake):
+        assert _primary_ip() == "192.168.1.207"
+
+
+def test_primary_ip_falls_back_when_nothing_found() -> None:
+    import psutil
+
+    with patch.object(psutil, "net_if_addrs", return_value={"lo0": _addrs("127.0.0.1")}):
+        assert _primary_ip() == "127.0.0.1"


### PR DESCRIPTION
Noticed during the ha-s7 setup session: the demo banner printed `192.168.1.245` while the Mac's actual LAN IP was `.207`. Reason — the old `_primary_ip()` used UDP-connect to `8.8.8.8` to discover "the" local IP, which picks whichever interface owns the default route. On a host with Tailscale or any VPN, that's the tunnel address, which no LAN peer can reach us on.

Instead, enumerate interfaces via psutil, skip:
- loopback (`127.0.0.0/8`), link-local (`169.254.0.0/16`), unspecified (`0.0.0.0`);
- interface names starting with `utun` / `tun` / `tap` / `wg` / `tailscale` / `zt`.

Then prefer an RFC1918 private-range address (the realistic "LAN peer can reach me here"), falling back to the first non-loopback, and ultimately `127.0.0.1`.

## Test plan

- [x] 3 new unit tests in `tests/test_demo.py` covering the Tailscale case, RFC1918 preference, and loopback fallback.
- [x] Full suite: 1551 passed.
- [x] mypy + ruff clean.
- [x] Smoke: `python -c "from snap7.demo import _primary_ip; print(_primary_ip())"` returns the correct LAN IP on my machine (was returning a Tailscale address before).
