### PR TITLE
fix: use proper PI service PDU format for PLC control commands

### DIFF
--- a/snap7/s7protocol.py
+++ b/snap7/s7protocol.py
@@ -103,6 +103,15 @@ def get_return_code_description(return_code: int) -> str:
     return "Unknown error"
 
 
+# PLC control PI service parameter byte sequences (from snap7 C library).
+# Stop: function(0x29) + 5 reserved + PI length(9) + "P_PROGRAM"
+_STOP_PARAMS = bytes.fromhex("29000000000009") + b"P_PROGRAM"
+# Hot start: function(0x28) + 7 reserved + block count(0) + pad(0) + PI length(9) + "P_PROGRAM"
+_HOT_START_PARAMS = bytes.fromhex("28000000000000fd000009") + b"P_PROGRAM"
+# Cold start: same as hot start but with block "C " before PI service
+_COLD_START_PARAMS = bytes.fromhex("28000000000000fd0002432009") + b"P_PROGRAM"
+
+
 class S7Protocol:
     """
     S7 protocol implementation.
@@ -381,7 +390,7 @@ class S7Protocol:
 
     def build_plc_control_request(self, operation: str) -> bytes:
         """
-        Build PLC control request.
+        Build PLC control request using the S7 PI service PDU format.
 
         Args:
             operation: Control operation ('stop', 'hot_start', 'cold_start')
