### PR TITLE
fix: use connection_type in TSAP composition during connect

### DIFF
--- a/snap7/async_client.py
+++ b/snap7/async_client.py
@@ -394,7 +394,7 @@ class AsyncClient(ClientMixin):
         self.slot = slot
         self._params[Parameter.RemotePort] = tcp_port
 
-        self.remote_tsap = 0x0100 | (rack << 5) | slot
+        self.remote_tsap = (self.connection_type << 8) | (rack << 5) | slot
 
         try:
             start_time = time.time()

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -582,7 +582,7 @@ class Client(ClientMixin):
 
         # Calculate TSAP values from rack/slot
         # Remote TSAP: rack and slot encoded as per S7 specification
-        self.remote_tsap = 0x0100 | (rack << 5) | slot
+        self.remote_tsap = (self.connection_type << 8) | (rack << 5) | slot
 
         try:
             start_time = time.time()
@@ -659,7 +659,7 @@ class Client(ClientMixin):
         self._params[Parameter.RemotePort] = port
 
         # Remote TSAP targets the gateway rack/slot
-        self.remote_tsap = 0x0100 | (router_rack << 5) | router_slot
+        self.remote_tsap = (self.connection_type << 8) | (router_rack << 5) | router_slot
 
         try:
             start_time = time.time()


### PR DESCRIPTION
## Summary

- The remote TSAP high byte was hardcoded to `0x01` (PG) in `connect()` and `connect_to()`, ignoring the value set via `set_connection_type()`. This broke PG/OP/S7Basic coexistence on real PLCs where multi-client separation depends on the connection type byte in the called TSAP.
- Fixed in sync client (`snap7/client.py`), async client (`snap7/async_client.py`), and the routing path (`connect_to`).

Fixes #765

## Test plan

- [ ] Verify with a real PLC that `set_connection_type(2)` (OP) allows concurrent PG connections
- [ ] Verify default behavior (connection_type=1, PG) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)