### PR TITLE
fix(s7commplus): restrict TLS groups in-code so the handshake works on OpenSSL >= 3.5

### DIFF
--- a/s7/_s7commplus_async_client.py
+++ b/s7/_s7commplus_async_client.py
@@ -26,6 +26,7 @@ from .protocol import (
 )
 from .codec import encode_header, decode_header, encode_typed_value, encode_object_qualifier
 from .vlq import encode_uint32_vlq, decode_uint32_vlq, decode_uint64_vlq
+from .connection import _restrict_tls_groups
 from ._s7commplus_client import (
     _build_read_payload,
     _parse_read_response,
@@ -231,6 +232,8 @@ class S7CommPlusAsyncClient:
 
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+        # Restrict to classic ECDHE groups; PLCs reject OpenSSL >= 3.5's PQ-hybrid default.
+        _restrict_tls_groups(ctx)
 
         if hasattr(ctx, "set_ciphersuites"):
             ctx.set_ciphersuites("TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256")

--- a/s7/connection.py
+++ b/s7/connection.py
@@ -38,9 +38,12 @@ Version-specific authentication after step 6::
 Reference: thomas-v2/S7CommPlusDriver (C#, LGPL-3.0)
 """
 
+import ctypes
+import ctypes.util
 import logging
 import ssl
 import struct
+import sys
 from typing import Optional, Type
 from types import TracebackType
 
@@ -60,6 +63,45 @@ from .vlq import encode_uint32_vlq, decode_uint32_vlq, decode_uint64_vlq
 from .protocol import DataType
 
 logger = logging.getLogger(__name__)
+
+# Classic ECDHE groups every S7-1200/1500 supports. OpenSSL >= 3.5 advertises a
+# post-quantum hybrid (X25519MLKEM768) by default, whose large ClientHello key_share
+# the PLCs reject (the connection is dropped during the handshake). We restrict the
+# PLC TLS context to these classic groups.
+_DEFAULT_TLS_GROUPS = "x25519:secp256r1:secp384r1"
+
+# OpenSSL control code for SSL_CTX_set1_groups_list (openssl/ssl.h: SSL_CTRL_SET_GROUPS_LIST).
+_SSL_CTRL_SET_GROUPS_LIST = 92
+
+
+def _restrict_tls_groups(ctx: ssl.SSLContext, groups: str = _DEFAULT_TLS_GROUPS) -> bool:
+    """Restrict the TLS key-exchange groups of ``ctx`` to ``groups`` (a colon list).
+
+    Python's ``ssl`` module exposes no API for the TLS 1.3 supported_groups list, so we
+    call OpenSSL's ``SSL_CTX_set1_groups_list`` through ctypes, reaching the ``SSL_CTX *``
+    stored as the first member of CPython's ``PySSLContext`` (right after ``PyObject_HEAD``).
+
+    Best-effort: returns ``True`` on success, or ``False`` (leaving OpenSSL's defaults) on
+    an unexpected interpreter layout or any failure.
+    """
+    if sys.implementation.name != "cpython" or ctypes.sizeof(ctypes.c_void_p) != 8:
+        return False
+    try:
+        libssl = ctypes.CDLL(ctypes.util.find_library("ssl") or "libssl.so")
+        libssl.SSL_CTX_ctrl.restype = ctypes.c_long
+        libssl.SSL_CTX_ctrl.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_long, ctypes.c_char_p]
+        # PySSLContext layout: PyObject_HEAD (16 bytes on 64-bit CPython) then `SSL_CTX *ctx`.
+        ssl_ctx = ctypes.c_void_p.from_address(id(ctx) + 16).value
+        if not ssl_ctx:
+            return False
+        rc = libssl.SSL_CTX_ctrl(ssl_ctx, _SSL_CTRL_SET_GROUPS_LIST, 0, groups.encode("ascii"))
+        if rc == 1:
+            logger.debug(f"TLS groups restricted to: {groups}")
+            return True
+        return False
+    except Exception as e:  # pragma: no cover - platform-dependent fallback
+        logger.debug(f"Could not restrict TLS groups in-code: {e}")
+        return False
 
 
 def _element_size(datatype: int) -> int:
@@ -1082,6 +1124,8 @@ class S7CommPlusConnection:
         """
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ctx.minimum_version = ssl.TLSVersion.TLSv1_3
+        # Restrict to classic ECDHE groups; PLCs reject OpenSSL >= 3.5's PQ-hybrid default.
+        _restrict_tls_groups(ctx)
 
         # TLS 1.3 ciphersuites are configured differently from TLS 1.2
         if hasattr(ctx, "set_ciphersuites"):

--- a/tests/test_s7_unit.py
+++ b/tests/test_s7_unit.py
@@ -11,7 +11,7 @@ from s7._s7commplus_client import (
     _parse_write_response,
 )
 from s7.codec import encode_pvalue_blob
-from s7.connection import S7CommPlusConnection, _element_size
+from s7.connection import S7CommPlusConnection, _element_size, _restrict_tls_groups
 from s7.protocol import DataType, ElementID, ObjectId
 from s7.vlq import (
     encode_uint32_vlq,
@@ -457,3 +457,32 @@ class TestClientErrorPaths:
         with S7CommPlusClient() as client:
             assert client.connected is False
         # Should not raise
+
+
+class TestRestrictTlsGroups:
+    """Test the in-code TLS supported_groups restriction."""
+
+    def test_restrict_classic_groups(self) -> None:
+        import ssl
+        import sys
+
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        result = _restrict_tls_groups(ctx, "x25519:secp256r1:secp384r1")
+        # On CPython 64-bit the OpenSSL ctrl succeeds; elsewhere it falls back to False.
+        if sys.implementation.name == "cpython" and ctypes_pointer_size_is_8():
+            assert result is True
+        # The context must remain usable regardless of the outcome.
+        assert ctx.wrap_bio(ssl.MemoryBIO(), ssl.MemoryBIO(), server_side=False) is not None
+
+    def test_restrict_invalid_groups_returns_false(self) -> None:
+        import ssl
+
+        ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        # A bogus group name makes SSL_CTX_set1_groups_list fail -> best-effort False.
+        assert _restrict_tls_groups(ctx, "not_a_real_group") is False
+
+
+def ctypes_pointer_size_is_8() -> bool:
+    import ctypes
+
+    return ctypes.sizeof(ctypes.c_void_p) == 8


### PR DESCRIPTION
## Summary
Builds on the COTP-tunneled TLS work in this branch. On OpenSSL 3.5+ (e.g. Debian 13) the default `supported_groups` advertise a post-quantum hybrid (`X25519MLKEM768`) whose ~1.2 KB ClientHello `key_share` the S7-1500 rejects — it drops the connection mid-handshake. Connecting otherwise requires an external `OPENSSL_CONF` restricting `Groups`, which is awkward to ship.

- Python's `ssl` module exposes no API for the TLS 1.3 `supported_groups` list, and `set_ecdh_curve` only affects the legacy (≤ TLS 1.2) temp-ECDH key.
- So we call OpenSSL's `SSL_CTX_set1_groups_list` via `ctypes`, reaching the `SSL_CTX *` stored as the first member of CPython's `PySSLContext`.
- The PLC TLS context (sync + async) is restricted to classic ECDHE groups (`x25519:secp256r1:secp384r1`), which every S7-1200/1500 supports.
- Best-effort: falls back to OpenSSL's defaults on an unexpected interpreter layout (non-CPython, 32-bit) or any failure.

## Why
Without this, `connect(use_tls=True)` fails during the TLS handshake on any host with OpenSSL ≥ 3.5 unless the user sets `OPENSSL_CONF` out of band.

## Test plan
- [x] New unit tests (`TestRestrictTlsGroups`): the OpenSSL ctrl succeeds on CPython 64-bit; a bogus group name falls back to `False`; the context stays usable either way.
- [x] `pytest tests/` + `ruff check` / `ruff format --check` — clean.
- [x] Live: against a TIA V17 S7-1500 the TLS 1.3 handshake now completes with **no** `OPENSSL_CONF` set (`tls_active=True`).

> Note: this targets `fix-tls-layering` since it depends on the COTP-tunneled TLS handshake from that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
