### PR TITLE
fix(s7commplus): correct V2 symbolic reads on a real S7-1500 (wire format + async/server TLS-in-COTP)

### DIFF
--- a/s7/_s7commplus_async_client.py
+++ b/s7/_s7commplus_async_client.py
@@ -49,6 +49,20 @@ _COTP_CC = 0xD0
 _COTP_DT = 0xF0
 
 
+def _element_size(datatype: int) -> int:
+    """Return the fixed byte size for an array element, or 0 for variable-length."""
+    if datatype in (DataType.BOOL, DataType.USINT, DataType.BYTE, DataType.SINT):
+        return 1
+    elif datatype in (DataType.UINT, DataType.WORD, DataType.INT):
+        return 2
+    elif datatype in (DataType.REAL, DataType.RID):
+        return 4
+    elif datatype in (DataType.LREAL, DataType.TIMESTAMP):
+        return 8
+    else:
+        return 0
+
+
 class S7CommPlusAsyncClient:
     """Pure async S7CommPlus client without legacy fallback.
 
@@ -72,7 +86,10 @@ class S7CommPlusAsyncClient:
         # TLS state
         self._tls_active: bool = False
         self._oms_secret: Optional[bytes] = None
-        self._server_session_version: Optional[int] = None
+        # ServerSessionVersion is captured as its raw typed value (flags+datatype+data)
+        # so it can be echoed back verbatim — real S7-1500 PLCs send it as a Struct.
+        self._server_session_version: Optional[bytes] = None
+        self._server_session_version_raw: Optional[bytes] = None
         self._session_setup_ok: bool = False
 
     @property
@@ -144,6 +161,11 @@ class S7CommPlusAsyncClient:
 
             # Step 4: S7CommPlus session setup (CreateObject)
             await self._create_session()
+
+            # After CreateObject (which always uses V1 framing), data PDUs over TLS
+            # use ProtocolVersion V2 on a real S7-1500 (matches the C# reference driver).
+            if self._tls_active:
+                self._protocol_version = ProtocolVersion.V2
 
             # Step 5: Version-specific validation
             if self._protocol_version >= ProtocolVersion.V3:
@@ -376,6 +398,7 @@ class S7CommPlusAsyncClient:
         self._tls_active = False
         self._oms_secret = None
         self._server_session_version = None
+        self._server_session_version_raw = None
         self._session_setup_ok = False
 
         if self._writer:
@@ -484,7 +507,7 @@ class S7CommPlusAsyncClient:
                 0x0000,
                 seq_num,
                 self._session_id,
-                0x36,
+                0x34 if function_code == FunctionCode.GET_MULTI_VARIABLES else 0x36,
             )
 
             integrity_id_bytes = b""
@@ -493,7 +516,12 @@ class S7CommPlusAsyncClient:
                 integrity_id = self._integrity_id_read if is_read else self._integrity_id_write
                 integrity_id_bytes = encode_uint32_vlq(integrity_id)
 
-            request = request_header + integrity_id_bytes + payload
+            # For V2+ the IntegrityId is spliced in just before the payload's trailing
+            # UInt32 (i.e. at the end), not right after the header.
+            if integrity_id_bytes and len(payload) >= 4:
+                request = request_header + payload[:-4] + integrity_id_bytes + payload[-4:]
+            else:
+                request = request_header + integrity_id_bytes + payload
 
             frame = encode_header(self._protocol_version, len(request)) + request
             frame += struct.pack(">BBH", 0x72, self._protocol_version, 0x0000)
@@ -510,16 +538,13 @@ class S7CommPlusAsyncClient:
             version, data_length, consumed = decode_header(response_data)
             response = response_data[consumed : consumed + data_length]
 
-            if len(response) < 14:
+            if len(response) < 10:
                 raise RuntimeError("Response too short")
 
-            resp_offset = 14
-            if self._with_integrity_id and self._protocol_version >= ProtocolVersion.V2:
-                if resp_offset < len(response):
-                    _resp_iid, iid_consumed = decode_uint32_vlq(response, resp_offset)
-                    resp_offset += iid_consumed
-
-            return response[resp_offset:]
+            # RESPONSE header is 10 bytes (opcode+res+func+res+seqnr+transport) — responses
+            # carry no SessionId field (requests do, hence their 14-byte header). For V2+ the
+            # IntegrityId travels at the END of the payload and is ignored by the parsers.
+            return response[10:]
 
     async def _cotp_connect(self, local_tsap: int, remote_tsap: bytes) -> None:
         """Perform COTP Connection Request / Confirm handshake."""
@@ -601,7 +626,7 @@ class S7CommPlusAsyncClient:
 
         request += bytes([ElementID.ATTRIBUTE])
         request += encode_uint32_vlq(ObjectId.SERVER_SESSION_CLIENT_RID)
-        request += encode_typed_value(DataType.RID, 0x80C3C901)
+        request += bytes([0x00]) + encode_typed_value(DataType.RID, 0x80C3C901)
 
         request += bytes([ElementID.START_OF_OBJECT])
         request += struct.pack(">I", ObjectId.GET_NEW_RID_ON_SERVER)
@@ -624,10 +649,27 @@ class S7CommPlusAsyncClient:
         if len(response) < 14:
             raise RuntimeError("CreateObject response too short")
 
-        self._session_id = struct.unpack_from(">I", response, 9)[0]
+        # Parse response body: ReturnValue(VLQ) + ObjectIdCount + ObjectIds(VLQ).
+        # The usable session id is ObjectIds[0] (NOT the header SessionId field).
+        body = response[14:]
+        boff = 0
+        while boff < len(body) and (body[boff] & 0x80):  # skip ReturnValue VLQ
+            boff += 1
+        boff += 1
+        obj_count = body[boff] if boff < len(body) else 0
+        boff += 1
+        object_ids = []
+        for _ in range(obj_count):
+            oid, _c = decode_uint32_vlq(body, boff)
+            boff += _c
+            object_ids.append(oid)
+        if object_ids:
+            self._session_id = object_ids[0]
+        else:
+            self._session_id = struct.unpack_from(">I", response, 9)[0]
         self._protocol_version = version
 
-        self._parse_create_object_response(response[14:])
+        self._parse_create_object_response(response[14 + boff :])
 
     def _parse_create_object_response(self, payload: bytes) -> None:
         """Parse CreateObject response to extract ServerSessionVersion (attribute 306)."""
@@ -643,26 +685,29 @@ class S7CommPlusAsyncClient:
                 offset += consumed
 
                 if attr_id == ObjectId.SERVER_SESSION_VERSION:
+                    # Capture the raw typed value (flags+datatype+data) to echo back —
+                    # real S7-1500 PLCs send ServerSessionVersion as a Struct (0x17).
+                    if offset + 2 > len(payload):
+                        break
+                    value_start = offset
+                    _flags = payload[offset]
+                    datatype = payload[offset + 1]
+                    end = self._skip_typed_value(payload, offset + 2, datatype, _flags)
+                    self._server_session_version_raw = bytes(payload[value_start:end])
+                    self._server_session_version = self._server_session_version_raw
+                    offset = end
+                    logger.info(
+                        f"ServerSessionVersion captured: type={datatype:#04x}, {len(self._server_session_version_raw)} bytes"
+                    )
+                    return
+                else:
+                    # Skip this attribute's typed value (flags + datatype + value)
                     if offset + 2 > len(payload):
                         break
                     _flags = payload[offset]
                     datatype = payload[offset + 1]
                     offset += 2
-                    if datatype in (DataType.UDINT, DataType.DWORD):
-                        value, consumed = decode_uint32_vlq(payload, offset)
-                        offset += consumed
-                        self._server_session_version = value
-                        logger.info(f"ServerSessionVersion = {value}")
-                        return
-                else:
-                    if offset + 2 > len(payload):
-                        break
-                    _flags = payload[offset]
-                    _dt = payload[offset + 1]
-                    offset += 2
-                    if offset < len(payload):
-                        _, consumed = decode_uint32_vlq(payload, offset)
-                        offset += consumed
+                    offset = self._skip_typed_value(payload, offset, datatype, _flags)
 
             elif tag == ElementID.START_OF_OBJECT:
                 offset += 1
@@ -685,6 +730,72 @@ class S7CommPlusAsyncClient:
 
         logger.debug("ServerSessionVersion not found in CreateObject response")
 
+    def _skip_typed_value(self, data: bytes, offset: int, datatype: int, flags: int) -> int:
+        """Skip over a typed value in the PObject tree (best-effort). Returns new offset."""
+        is_array = bool(flags & 0x10)
+
+        if is_array:
+            if offset >= len(data):
+                return offset
+            count, consumed = decode_uint32_vlq(data, offset)
+            offset += consumed
+            elem_size = _element_size(datatype)
+            if elem_size > 0:
+                offset += count * elem_size
+            else:
+                for _ in range(count):
+                    if offset >= len(data):
+                        break
+                    _, consumed = decode_uint32_vlq(data, offset)
+                    offset += consumed
+            return offset
+
+        if datatype == DataType.NULL:
+            return offset
+        elif datatype in (DataType.BOOL, DataType.USINT, DataType.BYTE, DataType.SINT):
+            return offset + 1
+        elif datatype in (DataType.UINT, DataType.WORD, DataType.INT):
+            return offset + 2
+        elif datatype in (DataType.UDINT, DataType.DWORD, DataType.AID, DataType.DINT):
+            _, consumed = decode_uint32_vlq(data, offset)
+            return offset + consumed
+        elif datatype in (DataType.ULINT, DataType.LWORD, DataType.LINT):
+            _, consumed = decode_uint64_vlq(data, offset)
+            return offset + consumed
+        elif datatype == DataType.REAL:
+            return offset + 4
+        elif datatype == DataType.LREAL:
+            return offset + 8
+        elif datatype == DataType.TIMESTAMP:
+            return offset + 8
+        elif datatype == DataType.TIMESPAN:
+            _, consumed = decode_uint64_vlq(data, offset)
+            return offset + consumed
+        elif datatype == DataType.RID:
+            return offset + 4
+        elif datatype in (DataType.BLOB, DataType.WSTRING):
+            length, consumed = decode_uint32_vlq(data, offset)
+            return offset + consumed + length
+        elif datatype == DataType.STRUCT:
+            # Normal-mode struct: UInt32 struct-id, then members [VLQ key][typed value],
+            # terminated by a 0x00 list-terminator byte (keys always start with high bit set).
+            offset += 4  # struct id (UInt32, not VLQ)
+            while offset < len(data):
+                if data[offset] == 0x00:
+                    offset += 1
+                    break
+                _key, consumed = decode_uint32_vlq(data, offset)
+                offset += consumed
+                if offset + 2 > len(data):
+                    break
+                sub_flags = data[offset]
+                sub_type = data[offset + 1]
+                offset += 2
+                offset = self._skip_typed_value(data, offset, sub_type, sub_flags)
+            return offset
+        else:
+            return offset
+
     async def _setup_session(self) -> bool:
         """Echo ServerSessionVersion back to the PLC via SetMultiVariables."""
         if self._server_session_version is None:
@@ -696,8 +807,8 @@ class S7CommPlusAsyncClient:
         payload += encode_uint32_vlq(1)
         payload += encode_uint32_vlq(ObjectId.SERVER_SESSION_VERSION)
         payload += encode_uint32_vlq(1)
-        payload += bytes([0x00, DataType.UDINT])
-        payload += encode_uint32_vlq(self._server_session_version)
+        # PValue: echo the ServerSessionVersion typed value verbatim (it may be a Struct)
+        payload += self._server_session_version_raw
         payload += bytes([0x00])
         payload += encode_object_qualifier()
         payload += struct.pack(">I", 0)

--- a/s7/_s7commplus_async_client.py
+++ b/s7/_s7commplus_async_client.py
@@ -83,8 +83,12 @@ class S7CommPlusAsyncClient:
         self._integrity_id_write: int = 0
         self._with_integrity_id: bool = False
 
-        # TLS state
+        # TLS state — TLS records are tunneled inside COTP DT frames via MemoryBIO
+        # (TPKT/COTP headers stay unencrypted), mirroring the sync S7CommPlusConnection.
         self._tls_active: bool = False
+        self._ssl_object: Optional[ssl.SSLObject] = None
+        self._incoming_bio: Optional[ssl.MemoryBIO] = None
+        self._outgoing_bio: Optional[ssl.MemoryBIO] = None
         self._oms_secret: Optional[bytes] = None
         # ServerSessionVersion is captured as its raw typed value (flags+datatype+data)
         # so it can be echoed back verbatim — real S7-1500 PLCs send it as a Struct.
@@ -266,33 +270,54 @@ class S7CommPlusAsyncClient:
             ctx.check_hostname = False
             ctx.verify_mode = ssl.CERT_NONE
 
-        transport = self._writer.transport
-        loop = asyncio.get_event_loop()
-        new_transport = await loop.start_tls(
-            transport,
-            transport.get_protocol(),
-            ctx,
-            server_hostname=self._host,
+        # BIO-based TLS: encrypt/decrypt in memory so the TLS records can be tunneled
+        # through COTP DT frames (TPKT/COTP stay unencrypted) — `start_tls` would instead
+        # wrap the whole TCP stream, encrypting TPKT/COTP too, which the PLC rejects.
+        self._incoming_bio = ssl.MemoryBIO()
+        self._outgoing_bio = ssl.MemoryBIO()
+        self._ssl_object = ctx.wrap_bio(
+            self._incoming_bio,
+            self._outgoing_bio,
+            server_side=False,
+            server_hostname=self._host if ctx.check_hostname else None,
         )
 
-        self._writer._transport = new_transport
+        await self._do_tls_handshake()
         self._tls_active = True
 
-        if new_transport is None:
-            from snap7.error import S7ConnectionError
+        try:
+            self._oms_secret = self._ssl_object.export_keying_material("EXPERIMENTAL_OMS", 32, None)
+            logger.debug("OMS exporter secret extracted from TLS session")
+        except (AttributeError, ssl.SSLError) as e:
+            logger.warning(f"Could not extract OMS exporter secret: {e}")
+            self._oms_secret = None
 
-            raise S7ConnectionError("TLS handshake failed: no transport returned")
+        logger.info("TLS 1.3 activated (tunneled inside COTP frames)")
 
-        ssl_object = new_transport.get_extra_info("ssl_object")
-        if ssl_object is not None:
+    async def _do_tls_handshake(self) -> None:
+        """Perform the TLS handshake, tunneling records through COTP DT frames."""
+        assert self._ssl_object is not None
+        while True:
             try:
-                self._oms_secret = ssl_object.export_keying_material("EXPERIMENTAL_OMS", 32, None)
-                logger.debug("OMS exporter secret extracted from TLS session")
-            except (AttributeError, ssl.SSLError) as e:
-                logger.warning(f"Could not extract OMS exporter secret: {e}")
-                self._oms_secret = None
+                self._ssl_object.do_handshake()
+                break
+            except ssl.SSLWantReadError:
+                await self._tls_flush_outgoing()
+                await self._tls_read_incoming()
+        await self._tls_flush_outgoing()
 
-        logger.info("TLS 1.3 activated on async COTP connection")
+    async def _tls_flush_outgoing(self) -> None:
+        """Send all pending outgoing TLS bytes as COTP DT frames."""
+        assert self._outgoing_bio is not None
+        data = self._outgoing_bio.read()
+        if data:
+            await self._send_cotp_raw(data)
+
+    async def _tls_read_incoming(self) -> None:
+        """Read one COTP DT frame and feed its payload to the TLS BIO."""
+        assert self._incoming_bio is not None
+        data = await self._recv_cotp_raw()
+        self._incoming_bio.write(data)
 
     async def _get_legitimation_challenge(self) -> bytes:
         """Request legitimation challenge from PLC."""
@@ -396,6 +421,9 @@ class S7CommPlusAsyncClient:
         self._integrity_id_read = 0
         self._integrity_id_write = 0
         self._tls_active = False
+        self._ssl_object = None
+        self._incoming_bio = None
+        self._outgoing_bio = None
         self._oms_secret = None
         self._server_session_version = None
         self._server_session_version_raw = None
@@ -854,7 +882,28 @@ class S7CommPlusAsyncClient:
             pass
 
     async def _send_cotp_dt(self, data: bytes) -> None:
-        """Send data wrapped in COTP DT + TPKT."""
+        """Send an S7CommPlus frame, routing through TLS (tunneled in COTP) when active."""
+        if self._tls_active:
+            assert self._ssl_object is not None
+            self._ssl_object.write(data)
+            await self._tls_flush_outgoing()
+        else:
+            await self._send_cotp_raw(data)
+
+    async def _recv_cotp_dt(self) -> bytes:
+        """Receive an S7CommPlus frame, decrypting from the TLS tunnel when active."""
+        if self._tls_active:
+            assert self._ssl_object is not None
+            while True:
+                try:
+                    return self._ssl_object.read(65536)
+                except ssl.SSLWantReadError:
+                    await self._tls_read_incoming()
+        else:
+            return await self._recv_cotp_raw()
+
+    async def _send_cotp_raw(self, data: bytes) -> None:
+        """Send raw bytes wrapped in COTP DT + TPKT (no TLS)."""
         if self._writer is None:
             raise RuntimeError("Not connected")
 
@@ -863,8 +912,8 @@ class S7CommPlusAsyncClient:
         self._writer.write(tpkt)
         await self._writer.drain()
 
-    async def _recv_cotp_dt(self) -> bytes:
-        """Receive TPKT + COTP DT and return the payload."""
+    async def _recv_cotp_raw(self) -> bytes:
+        """Receive one TPKT + COTP DT frame and return the payload (no TLS)."""
         if self._reader is None:
             raise RuntimeError("Not connected")
 

--- a/s7/_s7commplus_async_client.py
+++ b/s7/_s7commplus_async_client.py
@@ -24,7 +24,14 @@ from .protocol import (
     S7COMMPLUS_LOCAL_TSAP,
     S7COMMPLUS_REMOTE_TSAP,
 )
-from .codec import encode_header, decode_header, encode_typed_value, encode_object_qualifier
+from .codec import (
+    encode_header,
+    decode_header,
+    encode_typed_value,
+    encode_object_qualifier,
+    parse_create_object_session_id,
+    parse_server_session_version,
+)
 from .vlq import encode_uint32_vlq, decode_uint32_vlq, decode_uint64_vlq
 from ._s7commplus_client import (
     _build_read_payload,
@@ -47,20 +54,6 @@ logger = logging.getLogger(__name__)
 _COTP_CR = 0xE0
 _COTP_CC = 0xD0
 _COTP_DT = 0xF0
-
-
-def _element_size(datatype: int) -> int:
-    """Return the fixed byte size for an array element, or 0 for variable-length."""
-    if datatype in (DataType.BOOL, DataType.USINT, DataType.BYTE, DataType.SINT):
-        return 1
-    elif datatype in (DataType.UINT, DataType.WORD, DataType.INT):
-        return 2
-    elif datatype in (DataType.REAL, DataType.RID):
-        return 4
-    elif datatype in (DataType.LREAL, DataType.TIMESTAMP):
-        return 8
-    else:
-        return 0
 
 
 class S7CommPlusAsyncClient:
@@ -93,7 +86,6 @@ class S7CommPlusAsyncClient:
         # ServerSessionVersion is captured as its raw typed value (flags+datatype+data)
         # so it can be echoed back verbatim — real S7-1500 PLCs send it as a Struct.
         self._server_session_version: Optional[bytes] = None
-        self._server_session_version_raw: Optional[bytes] = None
         self._session_setup_ok: bool = False
 
     @property
@@ -304,6 +296,9 @@ class S7CommPlusAsyncClient:
             except ssl.SSLWantReadError:
                 await self._tls_flush_outgoing()
                 await self._tls_read_incoming()
+            except ssl.SSLWantWriteError:
+                # Rare with MemoryBIO, but the SSLObject can ask to write before reading.
+                await self._tls_flush_outgoing()
         await self._tls_flush_outgoing()
 
     async def _tls_flush_outgoing(self) -> None:
@@ -426,7 +421,6 @@ class S7CommPlusAsyncClient:
         self._outgoing_bio = None
         self._oms_secret = None
         self._server_session_version = None
-        self._server_session_version_raw = None
         self._session_setup_ok = False
 
         if self._writer:
@@ -680,149 +674,18 @@ class S7CommPlusAsyncClient:
         # Parse response body: ReturnValue(VLQ) + ObjectIdCount + ObjectIds(VLQ).
         # The usable session id is ObjectIds[0] (NOT the header SessionId field).
         body = response[14:]
-        boff = 0
-        while boff < len(body) and (body[boff] & 0x80):  # skip ReturnValue VLQ
-            boff += 1
-        boff += 1
-        obj_count = body[boff] if boff < len(body) else 0
-        boff += 1
-        object_ids = []
-        for _ in range(obj_count):
-            oid, _c = decode_uint32_vlq(body, boff)
-            boff += _c
-            object_ids.append(oid)
+        object_ids, obj_end = parse_create_object_session_id(body)
         if object_ids:
             self._session_id = object_ids[0]
         else:
             self._session_id = struct.unpack_from(">I", response, 9)[0]
         self._protocol_version = version
 
-        self._parse_create_object_response(response[14 + boff :])
-
-    def _parse_create_object_response(self, payload: bytes) -> None:
-        """Parse CreateObject response to extract ServerSessionVersion (attribute 306)."""
-        offset = 0
-        while offset < len(payload):
-            tag = payload[offset]
-
-            if tag == ElementID.ATTRIBUTE:
-                offset += 1
-                if offset >= len(payload):
-                    break
-                attr_id, consumed = decode_uint32_vlq(payload, offset)
-                offset += consumed
-
-                if attr_id == ObjectId.SERVER_SESSION_VERSION:
-                    # Capture the raw typed value (flags+datatype+data) to echo back —
-                    # real S7-1500 PLCs send ServerSessionVersion as a Struct (0x17).
-                    if offset + 2 > len(payload):
-                        break
-                    value_start = offset
-                    _flags = payload[offset]
-                    datatype = payload[offset + 1]
-                    end = self._skip_typed_value(payload, offset + 2, datatype, _flags)
-                    self._server_session_version_raw = bytes(payload[value_start:end])
-                    self._server_session_version = self._server_session_version_raw
-                    offset = end
-                    logger.info(
-                        f"ServerSessionVersion captured: type={datatype:#04x}, {len(self._server_session_version_raw)} bytes"
-                    )
-                    return
-                else:
-                    # Skip this attribute's typed value (flags + datatype + value)
-                    if offset + 2 > len(payload):
-                        break
-                    _flags = payload[offset]
-                    datatype = payload[offset + 1]
-                    offset += 2
-                    offset = self._skip_typed_value(payload, offset, datatype, _flags)
-
-            elif tag == ElementID.START_OF_OBJECT:
-                offset += 1
-                if offset + 4 > len(payload):
-                    break
-                offset += 4
-                _, consumed = decode_uint32_vlq(payload, offset)
-                offset += consumed
-                _, consumed = decode_uint32_vlq(payload, offset)
-                offset += consumed
-                _, consumed = decode_uint32_vlq(payload, offset)
-                offset += consumed
-
-            elif tag == ElementID.TERMINATING_OBJECT:
-                offset += 1
-            elif tag == 0x00:
-                offset += 1
-            else:
-                offset += 1
-
-        logger.debug("ServerSessionVersion not found in CreateObject response")
-
-    def _skip_typed_value(self, data: bytes, offset: int, datatype: int, flags: int) -> int:
-        """Skip over a typed value in the PObject tree (best-effort). Returns new offset."""
-        is_array = bool(flags & 0x10)
-
-        if is_array:
-            if offset >= len(data):
-                return offset
-            count, consumed = decode_uint32_vlq(data, offset)
-            offset += consumed
-            elem_size = _element_size(datatype)
-            if elem_size > 0:
-                offset += count * elem_size
-            else:
-                for _ in range(count):
-                    if offset >= len(data):
-                        break
-                    _, consumed = decode_uint32_vlq(data, offset)
-                    offset += consumed
-            return offset
-
-        if datatype == DataType.NULL:
-            return offset
-        elif datatype in (DataType.BOOL, DataType.USINT, DataType.BYTE, DataType.SINT):
-            return offset + 1
-        elif datatype in (DataType.UINT, DataType.WORD, DataType.INT):
-            return offset + 2
-        elif datatype in (DataType.UDINT, DataType.DWORD, DataType.AID, DataType.DINT):
-            _, consumed = decode_uint32_vlq(data, offset)
-            return offset + consumed
-        elif datatype in (DataType.ULINT, DataType.LWORD, DataType.LINT):
-            _, consumed = decode_uint64_vlq(data, offset)
-            return offset + consumed
-        elif datatype == DataType.REAL:
-            return offset + 4
-        elif datatype == DataType.LREAL:
-            return offset + 8
-        elif datatype == DataType.TIMESTAMP:
-            return offset + 8
-        elif datatype == DataType.TIMESPAN:
-            _, consumed = decode_uint64_vlq(data, offset)
-            return offset + consumed
-        elif datatype == DataType.RID:
-            return offset + 4
-        elif datatype in (DataType.BLOB, DataType.WSTRING):
-            length, consumed = decode_uint32_vlq(data, offset)
-            return offset + consumed + length
-        elif datatype == DataType.STRUCT:
-            # Normal-mode struct: UInt32 struct-id, then members [VLQ key][typed value],
-            # terminated by a 0x00 list-terminator byte (keys always start with high bit set).
-            offset += 4  # struct id (UInt32, not VLQ)
-            while offset < len(data):
-                if data[offset] == 0x00:
-                    offset += 1
-                    break
-                _key, consumed = decode_uint32_vlq(data, offset)
-                offset += consumed
-                if offset + 2 > len(data):
-                    break
-                sub_flags = data[offset]
-                sub_type = data[offset + 1]
-                offset += 2
-                offset = self._skip_typed_value(data, offset, sub_type, sub_flags)
-            return offset
+        self._server_session_version = parse_server_session_version(response[14 + obj_end :])
+        if self._server_session_version is not None:
+            logger.info(f"ServerSessionVersion captured: {len(self._server_session_version)} bytes")
         else:
-            return offset
+            logger.debug("ServerSessionVersion not found in CreateObject response")
 
     async def _setup_session(self) -> bool:
         """Echo ServerSessionVersion back to the PLC via SetMultiVariables."""
@@ -836,7 +699,7 @@ class S7CommPlusAsyncClient:
         payload += encode_uint32_vlq(ObjectId.SERVER_SESSION_VERSION)
         payload += encode_uint32_vlq(1)
         # PValue: echo the ServerSessionVersion typed value verbatim (it may be a Struct)
-        payload += self._server_session_version_raw
+        payload += self._server_session_version
         payload += bytes([0x00])
         payload += encode_object_qualifier()
         payload += struct.pack(">I", 0)

--- a/s7/_s7commplus_server.py
+++ b/s7/_s7commplus_server.py
@@ -550,18 +550,11 @@ class S7CommPlusServer:
         seq_num = struct.unpack_from(">H", payload, 7)[0]
         req_session_id = struct.unpack_from(">I", payload, 9)[0]
 
-        # For V2+, skip IntegrityId after the 14-byte header
-        request_offset = 14
-        if (
-            self._protocol_version >= ProtocolVersion.V2
-            and session_id != 0
-            and function_code not in (FunctionCode.INIT_SSL, FunctionCode.CREATE_OBJECT)
-        ):
-            if request_offset < len(payload):
-                _req_iid, iid_consumed = decode_uint32_vlq(payload, request_offset)
-                request_offset += iid_consumed
-
-        request_data = payload[request_offset:]
+        # The request header is 14 bytes (opcode + reserved + function + reserved
+        # + seqnr + SessionId + transport).  For V2+ the IntegrityId travels at the
+        # *end* of the payload (just before the trailing UInt32), where the request
+        # parsers harmlessly ignore it -- so the data simply starts after the header.
+        request_data = payload[14:]
 
         if function_code == FunctionCode.INIT_SSL:
             return self._handle_init_ssl(seq_num)
@@ -578,39 +571,31 @@ class S7CommPlusServer:
         else:
             return self._build_error_response(seq_num, req_session_id, function_code)
 
-    def _build_response_header(
-        self,
-        function_code: int,
-        seq_num: int,
-        session_id: int,
-        include_integrity_id: bool = False,
-        integrity_id: int = 0,
-    ) -> bytes:
-        """Build a 14-byte response header, optionally with IntegrityId (V2+).
+    def _build_response_header(self, function_code: int, seq_num: int) -> bytes:
+        """Build a 10-byte S7CommPlus data-response header.
+
+        Unlike requests (which carry a 4-byte SessionId, giving a 14-byte
+        header), real S7-1500 *responses* omit the SessionId field, so the
+        data header is 10 bytes: opcode + reserved + function + reserved +
+        seqnr + transport.  For V2+, the IntegrityId travels at the *end* of
+        the payload (appended by the individual handlers), not in the header.
 
         Args:
             function_code: Response function code
             seq_num: Sequence number echoed from request
-            session_id: Session ID
-            include_integrity_id: If True, append VLQ IntegrityId after header
-            integrity_id: IntegrityId value to include
 
         Returns:
-            Response header bytes (14 bytes, or 14+VLQ for V2+)
+            Response header bytes (10 bytes)
         """