@@ -389,26 +398,16 @@ class S7Protocol:
         Returns:
             Complete S7 PDU for PLC control
         """
-        # Map operations to S7 control codes
-        control_codes = {
-            "stop": 0x29,  # PLC_STOP
-            "hot_start": 0x28,  # PLC_CONTROL (warm restart)
-            "cold_start": 0x28,  # PLC_CONTROL (cold restart)
+        params: dict[str, bytes] = {
+            "stop": _STOP_PARAMS,
+            "hot_start": _HOT_START_PARAMS,
+            "cold_start": _COLD_START_PARAMS,
         }
 
-        if operation not in control_codes:
+        if operation not in params:
             raise ValueError(f"Unknown PLC control operation: {operation}")
 
-        function_code = control_codes[operation]
-
-        # Build control-specific parameters
-        if operation == "stop":
-            # Simple stop command
-            param_data = struct.pack(">B", function_code)
-        else:
-            # Start commands with restart type
-            restart_type = 1 if operation == "hot_start" else 2  # 1=warm, 2=cold
-            param_data = struct.pack(">BB", function_code, restart_type)
+        param_data = params[operation]
 
         header = struct.pack(
             ">BBHHHH",

--- a/snap7/server/__init__.py
+++ b/snap7/server/__init__.py
@@ -1272,30 +1272,16 @@ class Server:
 
                     return {"function_code": function_code, "item_count": item_count, "address_spec": parsed_addr}
         elif function_code == S7Function.PLC_CONTROL:
-            # Parse PLC control parameters
-            # Format varies: simple start or PI service (compress/copy_ram_to_rom)
-            if len(param_data) >= 2:
-                # Check for restart type (simple start)
-                restart_type = param_data[1]
-                if restart_type in (1, 2):
-                    return {"function_code": function_code, "restart_type": restart_type}
-
-            # Check for PI service (compress/copy_ram_to_rom)
-            # Format: func(1) + reserved(7) + pi_len(1) + pi_service
-            # Or: func(1) + reserved(6) + file_id_len(1) + pi_len(1) + file_id + pi_service
-            if len(param_data) >= 10:
-                # Look for PI service
-                pi_len = param_data[8]
-                if pi_len > 0 and len(param_data) >= 9 + pi_len:
-                    pi_service = param_data[9 : 9 + pi_len]
-                    # Check for file_id (copy_ram_to_rom)
-                    file_id_len = param_data[7]
-                    file_id = b""
-                    if file_id_len > 0 and len(param_data) >= 9 + file_id_len + pi_len:
-                        # Reparse with file_id
-                        file_id = param_data[9 : 9 + file_id_len]
-                        pi_service = param_data[9 + file_id_len : 9 + file_id_len + pi_len]
-                    return {"function_code": function_code, "pi_service": pi_service, "file_id": file_id}
+            if b"P_PROGRAM" in param_data:
+                restart_type = 2 if b"C " in param_data else 1
+                return {"function_code": function_code, "restart_type": restart_type, "pi_service": b"P_PROGRAM"}
+            elif b"_MSZL" in param_data:
+                file_id = b"P" if b"P_MSZL" in param_data else b""
+                return {"function_code": function_code, "pi_service": b"_MSZL", "file_id": file_id}
+            elif b"_DELE" in param_data:
+                return {"function_code": function_code, "pi_service": b"_DELE"}
+            if len(param_data) >= 2 and param_data[1] in (1, 2):
+                return {"function_code": function_code, "restart_type": param_data[1]}
 
         return {"function_code": function_code}
 

--- a/tests/test_s7protocol.py
+++ b/tests/test_s7protocol.py
@@ -13,6 +13,9 @@ from snap7.s7protocol import (
     S7UserDataGroup,
     S7UserDataSubfunction,
     get_return_code_description,
+    _STOP_PARAMS,
+    _HOT_START_PARAMS,
+    _COLD_START_PARAMS,
 )
 from snap7.error import S7ProtocolError
 
@@ -535,3 +538,43 @@ class TestValidatePDUReference:
 
         with pytest.raises(S7PacketLostError):
             self.proto.validate_pdu_reference(7)
+
+
+class TestPlcControlParams:
+    """Verify PLC control PDUs use the correct PI service format."""
+
+    def test_stop_params_match_c_library(self) -> None:
+        expected = bytes.fromhex("29000000000009") + b"P_PROGRAM"
+        assert _STOP_PARAMS == expected
+        assert len(_STOP_PARAMS) == 16
+
+    def test_hot_start_params_match_c_library(self) -> None:
+        expected = bytes.fromhex("28000000000000fd000009") + b"P_PROGRAM"
+        assert _HOT_START_PARAMS == expected
+        assert len(_HOT_START_PARAMS) == 20
+
+    def test_cold_start_params_match_c_library(self) -> None:
+        expected = bytes.fromhex("28000000000000fd0002432009") + b"P_PROGRAM"
+        assert _COLD_START_PARAMS == expected
+        assert len(_COLD_START_PARAMS) == 22
+
+    def test_stop_request_contains_p_program(self) -> None:
+        proto = S7Protocol()
+        request = proto.build_plc_control_request("stop")
+        assert b"P_PROGRAM" in request
+
+    def test_hot_start_request_contains_p_program(self) -> None:
+        proto = S7Protocol()
+        request = proto.build_plc_control_request("hot_start")
+        assert b"P_PROGRAM" in request
+
+    def test_cold_start_contains_cold_flag(self) -> None:
+        proto = S7Protocol()
+        request = proto.build_plc_control_request("cold_start")
+        assert b"P_PROGRAM" in request
+        assert b"C " in request
+
+    def test_invalid_operation(self) -> None:
+        proto = S7Protocol()
+        with pytest.raises(ValueError, match="Unknown PLC control operation"):
+            proto.build_plc_control_request("invalid")


### PR DESCRIPTION
## Summary

- Fixes #733 — PLC Stop/HotStart/ColdStart broken on real S7-300 after 3.0 upgrade
- The 3.0 rewrite sent bare function code bytes (1–2 bytes) instead of the full S7 PI service PDU format that real PLCs require
- Parameter byte sequences now match the original snap7 C library exactly:
  - **Stop**: `0x29` + 5 reserved + PI length + `P_PROGRAM` (16 bytes)
  - **Hot Start**: `0x28` + 7 reserved + block count + pad + PI length + `P_PROGRAM` (20 bytes)
  - **Cold Start**: same as hot start but with `C ` block before PI service (22 bytes)
- Server parser updated to detect PI service names in the new format

## Test plan

- [x] 7 new unit tests verifying parameter byte sequences match C library
- [x] Existing client/server integration tests pass (216 passed, 1 skipped)
- [ ] Verify on real S7-300 hardware (reporter can test with `pip install git+...@fix-plc-control-params`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)