### PR TITLE
fix: use correct sub_area (3736) for I/Q/M controller-area symbolic access

### DIFF
--- a/s7/protocol.py
+++ b/s7/protocol.py
@@ -152,7 +152,11 @@ class Ids(IntEnum):
 
     # Data block access sub-areas
     DB_VALUE_ACTUAL = 2550
-    CONTROLLER_AREA_VALUE_ACTUAL = 2551
+    # Symbolic (LID-based) access to controller areas (I/Q/M). The previous value
+    # 2551 was wrong: 2551 is DB_InitialChanged, not a controller-area sub-area, so
+    # the PLC rejected every I/Q/M symbolic read/write. ControllerArea_ValueActual
+    # is 3736 (0xE98). Ref: thomas-v2/S7CommPlusDriver/Core/Ids.cs.
+    CONTROLLER_AREA_VALUE_ACTUAL = 3736
 
     # ObjectQualifier structure IDs
     OBJECT_QUALIFIER = 1256

--- a/tests/test_s7_codec.py
+++ b/tests/test_s7_codec.py
@@ -37,6 +37,7 @@ from s7.codec import (
 )
 from s7.protocol import PROTOCOL_ID, DataType, Opcode, FunctionCode, Ids
 from s7.vlq import encode_uint32_vlq, encode_int32_vlq, encode_uint64_vlq, encode_int64_vlq
+from s7._s7commplus_client import _build_symbolic_read_payload, _build_symbolic_write_payload
 
 
 class TestFrameHeader:
@@ -355,6 +356,35 @@ class TestItemAddress:
         # First bytes should be VLQ(0x1234) which is non-zero
         assert addr_bytes[0] != 0
         assert field_count == 4
+
+
+class TestControllerAreaSubArea:
+    """Regression: I/Q/M symbolic access must use ControllerArea_ValueActual (3736).
+
+    The earlier value 2551 was DB_InitialChanged, not a controller-area sub-area,
+    so the PLC rejected every I/Q/M symbolic read/write.
+    """
+
+    # IArea/QArea/MArea native-object RIDs (all < 0x8A0E0000 → controller-area path)
+    IAREA_RID = 0x50
+
+    def test_constant_value(self) -> None:
+        assert Ids.CONTROLLER_AREA_VALUE_ACTUAL == 3736
+        assert Ids.CONTROLLER_AREA_VALUE_ACTUAL != Ids.DB_VALUE_ACTUAL
+
+    def test_read_payload_uses_controller_sub_area(self) -> None:
+        payload = _build_symbolic_read_payload(self.IAREA_RID, lids=[0x124])
+        assert encode_uint32_vlq(3736) in payload
+        assert encode_uint32_vlq(2551) not in payload
+
+    def test_write_payload_uses_controller_sub_area(self) -> None:
+        payload = _build_symbolic_write_payload(self.IAREA_RID, lids=[0x124], data=b"\x01")
+        assert encode_uint32_vlq(3736) in payload
+        assert encode_uint32_vlq(2551) not in payload
+
+    def test_db_area_still_uses_db_sub_area(self) -> None:
+        payload = _build_symbolic_read_payload(0x8A0E012C, lids=[0x4E, 0x69])
+        assert encode_uint32_vlq(Ids.DB_VALUE_ACTUAL) in payload
 
 
 class TestPValueBlob:


### PR DESCRIPTION
Fixes #736.

## Problem
Symbolic (LID-based) read/write to controller areas (I/Q/M) is rejected by the PLC
(read → item `ReturnValue` error → `RuntimeError("Symbolic read failed")`; write → `0x4D0013`),
while DB symbolic access works.

## Root cause
`Ids.CONTROLLER_AREA_VALUE_ACTUAL` is `2551`, but `2551` is `DB_InitialChanged`, not a
controller-area sub-area. The correct `ControllerArea_ValueActual` is **3736** (`0xE98`).
Both `_build_symbolic_read_payload` and `_build_symbolic_write_payload` select this constant
for `access_area < 0x8A0E0000`, so correcting the single constant fixes both paths.

Ref: `thomas-v2/S7CommPlusDriver/Core/Ids.cs` (`DB_ValueActual=2550`, `DB_InitialChanged=2551`,
`ControllerArea_ValueActual=3736`).

## Verified on hardware
In addition to the S7-1200 write-path finding in #736, this was confirmed independently on a real
**S7-1500 (CPU 1507S F soft-controller, FW V2.x) over TLS**, **read path**: with the fix, I/Q/M
symbolic reads succeed (Bool/Int/Word/Byte), with values matching an independent C# S7CommPlusDriver
symbol dump of the same CPU. With `2551` the identical reads fail.

## Tests
Adds `TestControllerAreaSubArea` to `tests/test_s7_codec.py`: pins the constant to 3736 and asserts
the read/write payload builders emit sub_area 3736 for controller areas and 2550 for DBs.