### PR TITLE
fix: use correct sub_area for I/Q/M symbolic access

### DIFF
--- a/s7/_s7commplus_client.py
+++ b/s7/_s7commplus_client.py
@@ -654,13 +654,12 @@ def _build_symbolic_read_payload(access_area: int, lids: list[int], symbol_crc: 
     are unreliable.  The PLC navigates its symbol tree using the LIDs.
 
     For DBs, ``access_sub_area`` is ``DB_VALUE_ACTUAL``.  For controller
-    areas (M/I/Q), it's ``CONTROLLER_AREA_VALUE_ACTUAL``.
+    areas (M/I/Q), it's ``CONTROLLER_AREA_SYMBOLIC_SUB_AREA`` (3736/0xE98).
     """
-    # Determine sub-area based on access_area
     if access_area >= 0x8A0E0000:
         access_sub_area = Ids.DB_VALUE_ACTUAL
     else:
-        access_sub_area = Ids.CONTROLLER_AREA_VALUE_ACTUAL
+        access_sub_area = Ids.CONTROLLER_AREA_SYMBOLIC_SUB_AREA
 
     addr_bytes, field_count = encode_item_address(
         access_area=access_area,
@@ -684,7 +683,7 @@ def _build_symbolic_write_payload(access_area: int, lids: list[int], data: bytes
     if access_area >= 0x8A0E0000:
         access_sub_area = Ids.DB_VALUE_ACTUAL
     else:
-        access_sub_area = Ids.CONTROLLER_AREA_VALUE_ACTUAL
+        access_sub_area = Ids.CONTROLLER_AREA_SYMBOLIC_SUB_AREA
 
     addr_bytes, field_count = encode_item_address(
         access_area=access_area,

--- a/s7/protocol.py
+++ b/s7/protocol.py
@@ -153,6 +153,7 @@ class Ids(IntEnum):
     # Data block access sub-areas
     DB_VALUE_ACTUAL = 2550
     CONTROLLER_AREA_VALUE_ACTUAL = 2551
+    CONTROLLER_AREA_SYMBOLIC_SUB_AREA = 3736
 
     # ObjectQualifier structure IDs
     OBJECT_QUALIFIER = 1256

--- a/tests/test_s7_unit.py
+++ b/tests/test_s7_unit.py
@@ -9,10 +9,12 @@ from s7._s7commplus_client import (
     _parse_read_response,
     _build_write_payload,
     _parse_write_response,
+    _build_symbolic_read_payload,
+    _build_symbolic_write_payload,
 )
 from s7.codec import encode_pvalue_blob
 from s7.connection import S7CommPlusConnection, _element_size
-from s7.protocol import DataType, ElementID, ObjectId
+from s7.protocol import DataType, ElementID, Ids, ObjectId
 from s7.vlq import (
     encode_uint32_vlq,
     encode_uint64_vlq,
@@ -457,3 +459,41 @@ class TestClientErrorPaths:
         with S7CommPlusClient() as client:
             assert client.connected is False
         # Should not raise
+
+
+# -- Symbolic sub_area tests --
+
+
+def _extract_sub_area(payload: bytes) -> int:
+    """Parse a symbolic payload and return the access_sub_area VLQ value."""
+    offset = 4  # skip LinkId (4 bytes)
+    _, consumed = decode_uint32_vlq(payload, offset)  # item count
+    offset += consumed
+    _, consumed = decode_uint32_vlq(payload, offset)  # field count
+    offset += consumed
+    _, consumed = decode_uint32_vlq(payload, offset)  # symbol_crc
+    offset += consumed
+    _, consumed = decode_uint32_vlq(payload, offset)  # access_area
+    offset += consumed
+    _, consumed = decode_uint32_vlq(payload, offset)  # num_lids
+    offset += consumed
+    sub_area, _ = decode_uint32_vlq(payload, offset)  # access_sub_area
+    return sub_area
+
+
+class TestSymbolicSubArea:
+    def test_read_db_uses_db_value_actual(self) -> None:
+        payload = _build_symbolic_read_payload(access_area=0x8A0E0001, lids=[1])
+        assert _extract_sub_area(payload) == Ids.DB_VALUE_ACTUAL
+
+    def test_read_iqm_uses_symbolic_sub_area(self) -> None:
+        payload = _build_symbolic_read_payload(access_area=Ids.NATIVE_THE_Q_AREA_RID, lids=[20])
+        assert _extract_sub_area(payload) == Ids.CONTROLLER_AREA_SYMBOLIC_SUB_AREA
+
+    def test_write_db_uses_db_value_actual(self) -> None:
+        payload = _build_symbolic_write_payload(access_area=0x8A0E0001, lids=[1], data=b"\x01")
+        assert _extract_sub_area(payload) == Ids.DB_VALUE_ACTUAL
+
+    def test_write_iqm_uses_symbolic_sub_area(self) -> None:
+        payload = _build_symbolic_write_payload(access_area=Ids.NATIVE_THE_M_AREA_RID, lids=[5], data=b"\xff")
+        assert _extract_sub_area(payload) == Ids.CONTROLLER_AREA_SYMBOLIC_SUB_AREA


### PR DESCRIPTION
## Summary

- Add `CONTROLLER_AREA_SYMBOLIC_SUB_AREA = 3736` (0xE98) to `Ids` enum
- Fix `_build_symbolic_read_payload` and `_build_symbolic_write_payload` to use 3736 instead of `CONTROLLER_AREA_VALUE_ACTUAL` (2551) for non-DB areas (I/Q/M)
- The PLC rejects symbolic writes with error `0x4D0013` when 2551 is used; 3736 was confirmed from EXOR HMI (AGLink) wire captures

Closes #736

## Test plan

- [x] New `TestSymbolicSubArea` tests verify sub_area selection for both DB and I/Q/M access, for both read and write payloads
- [x] All existing tests pass
- [x] mypy, ruff, pre-commit all clean
- [ ] Hardware verification on S7-1200 FW V4.5 (needs real PLC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)