-        header = struct.pack(
-            ">BHHHHIB",
+        return struct.pack(
+            ">BHHHHB",
             Opcode.RESPONSE,
             0x0000,
             function_code,
             0x0000,
             seq_num,
-            session_id,
             0x00,
         )
-        if include_integrity_id:
-            header += encode_uint32_vlq(integrity_id)
-        return header
 
     def _handle_init_ssl(self, seq_num: int) -> bytes:
         """Handle InitSSL -- respond to SSL initialization (V1 emulation, no real TLS)."""
@@ -653,6 +638,11 @@ class S7CommPlusServer:
         # Return code: success
         response += encode_uint32_vlq(0)
 
+        # ObjectIds block: a real S7-1500 returns the usable session id here as
+        # ObjectIds[0] (NOT in the response header).  Emit a single id.
+        response += bytes([0x01])  # ObjectId count
+        response += encode_uint32_vlq(session_id)
+
         # Object with session info
         response += bytes([ElementID.START_OF_OBJECT])
         response += struct.pack(">I", 0x00000001)  # Relation ID
@@ -660,15 +650,15 @@ class S7CommPlusServer:
         response += encode_uint32_vlq(0x00000000)  # Class flags
         response += encode_uint32_vlq(0x00000000)  # Attribute ID
 
-        # Session ID attribute
+        # Session ID attribute (PValue on the wire = flags + datatype + value)
         response += bytes([ElementID.ATTRIBUTE])
         response += encode_uint32_vlq(0x0131)  # ServerSession ID attribute
-        response += encode_typed_value(DataType.UDINT, session_id)
+        response += bytes([0x00]) + encode_typed_value(DataType.UDINT, session_id)
 
         # Protocol version attribute
         response += bytes([ElementID.ATTRIBUTE])
         response += encode_uint32_vlq(0x0132)  # Protocol version attribute
-        response += encode_typed_value(DataType.USINT, self._protocol_version)
+        response += bytes([0x00]) + encode_typed_value(DataType.USINT, self._protocol_version)
 
         # ServerSessionVersion attribute (306) - required for session setup handshake
         from .protocol import ObjectId
@@ -688,16 +678,7 @@ class S7CommPlusServer:
     def _handle_delete_object(self, seq_num: int, session_id: int) -> bytes:
         """Handle DeleteObject -- close a session."""
         response = bytearray()
-        response += struct.pack(
-            ">BHHHHIB",
-            Opcode.RESPONSE,
-            0x0000,
-            FunctionCode.DELETE_OBJECT,
-            0x0000,
-            seq_num,
-            session_id,
-            0x00,
-        )
+        response += self._build_response_header(FunctionCode.DELETE_OBJECT, seq_num)
         response += encode_uint32_vlq(0)  # Return code: success
         response += struct.pack(">I", 0)
         return bytes(response)
@@ -705,16 +686,7 @@ class S7CommPlusServer:
     def _handle_explore(self, seq_num: int, session_id: int, request_data: bytes) -> bytes:
         """Handle Explore -- return the object tree (registered data blocks)."""
         response = bytearray()
-        response += struct.pack(
-            ">BHHHHIB",
-            Opcode.RESPONSE,
-            0x0000,
-            FunctionCode.EXPLORE,
-            0x0000,
-            seq_num,
-            session_id,
-            0x00,
-        )
+        response += self._build_response_header(FunctionCode.EXPLORE, seq_num)
         response += encode_uint32_vlq(0)  # Return code: success
 
         # Return list of data blocks as objects using standard S7CommPlus IDs
@@ -779,16 +751,7 @@ class S7CommPlusServer:
         Reference: thomas-v2/S7CommPlusDriver/Core/GetMultiVariablesRequest.cs
         """
         response = bytearray()
-        response += struct.pack(
-            ">BHHHHIB",
-            Opcode.RESPONSE,
-            0x0000,
-            FunctionCode.GET_MULTI_VARIABLES,
-            0x0000,
-            seq_num,
-            session_id,
-            0x00,
-        )
+        response += self._build_response_header(FunctionCode.GET_MULTI_VARIABLES, seq_num)
 
         # Parse request payload
         items = _server_parse_read_request(request_data)
@@ -829,16 +792,7 @@ class S7CommPlusServer:
         Reference: thomas-v2/S7CommPlusDriver/Core/SetMultiVariablesRequest.cs
         """
         response = bytearray()
-        response += struct.pack(
-            ">BHHHHIB",
-            Opcode.RESPONSE,
-            0x0000,
-            FunctionCode.SET_MULTI_VARIABLES,
-            0x0000,
-            seq_num,
-            session_id,
-            0x00,
-        )
+        response += self._build_response_header(FunctionCode.SET_MULTI_VARIABLES, seq_num)
 
         # Parse request payload
         items, values = _server_parse_write_request(request_data)
@@ -871,16 +825,7 @@ class S7CommPlusServer:
     def _build_error_response(self, seq_num: int, session_id: int, function_code: int) -> bytes:
         """Build a generic error response for unsupported function codes."""
         response = bytearray()
-        response += struct.pack(
-            ">BHHHHIB",
-            Opcode.RESPONSE,
-            0x0000,
-            FunctionCode.ERROR,
-            0x0000,
-            seq_num,
-            session_id,
-            0x00,
-        )
+        response += self._build_response_header(FunctionCode.ERROR, seq_num)
         response += encode_uint32_vlq(0x04B1)  # Error function code
         response += struct.pack(">I", 0)
         return bytes(response)

--- a/s7/_s7commplus_server.py
+++ b/s7/_s7commplus_server.py
@@ -365,65 +365,76 @@ class S7CommPlusServer:
 
             # Step 2: S7CommPlus session
             session_id = 0
-            tls_activated = False
             # Per-client IntegrityId tracking (V2+)
             integrity_id_read = 0
             integrity_id_write = 0
+            # Per-client TLS state (None until activated). Like a real S7-1500, TLS records
+            # are tunneled inside COTP DT frames — the TPKT/COTP headers stay unencrypted.
+            tls: dict[str, Any] = {"obj": None, "in": None, "out": None}
+
+            def recv_app_frame() -> Optional[bytes]:
+                raw = self._recv_s7commplus_frame(client_sock)
+                if raw is None or tls["obj"] is None:
+                    return raw
+                tls["in"].write(raw)
+                while True:
+                    try:
+                        return tls["obj"].read(65536)
+                    except ssl.SSLWantReadError:
+                        more = self._recv_s7commplus_frame(client_sock)
+                        if more is None:
+                            return None
+                        tls["in"].write(more)
+
+            def send_app_frame(data: bytes) -> None:
+                frame = encode_header(self._protocol_version, len(data)) + data
+                frame += struct.pack(">BBH", 0x72, self._protocol_version, 0x0000)
+                if tls["obj"] is None:
+                    self._send_cotp_dt_raw(client_sock, frame)
+                else:
+                    tls["obj"].write(frame)
+                    out = tls["out"].read()
+                    if out:
+                        self._send_cotp_dt_raw(client_sock, out)
 
             while self._running:
                 try:
-                    # Receive TPKT + COTP DT + S7CommPlus data
-                    data = self._recv_s7commplus_frame(client_sock)
+                    data = recv_app_frame()
                     if data is None:
                         break
 
-                    # Process the S7CommPlus request
-                    response = self._process_request(data, session_id, integrity_id_read, integrity_id_write)
+                    # Decode the request function code once (used for TLS + IntegrityId).
+                    func_code = None
+                    try:
+                        _, _, hdr_consumed = decode_header(data)
+                        payload = data[hdr_consumed:]
+                        if len(payload) >= 14:
+                            func_code = struct.unpack_from(">H", payload, 3)[0]
+                    except (ValueError, struct.error):
+                        pass
 
+                    response = self._process_request(data, session_id, integrity_id_read, integrity_id_write)
                     if response is not None:
-                        # Check if session ID was assigned
                         if session_id == 0 and len(response) >= 14:
                             session_id = struct.unpack_from(">I", response, 9)[0]
+                        send_app_frame(response)
 
-                        self._send_s7commplus_frame(client_sock, response)
-
-                    # After InitSSL response, activate TLS if configured
+                    # Activate TLS right after the InitSSL response, tunneled inside COTP.
                     if (
-                        not tls_activated
+                        tls["obj"] is None
                         and self._use_tls
                         and self._ssl_context is not None
-                        and data is not None
-                        and len(data) >= 8
+                        and func_code == FunctionCode.INIT_SSL
                     ):
-                        # Check if this was an InitSSL request
-                        try:
-                            _, _, hdr_consumed = decode_header(data)
-                            payload = data[hdr_consumed:]
-                            if len(payload) >= 14:
-                                func_code = struct.unpack_from(">H", payload, 3)[0]
-                                if func_code == FunctionCode.INIT_SSL:
-                                    client_sock = self._ssl_context.wrap_socket(client_sock, server_side=True)
-                                    tls_activated = True
-                                    logger.debug(f"TLS activated for client {address}")
-                        except (ValueError, struct.error):
-                            pass
+                        tls["obj"], tls["in"], tls["out"] = self._server_tls_handshake(client_sock)
+                        logger.debug(f"TLS activated (COTP-tunneled) for client {address}")
 
-                    # Update IntegrityId counters based on function code (V2+)
-                    if self._protocol_version >= ProtocolVersion.V2 and session_id != 0:
-                        try:
-                            _, _, hdr_consumed = decode_header(data)
-                            payload = data[hdr_consumed:]
-                            if len(payload) >= 14:
-                                func_code = struct.unpack_from(">H", payload, 3)[0]
-                                if func_code in READ_FUNCTION_CODES:
-                                    integrity_id_read = (integrity_id_read + 1) & 0xFFFFFFFF
-                                elif func_code not in (
-                                    FunctionCode.INIT_SSL,
-                                    FunctionCode.CREATE_OBJECT,
-                                ):
-                                    integrity_id_write = (integrity_id_write + 1) & 0xFFFFFFFF
-                        except (ValueError, struct.error):
-                            pass
+                    # Update IntegrityId counters based on function code (V2+).
+                    if self._protocol_version >= ProtocolVersion.V2 and session_id != 0 and func_code is not None:
+                        if func_code in READ_FUNCTION_CODES:
+                            integrity_id_read = (integrity_id_read + 1) & 0xFFFFFFFF
+                        elif func_code not in (FunctionCode.INIT_SSL, FunctionCode.CREATE_OBJECT):
+                            integrity_id_write = (integrity_id_write + 1) & 0xFFFFFFFF
 
                 except socket.timeout:
                     continue
@@ -438,6 +449,29 @@ class S7CommPlusServer:
             except Exception:
                 pass
             logger.info(f"Client disconnected: {address}")
+
+    def _server_tls_handshake(self, sock: socket.socket) -> tuple[Any, Any, Any]:
+        """Perform the server-side TLS handshake, tunneling records through COTP DT frames."""
+        assert self._ssl_context is not None
+        in_bio = ssl.MemoryBIO()
+        out_bio = ssl.MemoryBIO()
+        ssl_obj = self._ssl_context.wrap_bio(in_bio, out_bio, server_side=True)
+        while True:
+            try:
+                ssl_obj.do_handshake()
+                break
+            except ssl.SSLWantReadError:
+                out = out_bio.read()
+                if out:
+                    self._send_cotp_dt_raw(sock, out)
+                rec = self._recv_s7commplus_frame(sock)
+                if rec is None:
+                    raise ConnectionError("client closed during TLS handshake")
+                in_bio.write(rec)
+        out = out_bio.read()
+        if out:
+            self._send_cotp_dt_raw(sock, out)
+        return ssl_obj, in_bio, out_bio
 
     def _handle_cotp_connect(self, sock: socket.socket) -> bool:
         """Handle COTP Connection Request / Confirm."""
@@ -506,16 +540,12 @@ class S7CommPlusServer:
         except Exception:
             return None
 
-    def _send_s7commplus_frame(self, sock: socket.socket, data: bytes) -> None:
-        """Send an S7CommPlus frame wrapped in TPKT/COTP."""
-        # S7CommPlus header (4 bytes) + data + trailer (4 bytes)
-        s7plus_frame = encode_header(self._protocol_version, len(data)) + data
-        s7plus_frame += struct.pack(">BBH", 0x72, self._protocol_version, 0x0000)
+    def _send_cotp_dt_raw(self, sock: socket.socket, data: bytes) -> None:
+        """Send raw bytes wrapped in a COTP DT + TPKT frame (no TLS, no S7CommPlus header).
 
-        # COTP DT header
-        cotp_dt = struct.pack(">BBB", 2, 0xF0, 0x80) + s7plus_frame
-
-        # TPKT
+        Carries either a plaintext S7CommPlus frame or, once TLS is active, a TLS record.
+        """
+        cotp_dt = struct.pack(">BBB", 2, 0xF0, 0x80) + data
         tpkt = struct.pack(">BBH", 3, 0, 4 + len(cotp_dt)) + cotp_dt
         sock.sendall(tpkt)
 

--- a/s7/codec.py
+++ b/s7/codec.py
@@ -13,9 +13,9 @@ Reference: thomas-v2/S7CommPlusDriver/Core/S7p.cs
 """
 
 import struct
-from typing import Any
+from typing import Any, Optional
 
-from .protocol import PROTOCOL_ID, DataType, Ids
+from .protocol import PROTOCOL_ID, DataType, ElementID, Ids, ObjectId
 from .vlq import (
     encode_uint32_vlq,
     decode_uint32_vlq,
@@ -493,3 +493,144 @@ def _pvalue_element_size(datatype: int) -> int:
         return 4
     else:
         return 0  # Variable-length (VLQ encoded)
+
+
+# -- PObject-tree parsing shared by the sync (S7CommPlusConnection) and async clients --
+
+
+def skip_typed_value(data: bytes, offset: int, datatype: int, flags: int) -> int:
+    """Skip over a typed value in the PObject tree (best-effort). Returns the new offset."""
+    is_array = bool(flags & 0x10)
+
+    if is_array:
+        if offset >= len(data):
+            return offset
+        count, consumed = decode_uint32_vlq(data, offset)
+        offset += consumed
+        elem_size = _pvalue_element_size(datatype)
+        if elem_size > 0:
+            offset += count * elem_size
+        else:
+            # Variable-length: skip each VLQ element.
+            for _ in range(count):
+                if offset >= len(data):
+                    break
+                _, consumed = decode_uint32_vlq(data, offset)
+                offset += consumed
+        return offset
+
+    if datatype == DataType.NULL:
+        return offset
+    elif datatype in (DataType.BOOL, DataType.USINT, DataType.BYTE, DataType.SINT):
+        return offset + 1
+    elif datatype in (DataType.UINT, DataType.WORD, DataType.INT):
+        return offset + 2
+    elif datatype in (DataType.UDINT, DataType.DWORD, DataType.AID, DataType.DINT):
+        _, consumed = decode_uint32_vlq(data, offset)
+        return offset + consumed
+    elif datatype in (DataType.ULINT, DataType.LWORD, DataType.LINT):
+        _, consumed = decode_uint64_vlq(data, offset)
+        return offset + consumed
+    elif datatype == DataType.REAL:
+        return offset + 4
+    elif datatype == DataType.LREAL:
+        return offset + 8
+    elif datatype == DataType.TIMESTAMP:
+        return offset + 8
+    elif datatype == DataType.TIMESPAN:
+        _, consumed = decode_uint64_vlq(data, offset)  # int64 VLQ
+        return offset + consumed
+    elif datatype == DataType.RID:
+        return offset + 4
+    elif datatype in (DataType.BLOB, DataType.WSTRING):
+        length, consumed = decode_uint32_vlq(data, offset)
+        return offset + consumed + length
+    elif datatype == DataType.STRUCT:
+        # Normal-mode struct: UInt32 struct-id, then members [VLQ key][typed value],
+        # terminated by a 0x00 list-terminator byte (keys always start with high bit set).
+        offset += 4  # struct id (UInt32, not VLQ)
+        while offset < len(data):
+            if data[offset] == 0x00:
+                offset += 1
+                break
+            _key, consumed = decode_uint32_vlq(data, offset)
+            offset += consumed
+            if offset + 2 > len(data):
+                break
+            sub_flags = data[offset]
+            sub_type = data[offset + 1]
+            offset += 2
+            offset = skip_typed_value(data, offset, sub_type, sub_flags)
+        return offset
+    else:
+        # Unknown type — can't skip reliably.
+        return offset
+
+
+def parse_create_object_session_id(body: bytes) -> tuple[list[int], int]:
+    """Parse a CreateObject response body (after the 14-byte response header).
+
+    Body layout: ReturnValue (UInt64 VLQ) + ObjectIdCount (1 byte) + ObjectIds (UInt32 VLQ
+    each). The usable session id is ``ObjectIds[0]`` (not the header SessionId field).
+
+    Returns ``(object_ids, offset)`` where ``offset`` points just past the ObjectIds.
+    """
+    _return_value, consumed = decode_uint64_vlq(body, 0)
+    boff = consumed
+    obj_count = body[boff] if boff < len(body) else 0
+    boff += 1
+    object_ids: list[int] = []
+    for _ in range(obj_count):
+        oid, c = decode_uint32_vlq(body, boff)
+        boff += c
+        object_ids.append(oid)
+    return object_ids, boff
+
+
+def parse_server_session_version(payload: bytes) -> Optional[bytes]:
+    """Scan a CreateObject response payload for the ServerSessionVersion attribute (306).
+
+    Returns the raw typed value (flags + datatype + data) to echo back during session
+    setup, or ``None`` if the attribute is not present. Real S7-1500 PLCs send it as a
+    Struct (0x17).
+    """
+    offset = 0
+    while offset < len(payload):
+        tag = payload[offset]
+
+        if tag == ElementID.ATTRIBUTE:
+            offset += 1
+            if offset >= len(payload):
+                break
+            attr_id, consumed = decode_uint32_vlq(payload, offset)
+            offset += consumed
+
+            if offset + 2 > len(payload):
+                break
+            flags = payload[offset]
+            datatype = payload[offset + 1]
+
+            if attr_id == ObjectId.SERVER_SESSION_VERSION:
+                value_start = offset
+                end = skip_typed_value(payload, offset + 2, datatype, flags)
+                return bytes(payload[value_start:end])
+            else:
+                offset = skip_typed_value(payload, offset + 2, datatype, flags)
+
+        elif tag == ElementID.START_OF_OBJECT:
+            offset += 1
+            if offset + 4 > len(payload):
+                break
+            offset += 4  # RelationId (fixed)
+            for _ in range(3):  # ClassId, ClassFlags, AttributeId (each VLQ)
+                _, consumed = decode_uint32_vlq(payload, offset)
+                offset += consumed
+
+        elif tag == ElementID.TERMINATING_OBJECT:
+            offset += 1
+        elif tag == 0x00:
+            offset += 1  # null terminator / padding
+        else:
+            offset += 1  # unknown tag — skip
+
+    return None

--- a/s7/connection.py
+++ b/s7/connection.py
@@ -55,25 +55,18 @@ from .protocol import (
     S7COMMPLUS_REMOTE_TSAP,
     READ_FUNCTION_CODES,
 )
-from .codec import encode_header, decode_header, encode_typed_value, encode_object_qualifier
+from .codec import (
+    encode_header,
+    decode_header,
+    encode_typed_value,
+    encode_object_qualifier,
+    parse_create_object_session_id,
+    parse_server_session_version,
+)
 from .vlq import encode_uint32_vlq, decode_uint32_vlq, decode_uint64_vlq
 from .protocol import DataType
 
 logger = logging.getLogger(__name__)
-
-
-def _element_size(datatype: int) -> int:
-    """Return the fixed byte size for an array element, or 0 for variable-length."""
-    if datatype in (DataType.BOOL, DataType.USINT, DataType.BYTE, DataType.SINT):
-        return 1
-    elif datatype in (DataType.UINT, DataType.WORD, DataType.INT):
-        return 2
-    elif datatype in (DataType.REAL, DataType.RID):
-        return 4
-    elif datatype in (DataType.LREAL, DataType.TIMESTAMP):
-        return 8
-    else:
-        return 0
 
 
 class S7CommPlusConnection:
@@ -116,7 +109,6 @@ class S7CommPlusConnection:
         # ServerSessionVersion is captured as its raw typed value (flags+datatype+data)
         # so it can be echoed back verbatim — real S7-1500 PLCs send it as a Struct.
         self._server_session_version: Optional[bytes] = None
-        self._server_session_version_raw: Optional[bytes] = None
         self._session_setup_ok: bool = False
 
         # V2+ IntegrityId tracking
@@ -695,22 +687,11 @@ class S7CommPlusConnection:
         # Parse response body: ReturnValue(UInt64 VLQ) + ObjectIdCount + ObjectIds(VLQ).
         # The usable session id is ObjectIds[0] (NOT the header SessionId field).
         body = response[14:]
-        boff = 0
-        while boff < len(body) and (body[boff] & 0x80):  # skip ReturnValue VLQ
-            boff += 1
-        boff += 1
-        obj_count = body[boff] if boff < len(body) else 0
-        boff += 1
-        object_ids = []
-        for _ in range(obj_count):
-            oid, _c = decode_uint32_vlq(body, boff)
-            boff += _c
-            object_ids.append(oid)
+        object_ids, obj_end = parse_create_object_session_id(body)
         if object_ids:
             self._session_id = object_ids[0]
         else:
             self._session_id = struct.unpack_from(">I", response, 9)[0]
-        self._resp_object_start = boff
         self._protocol_version = version
 
         # Parse and log the full response header
@@ -726,153 +707,11 @@ class S7CommPlusConnection:
         logger.debug(f"Session created: id=0x{self._session_id:08X} ({self._session_id}), version=V{version}")
 
         # Parse response payload to extract ServerSessionVersion
-        self._parse_create_object_response(response[14 + self._resp_object_start :])
-
-    def _parse_create_object_response(self, payload: bytes) -> None:
-        """Parse CreateObject response payload to extract ServerSessionVersion.
-
-        The response contains a PObject tree with attributes. We scan for
-        attribute 306 (ServerSessionVersion) which must be echoed back to
-        complete the session handshake.
-
-        Args:
-            payload: Response payload after the 14-byte response header
-        """
-        offset = 0
-        while offset < len(payload):
-            tag = payload[offset]
-
-            if tag == ElementID.ATTRIBUTE:
-                offset += 1
-                if offset >= len(payload):
-                    break
-                attr_id, consumed = decode_uint32_vlq(payload, offset)
-                offset += consumed
-
-                if attr_id == ObjectId.SERVER_SESSION_VERSION:
-                    # ServerSessionVersion is a Struct (0x17) on real S7-1500 PLCs;
-                    # capture the raw typed value (flags+datatype+data) to echo back.
-                    if offset + 2 > len(payload):
-                        break
-                    value_start = offset
-                    _flags = payload[offset]
-                    datatype = payload[offset + 1]
-                    end = self._skip_typed_value(payload, offset + 2, datatype, _flags)
-                    self._server_session_version_raw = bytes(payload[value_start:end])
-                    self._server_session_version = self._server_session_version_raw
-                    offset = end
-                    logger.info(
-                        f"ServerSessionVersion captured: type={datatype:#04x}, {len(self._server_session_version_raw)} bytes"
-                    )
-                    return
-                else:
-                    # Skip this attribute's value - we don't parse it, just advance
-                    # Try to skip the typed value (flags + datatype + value)
-                    if offset + 2 > len(payload):
-                        break
-                    _flags = payload[offset]
-                    datatype = payload[offset + 1]
-                    offset += 2
-                    offset = self._skip_typed_value(payload, offset, datatype, _flags)
-
-            elif tag == ElementID.START_OF_OBJECT:
-                offset += 1
-                # Skip RelationId (4 bytes fixed) + ClassId (VLQ) + ClassFlags (VLQ) + AttributeId (VLQ)
-                if offset + 4 > len(payload):
-                    break
-                offset += 4  # RelationId
-                _, consumed = decode_uint32_vlq(payload, offset)
-                offset += consumed  # ClassId
-                _, consumed = decode_uint32_vlq(payload, offset)
-                offset += consumed  # ClassFlags
-                _, consumed = decode_uint32_vlq(payload, offset)
-                offset += consumed  # AttributeId
-
-            elif tag == ElementID.TERMINATING_OBJECT:
-                offset += 1
-
-            elif tag == 0x00:
-                # Null terminator / padding
-                offset += 1
-
-            else:
-                # Unknown tag - try to skip
-                offset += 1
-
-        logger.debug("ServerSessionVersion not found in CreateObject response")
-
-    def _skip_typed_value(self, data: bytes, offset: int, datatype: int, flags: int) -> int:
-        """Skip over a typed value in the PObject tree.
-
-        Best-effort: advances offset past common value types.
-        Returns new offset.
-        """
-        is_array = bool(flags & 0x10)
-
-        if is_array:
-            if offset >= len(data):
-                return offset
-            count, consumed = decode_uint32_vlq(data, offset)
-            offset += consumed
-            # For fixed-size types, skip count * size
-            elem_size = _element_size(datatype)
-            if elem_size > 0:
-                offset += count * elem_size
-            else:
-                # Variable-length: skip each VLQ element
-                for _ in range(count):
-                    if offset >= len(data):
-                        break
-                    _, consumed = decode_uint32_vlq(data, offset)
-                    offset += consumed
-            return offset
-
-        if datatype == DataType.NULL:
-            return offset
-        elif datatype in (DataType.BOOL, DataType.USINT, DataType.BYTE, DataType.SINT):
-            return offset + 1
-        elif datatype in (DataType.UINT, DataType.WORD, DataType.INT):
-            return offset + 2
-        elif datatype in (DataType.UDINT, DataType.DWORD, DataType.AID, DataType.DINT):
-            _, consumed = decode_uint32_vlq(data, offset)
-            return offset + consumed
-        elif datatype in (DataType.ULINT, DataType.LWORD, DataType.LINT):
-            _, consumed = decode_uint64_vlq(data, offset)
-            return offset + consumed
-        elif datatype == DataType.REAL:
-            return offset + 4
-        elif datatype == DataType.LREAL:
-            return offset + 8
-        elif datatype == DataType.TIMESTAMP:
-            return offset + 8
-        elif datatype == DataType.TIMESPAN:
-            _, consumed = decode_uint64_vlq(data, offset)  # int64 VLQ
-            return offset + consumed
-        elif datatype == DataType.RID:
-            return offset + 4
-        elif datatype in (DataType.BLOB, DataType.WSTRING):
-            length, consumed = decode_uint32_vlq(data, offset)
-            return offset + consumed + length
-        elif datatype == DataType.STRUCT:
-            # Normal-mode struct: UInt32 struct-id, then members [VLQ key][typed value],
-            # terminated by a 0x00 list-terminator byte (keys always start with high bit set).
-            offset += 4  # struct id (UInt32, not VLQ)
-            while offset < len(data):
-                if data[offset] == 0x00:
-                    offset += 1
-                    break
-                _key, consumed = decode_uint32_vlq(data, offset)
-                offset += consumed
-                if offset + 2 > len(data):
-                    break
-                sub_flags = data[offset]
-                sub_type = data[offset + 1]
-                offset += 2
-                offset = self._skip_typed_value(data, offset, sub_type, sub_flags)
-            return offset
+        self._server_session_version = parse_server_session_version(response[14 + obj_end :])
+        if self._server_session_version is not None:
+            logger.info(f"ServerSessionVersion captured: {len(self._server_session_version)} bytes")
         else:
-            # Unknown type - can't skip reliably
-            return offset
+            logger.debug("ServerSessionVersion not found in CreateObject response")
 
     def _setup_session(self) -> bool:
         """Send SetMultiVariables to echo ServerSessionVersion back to the PLC.
@@ -915,7 +754,7 @@ class S7CommPlusConnection:
         # Value: ItemNumber = 1 (VLQ)
         payload += encode_uint32_vlq(1)
         # PValue: echo the ServerSessionVersion typed value verbatim (it is a Struct)
-        payload += self._server_session_version_raw
+        payload += self._server_session_version
         # Fill byte
         payload += bytes([0x00])
         # ObjectQualifier
@@ -1087,6 +926,9 @@ class S7CommPlusConnection:
             except ssl.SSLWantReadError:
                 self._tls_flush_outgoing()
                 self._tls_read_incoming()
+            except ssl.SSLWantWriteError:
+                # Rare with MemoryBIO, but the SSLObject can ask to write before reading.
+                self._tls_flush_outgoing()
         self._tls_flush_outgoing()
 
     def _setup_ssl_context(

--- a/s7/connection.py
+++ b/s7/connection.py
@@ -111,7 +111,10 @@ class S7CommPlusConnection:
         self._protocol_version: int = 0  # Detected from PLC response
         self._tls_active: bool = False
         self._connected = False
-        self._server_session_version: Optional[int] = None
+        # ServerSessionVersion is captured as its raw typed value (flags+datatype+data)
+        # so it can be echoed back verbatim — real S7-1500 PLCs send it as a Struct.
+        self._server_session_version: Optional[bytes] = None
+        self._server_session_version_raw: Optional[bytes] = None
         self._session_setup_ok: bool = False
 
         # V2+ IntegrityId tracking
@@ -200,6 +203,10 @@ class S7CommPlusConnection:
             # Step 4: CreateObject (S7CommPlus session setup)
             # CreateObject always uses V1 framing
             self._create_session()
+
+            # After CreateObject (V1), data PDUs over TLS use ProtocolVersion V2 (matches C# driver)
+            if self._tls_active:
+                self._protocol_version = ProtocolVersion.V2
 
             # Step 5: Session setup - echo ServerSessionVersion back to PLC
             if self._server_session_version is not None:
@@ -459,7 +466,7 @@ class S7CommPlusConnection:
             0x0000,  # Reserved
             seq_num,
             self._session_id,
-            0x36,  # Transport flags
+            0x34 if function_code == FunctionCode.GET_MULTI_VARIABLES else 0x36,  # Transport flags (0x34 for reads)
         )
 
         # For V2+ with IntegrityId enabled, insert IntegrityId after header
@@ -473,7 +480,12 @@ class S7CommPlusConnection:
             integrity_id_bytes = encode_uint32_vlq(integrity_id)
             logger.debug(f"  IntegrityId: {'read' if is_read else 'write'}={integrity_id}")
 
-        request = request_header + integrity_id_bytes + payload
+        # The IntegrityId is spliced in just before the payload's trailing UInt32 (i.e. at
+        # the end), not right after the header.
+        if integrity_id_bytes and len(payload) >= 4:
+            request = request_header + payload[:-4] + integrity_id_bytes + payload[-4:]
+        else:
+            request = request_header + integrity_id_bytes + payload
 
         logger.debug(f"=== SEND REQUEST === function_code=0x{function_code:04X} seq={seq_num} session=0x{self._session_id:08X}")
         logger.debug(f"  Request header (14 bytes): {request_header.hex(' ')}")
@@ -509,29 +521,24 @@ class S7CommPlusConnection:
         response = response_frame[consumed : consumed + data_length]
         logger.debug(f"  Response data ({len(response)} bytes): {response.hex(' ')}")
 
-        if len(response) < 14:
+        if len(response) < 10:
             from snap7.error import S7ConnectionError
 
             raise S7ConnectionError("Response too short")
 
-        # Parse response header for debug
+        # Parse the 10-byte response header for debug (responses carry no SessionId)
         resp_opcode = response[0]
         resp_func = struct.unpack_from(">H", response, 3)[0]
         resp_seq = struct.unpack_from(">H", response, 7)[0]
-        resp_session = struct.unpack_from(">I", response, 9)[0]
-        resp_transport = response[13]
+        resp_transport = response[9]
         logger.debug(
             f"  Response header: opcode=0x{resp_opcode:02X} function=0x{resp_func:04X} "
-            f"seq={resp_seq} session=0x{resp_session:08X} transport=0x{resp_transport:02X}"
+            f"seq={resp_seq} transport=0x{resp_transport:02X}"
         )
 
-        # For V2+ responses, skip IntegrityId in response before returning payload
-        resp_offset = 14
-        if self._with_integrity_id and self._protocol_version >= ProtocolVersion.V2:
-            if resp_offset < len(response):
-                resp_integrity_id, iid_consumed = decode_uint32_vlq(response, resp_offset)
-                resp_offset += iid_consumed
-                logger.debug(f"  Response IntegrityId: {resp_integrity_id}")
+        # RESPONSE header is 10 bytes (opcode+res+func+res+seqnr+transport) — responses have
+        # NO SessionId field (requests do, making their header 14 bytes). Integrity is at the END.
+        resp_offset = 10
 
         resp_payload = response[resp_offset:]
         logger.debug(f"  Response payload ({len(resp_payload)} bytes): {resp_payload.hex(' ')}")
@@ -636,10 +643,12 @@ class S7CommPlusConnection:
         # AttributeId: None (0)
         request += encode_uint32_vlq(0)
 
-        # Attribute: ServerSessionClientRID (300) = RID 0x80c3c901
+        # Attribute: ServerSessionClientRID (300) = RID 0x80c3c901.
+        # PValue on the wire is DatatypeFlags(1) + Datatype(1) + value; encode_typed_value emits
+        # only Datatype+value (by codec contract), so prepend the flags byte here at the call site.
         request += bytes([ElementID.ATTRIBUTE])
         request += encode_uint32_vlq(ObjectId.SERVER_SESSION_CLIENT_RID)
-        request += encode_typed_value(DataType.RID, 0x80C3C901)
+        request += bytes([0x00]) + encode_typed_value(DataType.RID, 0x80C3C901)
 
         # Nested object: ClassSubscriptions
         request += bytes([ElementID.START_OF_OBJECT])
@@ -679,8 +688,25 @@ class S7CommPlusConnection:
 
             raise S7ConnectionError("CreateObject response too short")
 
-        # Extract session ID from response header
-        self._session_id = struct.unpack_from(">I", response, 9)[0]
+        # Parse response body: ReturnValue(UInt64 VLQ) + ObjectIdCount + ObjectIds(VLQ).
+        # The usable session id is ObjectIds[0] (NOT the header SessionId field).
+        body = response[14:]
+        boff = 0
+        while boff < len(body) and (body[boff] & 0x80):  # skip ReturnValue VLQ
+            boff += 1
+        boff += 1
+        obj_count = body[boff] if boff < len(body) else 0
+        boff += 1
+        object_ids = []
+        for _ in range(obj_count):
+            oid, _c = decode_uint32_vlq(body, boff)
+            boff += _c
+            object_ids.append(oid)
+        if object_ids:
+            self._session_id = object_ids[0]
+        else:
+            self._session_id = struct.unpack_from(">I", response, 9)[0]
+        self._resp_object_start = boff
         self._protocol_version = version
 
         # Parse and log the full response header
@@ -696,7 +722,7 @@ class S7CommPlusConnection:
         logger.debug(f"Session created: id=0x{self._session_id:08X} ({self._session_id}), version=V{version}")
 
         # Parse response payload to extract ServerSessionVersion
-        self._parse_create_object_response(response[14:])
+        self._parse_create_object_response(response[14 + self._resp_object_start :])
 
     def _parse_create_object_response(self, payload: bytes) -> None:
         """Parse CreateObject response payload to extract ServerSessionVersion.
@@ -720,27 +746,21 @@ class S7CommPlusConnection:
                 offset += consumed
 
                 if attr_id == ObjectId.SERVER_SESSION_VERSION:
-                    # Next bytes are the typed value: flags + datatype + VLQ value
+                    # ServerSessionVersion is a Struct (0x17) on real S7-1500 PLCs;
+                    # capture the raw typed value (flags+datatype+data) to echo back.
                     if offset + 2 > len(payload):
                         break
+                    value_start = offset
                     _flags = payload[offset]
                     datatype = payload[offset + 1]
-                    offset += 2
-                    if datatype == DataType.UDINT:
-                        value, consumed = decode_uint32_vlq(payload, offset)
-                        offset += consumed
-                        self._server_session_version = value
-                        logger.info(f"ServerSessionVersion = {value}")
-                        return
-                    elif datatype == DataType.DWORD:
-                        value, consumed = decode_uint32_vlq(payload, offset)
-                        offset += consumed
-                        self._server_session_version = value
-                        logger.info(f"ServerSessionVersion = {value}")
-                        return
-                    else:
-                        # Skip unknown type - try to continue scanning
-                        logger.debug(f"ServerSessionVersion has unexpected type {datatype:#04x}")
+                    end = self._skip_typed_value(payload, offset + 2, datatype, _flags)
+                    self._server_session_version_raw = bytes(payload[value_start:end])
+                    self._server_session_version = self._server_session_version_raw
+                    offset = end
+                    logger.info(
+                        f"ServerSessionVersion captured: type={datatype:#04x}, {len(self._server_session_version_raw)} bytes"
+                    )
+                    return
                 else:
                     # Skip this attribute's value - we don't parse it, just advance
                     # Try to skip the typed value (flags + datatype + value)
@@ -830,9 +850,15 @@ class S7CommPlusConnection:
             length, consumed = decode_uint32_vlq(data, offset)
             return offset + consumed + length
         elif datatype == DataType.STRUCT:
-            count, consumed = decode_uint32_vlq(data, offset)
-            offset += consumed
-            for _ in range(count):
+            # Normal-mode struct: UInt32 struct-id, then members [VLQ key][typed value],
+            # terminated by a 0x00 list-terminator byte (keys always start with high bit set).
+            offset += 4  # struct id (UInt32, not VLQ)
+            while offset < len(data):
+                if data[offset] == 0x00:
+                    offset += 1
+                    break
+                _key, consumed = decode_uint32_vlq(data, offset)
+                offset += consumed
                 if offset + 2 > len(data):
                     break
                 sub_flags = data[offset]
@@ -884,9 +910,8 @@ class S7CommPlusConnection:
         payload += encode_uint32_vlq(ObjectId.SERVER_SESSION_VERSION)
         # Value: ItemNumber = 1 (VLQ)
         payload += encode_uint32_vlq(1)
-        # PValue: flags=0x00, type=UDInt, VLQ-encoded value
-        payload += bytes([0x00, DataType.UDINT])
-        payload += encode_uint32_vlq(self._server_session_version)
+        # PValue: echo the ServerSessionVersion typed value verbatim (it is a Struct)
+        payload += self._server_session_version_raw
         # Fill byte
         payload += bytes([0x00])
         # ObjectQualifier
@@ -910,7 +935,7 @@ class S7CommPlusConnection:
         version, data_length, consumed = decode_header(response_frame)
         response = response_frame[consumed : consumed + data_length]
 
-        if len(response) < 14:
+        if len(response) < 10:
             from snap7.error import S7ConnectionError
 
             raise S7ConnectionError("SetupSession response too short")
@@ -918,8 +943,8 @@ class S7CommPlusConnection:
         resp_func = struct.unpack_from(">H", response, 3)[0]
         logger.debug(f"SetupSession response: function=0x{resp_func:04X}")
 
-        # Parse return value from payload
-        resp_payload = response[14:]
+        # Parse return value from payload (data responses use a 10-byte header)
+        resp_payload = response[10:]
         if len(resp_payload) >= 1:
             return_value, _ = decode_uint64_vlq(resp_payload, 0)
             if return_value != 0:

--- a/s7/connection.py
+++ b/s7/connection.py
@@ -105,7 +105,9 @@ class S7CommPlusConnection:
         )
 
         self._ssl_context: Optional[ssl.SSLContext] = None
-        self._ssl_socket: Optional[ssl.SSLSocket] = None
+        self._ssl_object: Optional[ssl.SSLObject] = None
+        self._incoming_bio: Optional[ssl.MemoryBIO] = None
+        self._outgoing_bio: Optional[ssl.MemoryBIO] = None
         self._session_id: int = 0
         self._sequence_number: int = 0
         self._protocol_version: int = 0  # Detected from PLC response
@@ -425,7 +427,9 @@ class S7CommPlusConnection:
         self._connected = False
         self._session_setup_ok = False
         self._tls_active = False
-        self._ssl_socket = None
+        self._ssl_object = None
+        self._incoming_bio = None
+        self._outgoing_bio = None
         self._oms_secret = None
         self._session_id = 0
         self._sequence_number = 0
@@ -439,16 +443,16 @@ class S7CommPlusConnection:
     def send_request(self, function_code: int, payload: bytes = b"") -> bytes:
         """Send an S7CommPlus request and receive the response.
 
-        For V2+ with IntegrityId tracking enabled, the IntegrityId is
-        appended after the 14-byte request header (as a VLQ uint32).
-        Read vs write counters are selected based on the function code.
+        For V2+ with IntegrityId tracking enabled, the IntegrityId is spliced into
+        the request payload just before its trailing fill bytes. Read vs write
+        counters are selected based on the function code.
 
         Args:
             function_code: S7CommPlus function code
             payload: Request payload (after the 14-byte request header)
 
         Returns:
-            Response payload (after the 14-byte response header)
+            Response payload (after the 10-byte response header)
         """
         if not self._connected:
             from snap7.error import S7ConnectionError
@@ -501,7 +505,7 @@ class S7CommPlusConnection:
         frame += struct.pack(">BBH", 0x72, frame_version, 0x0000)
 
         logger.debug(f"  Full frame ({len(frame)} bytes): {frame.hex(' ')}")
-        self._iso_conn.send_data(frame)
+        self._send_s7_data(frame)
 
         # Increment the appropriate IntegrityId counter after sending
         if self._with_integrity_id and self._protocol_version >= ProtocolVersion.V2:
@@ -511,7 +515,7 @@ class S7CommPlusConnection:
                 self._integrity_id_write = (self._integrity_id_write + 1) & 0xFFFFFFFF
 
         # Receive response
-        response_frame = self._iso_conn.receive_data()
+        response_frame = self._recv_s7_data()
         logger.debug(f"=== RECV RESPONSE === raw frame ({len(response_frame)} bytes): {response_frame.hex(' ')}")
 
         # Parse frame header, use data_length to exclude trailer
@@ -582,10 +586,10 @@ class S7CommPlusConnection:
         frame += struct.pack(">BBH", 0x72, ProtocolVersion.V1, 0x0000)
 
         logger.debug(f"=== InitSSL === sending ({len(frame)} bytes): {frame.hex(' ')}")
-        self._iso_conn.send_data(frame)
+        self._send_s7_data(frame)
 
         # Receive InitSSL response
-        response_frame = self._iso_conn.receive_data()
+        response_frame = self._recv_s7_data()
         logger.debug(f"=== InitSSL === received ({len(response_frame)} bytes): {response_frame.hex(' ')}")
 
         # Parse S7CommPlus frame header
@@ -670,10 +674,10 @@ class S7CommPlusConnection:
         frame += struct.pack(">BBH", 0x72, ProtocolVersion.V1, 0x0000)
 
         logger.debug(f"=== CreateObject === sending ({len(frame)} bytes): {frame.hex(' ')}")
-        self._iso_conn.send_data(frame)
+        self._send_s7_data(frame)
 
         # Receive response
-        response_frame = self._iso_conn.receive_data()
+        response_frame = self._recv_s7_data()
         logger.debug(f"=== CreateObject === received ({len(response_frame)} bytes): {response_frame.hex(' ')}")
 
         # Parse S7CommPlus frame header
@@ -926,10 +930,10 @@ class S7CommPlusConnection:
         frame += struct.pack(">BBH", 0x72, self._protocol_version, 0x0000)
 
         logger.debug(f"=== SetupSession === sending ({len(frame)} bytes): {frame.hex(' ')}")
-        self._iso_conn.send_data(frame)
+        self._send_s7_data(frame)
 
         # Receive response
-        response_frame = self._iso_conn.receive_data()
+        response_frame = self._recv_s7_data()
         logger.debug(f"=== SetupSession === received ({len(response_frame)} bytes): {response_frame.hex(' ')}")
 
         version, data_length, consumed = decode_header(response_frame)
@@ -973,11 +977,11 @@ class S7CommPlusConnection:
 
         frame = encode_header(self._protocol_version, len(request)) + request
         frame += struct.pack(">BBH", 0x72, self._protocol_version, 0x0000)
-        self._iso_conn.send_data(frame)
+        self._send_s7_data(frame)
 
         # Best-effort receive
         try:
-            self._iso_conn.receive_data()
+            self._recv_s7_data()
         except Exception:
             pass
 
@@ -987,17 +991,55 @@ class S7CommPlusConnection:
         self._sequence_number = (self._sequence_number + 1) & 0xFFFF
         return seq
 
+    def _send_s7_data(self, data: bytes) -> None:
+        """Send an S7CommPlus frame, routing through TLS when active."""
+        if self._tls_active:
+            self._ssl_object.write(data)  # type: ignore[union-attr]
+            self._tls_flush_outgoing()
+        else:
+            self._iso_conn.send_data(data)
+
+    def _recv_s7_data(self) -> bytes:
+        """Receive an S7CommPlus frame, routing through TLS when active."""
+        if self._tls_active:
+            while True:
+                try:
+                    return self._ssl_object.read(65536)  # type: ignore[union-attr]
+                except ssl.SSLWantReadError:
+                    self._tls_read_incoming()
+        else:
+            return self._iso_conn.receive_data()
+
+    def _tls_flush_outgoing(self) -> None:
+        """Send all pending TLS records through COTP framing."""
+        data = self._outgoing_bio.read()  # type: ignore[union-attr]
+        if data:
+            self._iso_conn.send_data(data)
+
+    def _tls_read_incoming(self) -> None:
+        """Read a COTP frame and feed its payload to the TLS BIO."""
+        data = self._iso_conn.receive_data()
+        self._incoming_bio.write(data)  # type: ignore[union-attr]
+
     def _activate_tls(
         self,
         tls_cert: Optional[str] = None,
         tls_key: Optional[str] = None,
         tls_ca: Optional[str] = None,
     ) -> None:
-        """Activate TLS 1.3 over the COTP connection.
+        """Activate TLS 1.3 tunneled inside COTP data frames.
 
-        Called after InitSSL and before CreateObject. Wraps the underlying
-        TCP socket with TLS and extracts the OMS exporter secret for
-        legitimation key derivation.
+        The S7CommPlus protocol transports TLS records as the payload
+        of COTP DT frames — TPKT and COTP headers stay unencrypted on
+        the wire. This differs from a standard ``ssl.wrap_socket`` call
+        which would encrypt everything (including TPKT/COTP), which
+        Siemens PLCs reject.
+
+        Uses ``ssl.MemoryBIO`` + ``ssl.SSLObject`` to encrypt/decrypt
+        without wrapping the TCP socket, keeping TPKT/COTP framing
+        intact via ``ISOTCPConnection.send_data/receive_data``.
+
+        Called after InitSSL and before CreateObject.
 
         Args:
             tls_cert: Path to client TLS certificate (PEM)
@@ -1010,29 +1052,42 @@ class S7CommPlusConnection:
             ca_path=tls_ca,
         )
 
-        # Wrap the raw TCP socket used by ISOTCPConnection
-        raw_socket = self._iso_conn.socket
-        if raw_socket is None:
-            from snap7.error import S7ConnectionError
+        # BIO-based TLS: encrypt/decrypt bytes without touching the
+        # TCP socket, so TPKT/COTP framing stays unencrypted.
+        self._incoming_bio = ssl.MemoryBIO()
+        self._outgoing_bio = ssl.MemoryBIO()
+        self._ssl_object = ctx.wrap_bio(
+            self._incoming_bio,
+            self._outgoing_bio,
+            server_side=False,
+            server_hostname=self.host if ctx.check_hostname else None,
+        )
 
-            raise S7ConnectionError("Cannot activate TLS: no TCP socket")
+        # TLS handshake — records tunnel through COTP frames
+        self._do_tls_handshake()
 
-        self._ssl_socket = ctx.wrap_socket(raw_socket, server_hostname=self.host)
-
-        # Replace the socket in ISOTCPConnection so all subsequent
-        # send_data/receive_data calls go through TLS
-        self._iso_conn.socket = self._ssl_socket
         self._tls_active = True
 
         # Extract OMS exporter secret for legitimation key derivation
         try:
-            self._oms_secret = self._ssl_socket.export_keying_material("EXPERIMENTAL_OMS", 32, None)
+            self._oms_secret = self._ssl_object.export_keying_material("EXPERIMENTAL_OMS", 32, None)
             logger.debug("OMS exporter secret extracted from TLS session")
         except (AttributeError, ssl.SSLError) as e:
             logger.warning(f"Could not extract OMS exporter secret: {e}")
             self._oms_secret = None
 
-        logger.info("TLS 1.3 activated on COTP connection")
+        logger.info("TLS 1.3 activated (tunneled inside COTP frames)")
+
+    def _do_tls_handshake(self) -> None:
+        """Perform TLS handshake, tunneling records through COTP."""
+        while True:
+            try:
+                self._ssl_object.do_handshake()  # type: ignore[union-attr]
+                break
+            except ssl.SSLWantReadError:
+                self._tls_flush_outgoing()
+                self._tls_read_incoming()
+        self._tls_flush_outgoing()
 
     def _setup_ssl_context(
         self,

--- a/tests/test_s7_tls.py
+++ b/tests/test_s7_tls.py
@@ -238,3 +238,85 @@ class TestAsyncClientV2WithTLS:
 
         assert not client.connected
         assert not client.tls_active
+
+
+class TestSyncTLSBioPlumbing:
+    """Unit tests for the sync client's MemoryBIO-based TLS-in-COTP routing.
+
+    Exercises _do_tls_handshake / _send_s7_data / _recv_s7_data / _tls_flush_outgoing /
+    _tls_read_incoming against a self-connected server SSLObject — no socket, no PLC.
+    """
+
+    def _make_connected_pair(self):
+        import ssl
+        from s7.connection import S7CommPlusConnection
+
+        cert_path, key_path = _generate_self_signed_cert()
+
+        server_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        server_ctx.load_cert_chain(cert_path, key_path)
+        server_in, server_out = ssl.MemoryBIO(), ssl.MemoryBIO()
+        server_ssl = server_ctx.wrap_bio(server_in, server_out, server_side=True)
+
+        client_ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        client_ctx.check_hostname = False
+        client_ctx.verify_mode = ssl.CERT_NONE
+
+        conn = S7CommPlusConnection("127.0.0.1", 102)
+        conn._incoming_bio = ssl.MemoryBIO()
+        conn._outgoing_bio = ssl.MemoryBIO()
+        conn._ssl_object = client_ctx.wrap_bio(conn._incoming_bio, conn._outgoing_bio)
+
+        # Loopback iso layer: ciphertext the client "sends" goes into the server's
+        # incoming BIO; bytes the client "receives" are popped from inbox.
+        class _Loop:
+            def __init__(self) -> None:
+                self.inbox: list[bytes] = []
+
+            def send_data(self, data: bytes) -> None:
+                server_in.write(data)
+
+            def receive_data(self) -> bytes:
+                return self.inbox.pop(0)
+
+        conn._iso_conn = _Loop()  # type: ignore[assignment]
+
+        # Deterministic handshake pump (mirrors the BIO mechanism without blocking I/O).
+        client_done = server_done = False
+        for _ in range(40):
+            try:
+                conn._ssl_object.do_handshake()
+                client_done = True
+            except ssl.SSLWantReadError:
+                pass
+            out = conn._outgoing_bio.read()
+            if out:
+                server_in.write(out)
+            try:
+                server_ssl.do_handshake()
+                server_done = True
+            except ssl.SSLWantReadError:
+                pass
+            out = server_out.read()
+            if out:
+                conn._incoming_bio.write(out)
+            if client_done and server_done:
+                break
+        assert client_done and server_done, "TLS handshake did not complete over MemoryBIO"
+
+        conn._tls_active = True
+        return conn, server_ssl, server_out
+
+    def test_send_routes_encrypted_through_cotp_layer(self) -> None:
+        conn, server_ssl, _server_out = self._make_connected_pair()
+        frame = struct.pack(">BBH", 0x72, 0x02, 4) + b"\xde\xad\xbe\xef"
+        conn._send_s7_data(frame)
+        # The server decrypts exactly what the client sent through the BIO plumbing.
+        assert server_ssl.read(65536) == frame
+
+    def test_recv_routes_decrypted_from_cotp_layer(self) -> None:
+        conn, server_ssl, server_out = self._make_connected_pair()
+        payload = b"\x72\x02\x00\x00pushed-frame"
+        server_ssl.write(payload)
+        conn._iso_conn.inbox.append(server_out.read())  # queue ciphertext for the client
+        assert conn._recv_s7_data() == payload

--- a/tests/test_s7_unit.py
+++ b/tests/test_s7_unit.py
@@ -314,11 +314,12 @@ class TestSkipTypedValue:
         assert new_offset == len(data)
 
     def test_struct(self, conn: S7CommPlusConnection) -> None:
-        # Struct with 2 USINT sub-values
-        vlq_count = encode_uint32_vlq(2)
-        sub1 = bytes([0x00, DataType.USINT, 0x0A])  # flags + type + value
-        sub2 = bytes([0x00, DataType.USINT, 0x14])
-        data = vlq_count + sub1 + sub2
+        # Normal-mode struct: UInt32 struct-id, then members [VLQ key][flags+type+value],
+        # terminated by a 0x00 list-terminator byte (member keys never start with 0x00).
+        struct_id = struct.pack(">I", 0x0000002A)
+        member1 = encode_uint32_vlq(1) + bytes([0x00, DataType.USINT, 0x0A])
+        member2 = encode_uint32_vlq(2) + bytes([0x00, DataType.USINT, 0x14])
+        data = struct_id + member1 + member2 + bytes([0x00])
         new_offset = conn._skip_typed_value(data, 0, DataType.STRUCT, 0x00)
         assert new_offset == len(data)
 
@@ -367,13 +368,17 @@ class TestParseCreateObjectResponse:
         conn = S7CommPlusConnection("127.0.0.1")
         payload = self._build_create_response_with_session_version(3, DataType.UDINT)
         conn._parse_create_object_response(payload)
-        assert conn._server_session_version == 3
+        # ServerSessionVersion is captured as the raw typed value (flags+datatype+value)
+        # so it can be echoed back verbatim — real S7-1500 PLCs send it as a Struct.
+        assert conn._server_session_version_raw == bytes([0x00, DataType.UDINT]) + encode_uint32_vlq(3)
+        assert conn._server_session_version == conn._server_session_version_raw
 
     def test_parse_dword_version(self) -> None:
         conn = S7CommPlusConnection("127.0.0.1")
         payload = self._build_create_response_with_session_version(2, DataType.DWORD)
         conn._parse_create_object_response(payload)
-        assert conn._server_session_version == 2
+        assert conn._server_session_version_raw == bytes([0x00, DataType.DWORD]) + encode_uint32_vlq(2)
+        assert conn._server_session_version == conn._server_session_version_raw
 
     def test_version_not_found(self) -> None:
         conn = S7CommPlusConnection("127.0.0.1")
@@ -399,7 +404,7 @@ class TestParseCreateObjectResponse:
         payload += bytes([0x00, DataType.UDINT])
         payload += encode_uint32_vlq(1)
         conn._parse_create_object_response(bytes(payload))
-        assert conn._server_session_version == 1
+        assert conn._server_session_version_raw == bytes([0x00, DataType.UDINT]) + encode_uint32_vlq(1)
 
     def test_with_start_of_object(self) -> None:
         conn = S7CommPlusConnection("127.0.0.1")
@@ -418,7 +423,7 @@ class TestParseCreateObjectResponse:
         payload += bytes([0x00, DataType.UDINT])
         payload += encode_uint32_vlq(3)
         conn._parse_create_object_response(bytes(payload))
-        assert conn._server_session_version == 3
+        assert conn._server_session_version_raw == bytes([0x00, DataType.UDINT]) + encode_uint32_vlq(3)
 
 
 # -- Client error path tests --

--- a/tests/test_s7_unit.py
+++ b/tests/test_s7_unit.py
@@ -11,7 +11,8 @@ from s7._s7commplus_client import (
     _parse_write_response,
 )
 from s7.codec import encode_pvalue_blob
-from s7.connection import S7CommPlusConnection, _element_size
+from s7.codec import _pvalue_element_size as _element_size
+from s7.codec import skip_typed_value, parse_server_session_version
 from s7.protocol import DataType, ElementID, ObjectId
 from s7.vlq import (
     encode_uint32_vlq,
@@ -201,156 +202,156 @@ class TestConnectionElementSize:
 
 
 class TestSkipTypedValue:
-    """Test S7CommPlusConnection._skip_typed_value with constructed byte buffers."""
+    """Test codec.skip_typed_value with constructed byte buffers."""
 
-    @pytest.fixture()
-    def conn(self) -> S7CommPlusConnection:
-        return S7CommPlusConnection("127.0.0.1")
+    def test_null(self) -> None:
+        assert skip_typed_value(b"", 0, DataType.NULL, 0x00) == 0
 
-    def test_null(self, conn: S7CommPlusConnection) -> None:
-        assert conn._skip_typed_value(b"", 0, DataType.NULL, 0x00) == 0
-
-    def test_bool(self, conn: S7CommPlusConnection) -> None:
+    def test_bool(self) -> None:
         data = bytes([0x01])
-        assert conn._skip_typed_value(data, 0, DataType.BOOL, 0x00) == 1
+        assert skip_typed_value(data, 0, DataType.BOOL, 0x00) == 1
 
-    def test_usint(self, conn: S7CommPlusConnection) -> None:
+    def test_usint(self) -> None:
         data = bytes([42])
-        assert conn._skip_typed_value(data, 0, DataType.USINT, 0x00) == 1
+        assert skip_typed_value(data, 0, DataType.USINT, 0x00) == 1
 
-    def test_byte(self, conn: S7CommPlusConnection) -> None:
+    def test_byte(self) -> None:
         data = bytes([0xAB])
-        assert conn._skip_typed_value(data, 0, DataType.BYTE, 0x00) == 1
+        assert skip_typed_value(data, 0, DataType.BYTE, 0x00) == 1
 
-    def test_sint(self, conn: S7CommPlusConnection) -> None:
+    def test_sint(self) -> None:
         data = bytes([0xD6])
-        assert conn._skip_typed_value(data, 0, DataType.SINT, 0x00) == 1
+        assert skip_typed_value(data, 0, DataType.SINT, 0x00) == 1
 
-    def test_uint(self, conn: S7CommPlusConnection) -> None:
+    def test_uint(self) -> None:
         data = struct.pack(">H", 1000)
-        assert conn._skip_typed_value(data, 0, DataType.UINT, 0x00) == 2
+        assert skip_typed_value(data, 0, DataType.UINT, 0x00) == 2
 
-    def test_word(self, conn: S7CommPlusConnection) -> None:
+    def test_word(self) -> None:
         data = struct.pack(">H", 0xBEEF)
-        assert conn._skip_typed_value(data, 0, DataType.WORD, 0x00) == 2
+        assert skip_typed_value(data, 0, DataType.WORD, 0x00) == 2
 
-    def test_int(self, conn: S7CommPlusConnection) -> None:
+    def test_int(self) -> None:
         data = struct.pack(">h", -1000)
-        assert conn._skip_typed_value(data, 0, DataType.INT, 0x00) == 2
+        assert skip_typed_value(data, 0, DataType.INT, 0x00) == 2
 
-    def test_udint(self, conn: S7CommPlusConnection) -> None:
+    def test_udint(self) -> None:
         vlq = encode_uint32_vlq(100000)
-        new_offset = conn._skip_typed_value(vlq, 0, DataType.UDINT, 0x00)
+        new_offset = skip_typed_value(vlq, 0, DataType.UDINT, 0x00)
         assert new_offset == len(vlq)
 
-    def test_dword(self, conn: S7CommPlusConnection) -> None:
+    def test_dword(self) -> None:
         vlq = encode_uint32_vlq(0xDEADBEEF)
-        new_offset = conn._skip_typed_value(vlq, 0, DataType.DWORD, 0x00)
+        new_offset = skip_typed_value(vlq, 0, DataType.DWORD, 0x00)
         assert new_offset == len(vlq)
 
-    def test_aid(self, conn: S7CommPlusConnection) -> None:
+    def test_aid(self) -> None:
         vlq = encode_uint32_vlq(306)
-        new_offset = conn._skip_typed_value(vlq, 0, DataType.AID, 0x00)
+        new_offset = skip_typed_value(vlq, 0, DataType.AID, 0x00)
         assert new_offset == len(vlq)
 
-    def test_dint(self, conn: S7CommPlusConnection) -> None:
+    def test_dint(self) -> None:
         vlq = encode_int32_vlq(-100000)
-        new_offset = conn._skip_typed_value(vlq, 0, DataType.DINT, 0x00)
+        new_offset = skip_typed_value(vlq, 0, DataType.DINT, 0x00)
         assert new_offset == len(vlq)
 
-    def test_ulint(self, conn: S7CommPlusConnection) -> None:
+    def test_ulint(self) -> None:
         vlq = encode_uint64_vlq(2**40)
-        new_offset = conn._skip_typed_value(vlq, 0, DataType.ULINT, 0x00)
+        new_offset = skip_typed_value(vlq, 0, DataType.ULINT, 0x00)
         assert new_offset == len(vlq)
 
-    def test_lword(self, conn: S7CommPlusConnection) -> None:
+    def test_lword(self) -> None:
         vlq = encode_uint64_vlq(0xCAFE)
-        new_offset = conn._skip_typed_value(vlq, 0, DataType.LWORD, 0x00)
+        new_offset = skip_typed_value(vlq, 0, DataType.LWORD, 0x00)
         assert new_offset == len(vlq)
 
-    def test_lint(self, conn: S7CommPlusConnection) -> None:
+    def test_lint(self) -> None:
         from s7.vlq import encode_int64_vlq
 
         vlq = encode_int64_vlq(-(2**40))
-        new_offset = conn._skip_typed_value(vlq, 0, DataType.LINT, 0x00)
+        new_offset = skip_typed_value(vlq, 0, DataType.LINT, 0x00)
         assert new_offset == len(vlq)
 
-    def test_real(self, conn: S7CommPlusConnection) -> None:
+    def test_real(self) -> None:
         data = struct.pack(">f", 3.14)
-        assert conn._skip_typed_value(data, 0, DataType.REAL, 0x00) == 4
+        assert skip_typed_value(data, 0, DataType.REAL, 0x00) == 4
 
-    def test_lreal(self, conn: S7CommPlusConnection) -> None:
+    def test_lreal(self) -> None:
         data = struct.pack(">d", 2.718)
-        assert conn._skip_typed_value(data, 0, DataType.LREAL, 0x00) == 8
+        assert skip_typed_value(data, 0, DataType.LREAL, 0x00) == 8
 
-    def test_timestamp(self, conn: S7CommPlusConnection) -> None:
+    def test_timestamp(self) -> None:
         data = struct.pack(">Q", 0x0001020304050607)
-        assert conn._skip_typed_value(data, 0, DataType.TIMESTAMP, 0x00) == 8
+        assert skip_typed_value(data, 0, DataType.TIMESTAMP, 0x00) == 8
 
-    def test_timespan(self, conn: S7CommPlusConnection) -> None:
+    def test_timespan(self) -> None:
         from s7.vlq import encode_int64_vlq
 
         vlq = encode_int64_vlq(5000)
         # TIMESPAN uses uint64_vlq for skipping in _skip_typed_value
-        new_offset = conn._skip_typed_value(vlq, 0, DataType.TIMESPAN, 0x00)
+        new_offset = skip_typed_value(vlq, 0, DataType.TIMESPAN, 0x00)
         assert new_offset == len(vlq)
 
-    def test_rid(self, conn: S7CommPlusConnection) -> None:
+    def test_rid(self) -> None:
         data = struct.pack(">I", 0x12345678)
-        assert conn._skip_typed_value(data, 0, DataType.RID, 0x00) == 4
+        assert skip_typed_value(data, 0, DataType.RID, 0x00) == 4
 
-    def test_blob(self, conn: S7CommPlusConnection) -> None:
+    def test_blob(self) -> None:
         blob_data = bytes([1, 2, 3, 4])
         vlq_len = encode_uint32_vlq(len(blob_data))
         data = vlq_len + blob_data
-        new_offset = conn._skip_typed_value(data, 0, DataType.BLOB, 0x00)
+        new_offset = skip_typed_value(data, 0, DataType.BLOB, 0x00)
         assert new_offset == len(data)
 
-    def test_wstring(self, conn: S7CommPlusConnection) -> None:
+    def test_wstring(self) -> None:
         text = "hello".encode("utf-8")
         vlq_len = encode_uint32_vlq(len(text))
         data = vlq_len + text
-        new_offset = conn._skip_typed_value(data, 0, DataType.WSTRING, 0x00)
+        new_offset = skip_typed_value(data, 0, DataType.WSTRING, 0x00)
         assert new_offset == len(data)
 
-    def test_struct(self, conn: S7CommPlusConnection) -> None:
+    def test_struct(self) -> None:
         # Normal-mode struct: UInt32 struct-id, then members [VLQ key][flags+type+value],
         # terminated by a 0x00 list-terminator byte (member keys never start with 0x00).
         struct_id = struct.pack(">I", 0x0000002A)
         member1 = encode_uint32_vlq(1) + bytes([0x00, DataType.USINT, 0x0A])
         member2 = encode_uint32_vlq(2) + bytes([0x00, DataType.USINT, 0x14])
         data = struct_id + member1 + member2 + bytes([0x00])
-        new_offset = conn._skip_typed_value(data, 0, DataType.STRUCT, 0x00)
+        new_offset = skip_typed_value(data, 0, DataType.STRUCT, 0x00)
         assert new_offset == len(data)
 
-    def test_unknown_type(self, conn: S7CommPlusConnection) -> None:
+    def test_unknown_type(self) -> None:
         # Unknown type should return same offset (can't skip)
-        assert conn._skip_typed_value(bytes([0xFF]), 0, 0xFF, 0x00) == 0
+        assert skip_typed_value(bytes([0xFF]), 0, 0xFF, 0x00) == 0
 
     # -- Array tests --
 
-    def test_array_fixed_size(self, conn: S7CommPlusConnection) -> None:
+    def test_array_fixed_size(self) -> None:
         count_vlq = encode_uint32_vlq(3)
         elements = bytes([10, 20, 30])
         data = count_vlq + elements
-        new_offset = conn._skip_typed_value(data, 0, DataType.USINT, 0x10)
+        new_offset = skip_typed_value(data, 0, DataType.USINT, 0x10)
         assert new_offset == len(data)
 
-    def test_array_variable_length(self, conn: S7CommPlusConnection) -> None:
+    def test_array_variable_length(self) -> None:
         count_vlq = encode_uint32_vlq(2)
         elem1 = encode_uint32_vlq(100)
         elem2 = encode_uint32_vlq(200)
         data = count_vlq + elem1 + elem2
-        new_offset = conn._skip_typed_value(data, 0, DataType.UDINT, 0x10)
+        new_offset = skip_typed_value(data, 0, DataType.UDINT, 0x10)
         assert new_offset == len(data)
 
-    def test_array_empty_data(self, conn: S7CommPlusConnection) -> None:
+    def test_array_empty_data(self) -> None:
         # Edge case: array flag but no data
-        assert conn._skip_typed_value(b"", 0, DataType.USINT, 0x10) == 0
+        assert skip_typed_value(b"", 0, DataType.USINT, 0x10) == 0
 
 
 class TestParseCreateObjectResponse:
-    """Test _parse_create_object_response with constructed payloads."""
+    """Test parse_server_session_version with constructed payloads.
+
+    Returns the raw typed value (flags + datatype + value) to echo back verbatim —
+    real S7-1500 PLCs send ServerSessionVersion as a Struct — or None if absent.
+    """
 
     def _build_create_response_with_session_version(self, version: int, datatype: int = DataType.UDINT) -> bytes:
         """Build a minimal CreateObject response containing ServerSessionVersion."""
@@ -365,33 +366,24 @@ class TestParseCreateObjectResponse:
         return bytes(payload)
 
     def test_parse_udint_version(self) -> None:
-        conn = S7CommPlusConnection("127.0.0.1")
         payload = self._build_create_response_with_session_version(3, DataType.UDINT)
-        conn._parse_create_object_response(payload)
-        # ServerSessionVersion is captured as the raw typed value (flags+datatype+value)
-        # so it can be echoed back verbatim — real S7-1500 PLCs send it as a Struct.
-        assert conn._server_session_version_raw == bytes([0x00, DataType.UDINT]) + encode_uint32_vlq(3)
-        assert conn._server_session_version == conn._server_session_version_raw
+        result = parse_server_session_version(payload)
+        assert result == bytes([0x00, DataType.UDINT]) + encode_uint32_vlq(3)
 
     def test_parse_dword_version(self) -> None:
-        conn = S7CommPlusConnection("127.0.0.1")
         payload = self._build_create_response_with_session_version(2, DataType.DWORD)
-        conn._parse_create_object_response(payload)
-        assert conn._server_session_version_raw == bytes([0x00, DataType.DWORD]) + encode_uint32_vlq(2)
-        assert conn._server_session_version == conn._server_session_version_raw
+        result = parse_server_session_version(payload)
+        assert result == bytes([0x00, DataType.DWORD]) + encode_uint32_vlq(2)
 
     def test_version_not_found(self) -> None:
-        conn = S7CommPlusConnection("127.0.0.1")
         # Build payload with a different attribute, not ServerSessionVersion
         payload = bytearray()
         payload += bytes([ElementID.ATTRIBUTE])
         payload += encode_uint32_vlq(999)  # Some other attribute ID
         payload += bytes([0x00, DataType.USINT, 42])
-        conn._parse_create_object_response(bytes(payload))
-        assert conn._server_session_version is None
+        assert parse_server_session_version(bytes(payload)) is None
 
     def test_with_preceding_attributes(self) -> None:
-        conn = S7CommPlusConnection("127.0.0.1")
         payload = bytearray()
         # First attribute: some random one with a UINT value
         payload += bytes([ElementID.ATTRIBUTE])
@@ -403,11 +395,10 @@ class TestParseCreateObjectResponse:
         payload += encode_uint32_vlq(ObjectId.SERVER_SESSION_VERSION)
         payload += bytes([0x00, DataType.UDINT])
         payload += encode_uint32_vlq(1)
-        conn._parse_create_object_response(bytes(payload))
-        assert conn._server_session_version_raw == bytes([0x00, DataType.UDINT]) + encode_uint32_vlq(1)
+        result = parse_server_session_version(bytes(payload))
+        assert result == bytes([0x00, DataType.UDINT]) + encode_uint32_vlq(1)
 
     def test_with_start_of_object(self) -> None:
-        conn = S7CommPlusConnection("127.0.0.1")
         payload = bytearray()
         # StartOfObject tag (needs RelationId + ClassId + ClassFlags + AttributeId)
         payload += bytes([ElementID.START_OF_OBJECT])
@@ -422,8 +413,8 @@ class TestParseCreateObjectResponse:
         payload += encode_uint32_vlq(ObjectId.SERVER_SESSION_VERSION)
         payload += bytes([0x00, DataType.UDINT])
         payload += encode_uint32_vlq(3)
-        conn._parse_create_object_response(bytes(payload))
-        assert conn._server_session_version_raw == bytes([0x00, DataType.UDINT]) + encode_uint32_vlq(3)
+        result = parse_server_session_version(bytes(payload))
+        assert result == bytes([0x00, DataType.UDINT]) + encode_uint32_vlq(3)
 
 
 # -- Client error path tests --


### PR DESCRIPTION
## Summary
The S7CommPlus V2 path (symbolic LID access, `GetMultiVariables`, session setup, TLS) shipped on `master` but had never been exercised against real hardware. Validated against a TIA V17 S7-1500, several things were wrong — and because the bundled emulator (`_s7commplus_server.py`) shared the same assumptions, the client↔server round-trip tests passed without being correct. Two related commits:

### 1. Correct the V2 wire format (sync + async clients + emulator)
- **Response header is 10 bytes, not 14** — responses carry no `SessionId` field (requests do, hence their 14-byte header). We were stripping 14, corrupting every parsed payload and rejecting short (e.g. write) responses as "too short".
- **Session id is `ObjectIds[0]`** from the `CreateObject` response body, not the header `SessionId`.
- **`ServerSessionVersion` is a `Struct` (0x17)** on real PLCs, not a scalar `UDInt`: capture its raw typed value and echo it back verbatim during session setup.
- **`IntegrityId` (V2+) travels at the end** of the request payload (just before the trailing `UInt32`), not after the header.
- **`GetMultiVariables` uses transport flag `0x34`** (reads); `0x36` otherwise.
- **Normal-mode struct skip**: `UInt32` struct-id + `[VLQ key][typed value]` members, terminated by a `0` byte (was assuming a VLQ element count).
- The emulator was corrected to speak the same wire format, so the round-trip tests validate the corrected protocol instead of a shared mistake.

### 2. Tunnel TLS inside COTP (async client + emulator)
The async client activated TLS with `loop.start_tls`, which encrypts the whole TCP stream — including the TPKT/COTP headers — so a real S7-1500 (which carries TLS records as the *payload* of COTP DT frames) drops the connection; the demo server had the matching problem (`ssl.wrap_socket`). Both are switched to `ssl.MemoryBIO` + `SSLObject`, mirroring the sync `S7CommPlusConnection`'s COTP-tunneled TLS: handshake and records travel through COTP DT frames, TPKT/COTP stay unencrypted. The async client also now exposes the OMS exporter secret (needed for password legitimation).

## Test plan
- [x] `pytest tests/` — all green (previously 25 of these failed: the emulator and unit fixtures encoded the old, wrong assumptions; both corrected here). `ruff check` / `ruff format --check` clean.
- [x] Live, **sync**: `read_tag` returns correct typed scalar values, `read_tags` batching, and `explore()` against a real S7-1500 over TLS.
- [x] Live, **async**: `connect(use_tls=True)` reaches `V2` with `session_setup_ok=True`, then `explore()` + symbolic/struct reads — same results as the sync client.

> On OpenSSL ≥ 3.5 the TLS handshake against a real PLC also needs the classic-group restriction in #746.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
