### PR TITLE
s7: explain V1-initial firmware-band fallback to users

### DIFF
--- a/s7/connection.py
+++ b/s7/connection.py
@@ -205,7 +205,14 @@ class S7CommPlusConnection:
             if self._server_session_version is not None:
                 self._session_setup_ok = self._setup_session()
             else:
-                logger.warning("PLC did not provide ServerSessionVersion - session setup incomplete")
+                logger.warning(
+                    "PLC did not provide a scalar ServerSessionVersion attribute. "
+                    "This is the V1-initial S7-1200 firmware band (FW < 4.5 "
+                    "predating TLS) which sends a Struct(314) value and requires "
+                    "the proprietary SessionKey handshake — not yet implemented "
+                    "in python-snap7 (tracked in issue #710). Falling back to "
+                    "legacy PUT/GET: db_read/db_write will work, browse() will not."
+                )
                 self._session_setup_ok = False
 
             # Step 6: Version-specific post-setup


### PR DESCRIPTION
## Summary
- Replace the generic ``PLC did not provide ServerSessionVersion`` warning with an actionable message that tells users which firmware band hit this case (V1-initial S7-1200, FW < 4.5), what the impact is (db_read/db_write still work, browse() won't), and where to follow the limitation (#710).

## Why
The V1-initial S7-1200 firmware band sends a ``Struct(314)`` value for ``ServerSessionVersion`` instead of a scalar. Master only handles the scalar case, so the setup-echo can't run, the PLC drops the connection, and the unified Client transparently falls back to legacy PUT/GET. The fall-through is correct, but the previous log line gave users no way to tell whether it was a bug, a network issue, or just an unsupported firmware band.

This is the cheap-but-honest path forward chosen in lieu of porting the proprietary HarpoS7-style SessionKey handshake. The full research artefacts live on ``research/harpo-port-incomplete`` for whoever picks that up later.

Refs #710.

## Test plan
- [x] ``test_s7_unit.py`` and ``test_s7_v2.py`` still pass (97 passed, 6 skipped).
- [x] mypy + ruff clean on ``s7/connection.py``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)