### PR TITLE
doc: add I/Q/M symbolic access caveats to API docstrings

### DIFF
--- a/s7/_s7commplus_client.py
+++ b/s7/_s7commplus_client.py
@@ -210,6 +210,21 @@ class S7CommPlusClient:
         between downloads. Symbolic access navigates the PLC's symbol tree
         using LIDs (Local IDs) discovered via :meth:`browse`.
 
+        .. note:: **I/Q/M area caveats** (observed on S7-1200 FW V4.5):
+
+           - **Physical PAQ LIDs return error when value is 0x00.**
+             Reading a physical Q-byte LID (e.g. QB0) when all outputs are
+             OFF raises ``RuntimeError`` instead of returning ``b"\\x00"``.
+             Callers should catch the exception and treat it as zero.
+           - **TCP RST after first I/Q/M read.** The PLC sends a TCP RST
+             after the first successful I/Q/M ``GetMultiVariables`` per
+             connection. DB reads are unaffected. Workaround: reconnect
+             before each I/Q/M read.
+           - **Symbolic BOOL LIDs can be stale vs. physical PAQ.** A
+             symbolic BOOL tag written via ``SetMultiVariables`` may not
+             reflect later forced writes to the physical address. For
+             reliable output state, read the physical byte LID instead.
+
         Args:
             access_area: Access area ID. For DBs this is
                 ``0x8A0E0000 + db_number``.
@@ -234,7 +249,13 @@ class S7CommPlusClient:
 
         .. warning:: This method is **experimental** and may change.
 
-        See :meth:`read_symbolic` for context on when to use symbolic access.
+        See :meth:`read_symbolic` for context on when to use symbolic access
+        and I/Q/M area caveats.
+
+        .. note:: Writing a symbolic BOOL tag does **not** update the
+           physical PAQ byte on some S7-1200 firmware versions. A
+           subsequent read of the physical byte LID may show a different
+           value than the symbolic BOOL LID.
 
         Args:
             access_area: Access area ID.

--- a/s7/client.py
+++ b/s7/client.py
@@ -309,6 +309,11 @@ class Client:
         S7CommPlus LID-based access.  For classic tags (byte-offset),
         delegates to the legacy client.
 
+        .. note:: When reading symbolic I/Q/M tags on S7-1200 PLCs, see
+           :meth:`~s7._s7commplus_client.S7CommPlusClient.read_symbolic`
+           for known caveats (PAQ error at zero, TCP RST per connection,
+           stale BOOL LIDs).
+
         Args:
             tag: A :class:`~snap7.tags.Tag` instance or address string.
 


### PR DESCRIPTION
## Summary
- Document hardware-observed I/Q/M symbolic access limitations in `read_symbolic`, `write_symbolic`, and `read_tag` docstrings
- Caveats: physical PAQ error at zero, TCP RST per I/Q/M connection, stale symbolic BOOL LIDs

These show up in the Sphinx-generated API docs.

## Test plan
- [x] ruff check/format passes
- [x] Existing tests pass (doc-only change)

Closes #739

🤖 Generated with [Claude Code](https://claude.com/claude-code)