### PR TITLE
fix: handle single-byte scalar in _parse_read_response

### DIFF
--- a/s7/_s7commplus_client.py
+++ b/s7/_s7commplus_client.py
@@ -455,6 +455,10 @@ class S7CommPlusClient:
 
 # -- Request/response builders (module-level for reuse by async client) --
 
+# S7-1200 wraps a single BOOL/USINT in [value 0x00 | 00 04 00 00 00 00].
+# The leading byte is misread by VLQ as a non-zero return code.
+_SCALAR_RESPONSE_SUFFIX = bytes.fromhex("000400000000")
+
 
 def _build_read_payload(items: list[tuple[int, int, int]]) -> bytes:
     """Build a GetMultiVariables request payload.
@@ -499,6 +503,12 @@ def _parse_read_response(response: bytes) -> list[Optional[bytes]]:
         List of raw bytes per item (None for errored items)
     """
     offset = 0
+
+    # S7-1200 single-byte scalar: [value 0x00 | 00 04 00 00 00 00]
+    if response.endswith(_SCALAR_RESPONSE_SUFFIX):
+        body = response[: -len(_SCALAR_RESPONSE_SUFFIX)]
+        if len(body) == 2 and body[1] == 0x00:
+            return [bytes(body[:1])]
 
     return_value, consumed = decode_uint64_vlq(response, offset)
     offset += consumed

--- a/tests/test_s7_unit.py
+++ b/tests/test_s7_unit.py
@@ -100,6 +100,21 @@ class TestParseReadResponse:
         assert results[0] == data1
         assert results[1] is None  # Error item
 
+    def test_single_byte_scalar_bool_true(self) -> None:
+        response = b"\x01\x00\x00\x04\x00\x00\x00\x00"
+        results = _parse_read_response(response)
+        assert results == [b"\x01"]
+
+    def test_single_byte_scalar_bool_false(self) -> None:
+        response = b"\x00\x00\x00\x04\x00\x00\x00\x00"
+        results = _parse_read_response(response)
+        assert results == [b"\x00"]
+
+    def test_single_byte_scalar_usint(self) -> None:
+        response = b"\x2a\x00\x00\x04\x00\x00\x00\x00"
+        results = _parse_read_response(response)
+        assert results == [b"\x2a"]
+
 
 class TestParseWriteResponse:
     @staticmethod


### PR DESCRIPTION
## Summary

- Fix `_parse_read_response` misreading single-byte BOOL/USINT values as PLC errors on S7-1200
- S7-1200 wraps bare scalars in `[value 0x00 | 00 04 00 00 00 00]`; the VLQ parser decoded `value=1` (BOOL TRUE) as a non-zero return code, causing every TRUE read to raise `RuntimeError`
- Add early detection for this 8-byte format before the VLQ error-code path

Fixes #737 (from #735 Bug 2)

## Test plan

- [x] Added `test_single_byte_scalar_bool_true`, `test_single_byte_scalar_bool_false`, `test_single_byte_scalar_usint` to `TestParseReadResponse`
- [x] All existing tests pass (`pytest tests/test_s7_unit.py`)
- [x] mypy, ruff, pre-commit all clean
- [ ] Needs real hardware validation on S7-1200 FW V4.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)