### PR TITLE
Docs: require pre-commit before every push

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -225,6 +225,7 @@ pytest tests/
 - **Each PR should have a single purpose**: Whether it is a bug fix, a new feature, a refactor, or a documentation update, keep it to one thing per PR.
 - **Run the full test suite before submitting**: Run `make test` or `pytest` and ensure all tests pass.
 - **Ensure mypy and ruff pass**: Run `mypy snap7 tests example` and `ruff check snap7 tests example` with no errors before opening a PR.
+- **Always run `uv run pre-commit run --all-files` before every `git push`.** Individual `ruff check` / `ruff format --check` commands don't exercise every hook (`ruff format` is the one that actually reformats files, not the `--check` variant). Skipping pre-commit is the single most common reason CI fails on the ruff-format hook right after a push. If the hook reformats, amend and re-push — do not rely on "it passed locally" via other commands.
 - **If using AI coding assistants**: Review the generated code carefully before submitting. AI-generated PRs that are large, unfocused, or not thoroughly reviewed are likely to be rejected.
 
 ## Library Architecture Notes


### PR DESCRIPTION
Add one line to CLAUDE.md's contribution section: always run `uv run pre-commit run --all-files` before every `git push`. Individual `ruff check` / `ruff format --check` commands don't exercise every hook (`ruff format` without `--check` is the one that reformats files), and skipping pre-commit is the most common reason CI fails on the ruff-format hook right after a push.