### PR TITLE
Accept V1 CreateObject responses without ServerSessionVersion (GH-710)

### DIFF
--- a/s7/_s7commplus_async_client.py
+++ b/s7/_s7commplus_async_client.py
@@ -163,12 +163,8 @@ class S7CommPlusAsyncClient:
 
             self._connected = True
 
-            # Step 6: Session setup - echo ServerSessionVersion back to PLC
-            if self._server_session_version is not None:
-                self._session_setup_ok = await self._setup_session()
-            else:
-                logger.warning("PLC did not provide ServerSessionVersion - session setup incomplete")
-                self._session_setup_ok = False
+            # Step 6: Session setup — echo ServerSessionVersion or accept V1 without.
+            self._session_setup_ok = await self._finalize_session_setup()
             logger.info(
                 f"Async S7CommPlus connected to {host}:{port}, "
                 f"version=V{self._protocol_version}, session={self._session_id}, "
@@ -684,6 +680,23 @@ class S7CommPlusAsyncClient:
                 offset += 1
 
         logger.debug("ServerSessionVersion not found in CreateObject response")
+
+    async def _finalize_session_setup(self) -> bool:
+        """Apply the version-specific rule for step 6 of the handshake.
+
+        - If the PLC sent ``ServerSessionVersion``, echo it back (side effect).
+        - V1 PLCs don't track integrity IDs, so the echo is optional; some
+          S7-1200 firmware (V4.2.2) omits the attribute entirely and we must
+          still accept the connection. See GH-710.
+        - V2+ strictly requires the echo; treat absence as a setup failure.
+        """
+        if self._server_session_version is not None:
+            return await self._setup_session()
+        if self._protocol_version == ProtocolVersion.V1:
+            logger.debug("V1: no ServerSessionVersion from PLC (accepted)")
+            return True
+        logger.warning("PLC did not provide ServerSessionVersion - session setup incomplete")
+        return False
 
     async def _setup_session(self) -> bool:
         """Echo ServerSessionVersion back to the PLC via SetMultiVariables."""

--- a/s7/connection.py
+++ b/s7/connection.py
@@ -201,12 +201,8 @@ class S7CommPlusConnection:
             # CreateObject always uses V1 framing
             self._create_session()
 
-            # Step 5: Session setup - echo ServerSessionVersion back to PLC
-            if self._server_session_version is not None:
-                self._session_setup_ok = self._setup_session()
-            else:
-                logger.warning("PLC did not provide ServerSessionVersion - session setup incomplete")
-                self._session_setup_ok = False
+            # Step 5: Session setup — echo ServerSessionVersion or accept V1 without.
+            self._session_setup_ok = self._finalize_session_setup()
 
             # Step 6: Version-specific post-setup
             if self._protocol_version >= ProtocolVersion.V3:
@@ -843,6 +839,23 @@ class S7CommPlusConnection:
         else:
             # Unknown type - can't skip reliably
             return offset
+
+    def _finalize_session_setup(self) -> bool:
+        """Apply the version-specific rule for step 5 of the handshake.
+
+        - If the PLC sent ``ServerSessionVersion``, echo it back (side effect).
+        - V1 PLCs don't track integrity IDs, so the echo is optional; some
+          S7-1200 firmware (V4.2.2) omits the attribute entirely and we must
+          still accept the connection. See GH-710.
+        - V2+ strictly requires the echo; treat absence as a setup failure.
+        """
+        if self._server_session_version is not None:
+            return self._setup_session()
+        if self._protocol_version == ProtocolVersion.V1:
+            logger.debug("V1: no ServerSessionVersion from PLC (accepted)")
+            return True
+        logger.warning("PLC did not provide ServerSessionVersion - session setup incomplete")
+        return False
 
     def _setup_session(self) -> bool:
         """Send SetMultiVariables to echo ServerSessionVersion back to the PLC.

--- a/tests/test_s7_unit.py
+++ b/tests/test_s7_unit.py
@@ -12,7 +12,7 @@ from s7._s7commplus_client import (
 )
 from s7.codec import encode_pvalue_blob
 from s7.connection import S7CommPlusConnection, _element_size
-from s7.protocol import DataType, ElementID, ObjectId
+from s7.protocol import DataType, ElementID, ObjectId, ProtocolVersion
 from s7.vlq import (
     encode_uint32_vlq,
     encode_uint64_vlq,
@@ -419,6 +419,47 @@ class TestParseCreateObjectResponse:
         payload += encode_uint32_vlq(3)
         conn._parse_create_object_response(bytes(payload))
         assert conn._server_session_version == 3
+
+
+class TestFinalizeSessionSetup:
+    """GH-710: V1 PLCs may omit ServerSessionVersion; the connection must still succeed.
+
+    V2+ still requires the echo (integrity-ID tracking), so absence there is
+    a real failure.
+    """
+
+    def test_v1_without_server_session_version_accepts(self) -> None:
+        conn = S7CommPlusConnection("127.0.0.1")
+        conn._protocol_version = ProtocolVersion.V1
+        conn._server_session_version = None
+        assert conn._finalize_session_setup() is True
+
+    def test_v2_without_server_session_version_fails(self) -> None:
+        conn = S7CommPlusConnection("127.0.0.1")
+        conn._protocol_version = ProtocolVersion.V2
+        conn._server_session_version = None
+        assert conn._finalize_session_setup() is False
+
+    def test_v3_without_server_session_version_fails(self) -> None:
+        conn = S7CommPlusConnection("127.0.0.1")
+        conn._protocol_version = ProtocolVersion.V3
+        conn._server_session_version = None
+        assert conn._finalize_session_setup() is False
+
+    def test_with_server_session_version_delegates_to_setup_session(self) -> None:
+        conn = S7CommPlusConnection("127.0.0.1")
+        conn._protocol_version = ProtocolVersion.V1
+        conn._server_session_version = 42
+        # Stub out the network call; assert it's invoked and its return is propagated.
+        calls: list[int] = []
+
+        def fake_setup_session() -> bool:
+            calls.append(1)
+            return True
+
+        conn._setup_session = fake_setup_session  # type: ignore[method-assign]
+        assert conn._finalize_session_setup() is True
+        assert calls == [1]
 
 
 # -- Client error path tests --


### PR DESCRIPTION
Fixes #710.

## Summary

S7-1200 F/W v4.2.2 completes the S7CommPlus handshake but **omits the `ServerSessionVersion` attribute** from its CreateObject response. We were treating any missing `ServerSessionVersion` as a session-setup failure, disconnecting the CommPlus client, and falling through to legacy — then calls that require CommPlus (`browse()`, symbolic reads, …) surface confusing errors.

Confirmed from the attached pcap: the PLC's CreateObject response (packet 16) is only 38 bytes and contains no attribute 306. That's not a parser bug — the PLC just doesn't send it.

## Why V1 is OK without it

The `ServerSessionVersion` echo is the V2+ integrity-ID handshake step. V1 connections don't track integrity IDs, so the echo is advisory. Relaxing the rule:

- V1 + no `ServerSessionVersion` → accept, `session_setup_ok=True`
- V1 + `ServerSessionVersion` present → echo it back (unchanged)
- V2 / V3 + no `ServerSessionVersion` → still fail (integrity IDs genuinely required)

Applied symmetrically in `s7/connection.py` (sync) and `s7/_s7commplus_async_client.py` (async). Decision extracted into `_finalize_session_setup` so it's unit-testable without mocking TCP.

## Test plan

- [x] 4 new unit tests in `tests/test_s7_unit.py::TestFinalizeSessionSetup`: V1-without, V2-without, V3-without, V1-with.
- [x] Full suite: 1558 passed, 88 skipped.
- [x] mypy + ruff + pre-commit clean.

@xBiggs — could you pull this branch and re-run `client.browse()` against your S7-1200 to confirm? The logged warning should disappear and `browse()` should succeed instead of falling back to legacy.
