### PR TITLE
fix: auto-reconnect not triggered on multi-block read path

### DIFF
--- a/snap7/client.py
+++ b/snap7/client.py
@@ -1292,8 +1292,13 @@ class Client(ClientMixin):
 
     def _execute_packets_sequential(self, packet_requests: list[Tuple[int, bytes, ReadPacket]]) -> None:
         """Execute multi-block packets one at a time."""
-        for _, request, packet in packet_requests:
-            response = self._send_receive(request)
+        for _, _request, packet in packet_requests:
+            block_specs = [(blk.area, blk.db_number, blk.start_offset, blk.byte_length) for blk in packet.blocks]
+
+            def build_request(specs: list[tuple[int, int, int, int]] = block_specs) -> bytes:
+                return self.protocol.build_multi_read_request(specs)
+
+            response = self._send_receive_with_reconnect(build_request)
             block_data_list = self.protocol.extract_multi_read_data(response, len(packet.blocks))
             for blk, buf in zip(packet.blocks, block_data_list):
                 blk.buffer = buf
@@ -1302,9 +1307,20 @@ class Client(ClientMixin):
         """Execute multi-block packets using parallel dispatch.
 
         Sends up to *max_parallel* PDUs back-to-back before reading
-        responses, reducing round-trip overhead.
+        responses, reducing round-trip overhead.  Falls back to
+        sequential reconnect-aware execution on connection loss.
         """
-        # Process in chunks of max_parallel
+        try:
+            self._execute_packets_parallel_inner(packet_requests)
+        except (S7ConnectionError, OSError) as e:
+            if not self._auto_reconnect:
+                raise
+            logger.warning(f"Connection lost during parallel read: {e}")
+            self._do_reconnect()
+            self._execute_packets_sequential(packet_requests)
+
+    def _execute_packets_parallel_inner(self, packet_requests: list[Tuple[int, bytes, ReadPacket]]) -> None:
+        """Inner parallel dispatch without reconnect handling."""
         for chunk_start in range(0, len(packet_requests), self.max_parallel):
             chunk = packet_requests[chunk_start : chunk_start + self.max_parallel]
             requests = [(pkt_idx, pdu) for pkt_idx, pdu, _ in chunk]

--- a/tests/test_reconnect.py
+++ b/tests/test_reconnect.py
@@ -10,7 +10,8 @@ import pytest
 from snap7.client import Client
 from snap7.error import S7ConnectionError
 from snap7.server import Server
-from snap7.type import SrvArea
+from snap7.tags import Tag
+from snap7.type import Area, SrvArea
 
 logging.basicConfig(level=logging.WARNING)
 
@@ -149,6 +150,26 @@ class TestAutoReconnect(unittest.TestCase):
             # Verify the data was written after reconnection
             data = client.db_read(db_number, 0, 4)
             assert data == bytearray([5, 6, 7, 8])
+        finally:
+            client.disconnect()
+
+    def test_reconnect_on_multi_block_read(self) -> None:
+        """Client reconnects when connection drops during multi-block sequential read."""
+        client = Client(auto_reconnect=True, max_retries=3, retry_delay=0.1)
+        client.connect(ip, rack, slot, tcpport)
+
+        try:
+            tags = [Tag(Area.DB, db_number, i * 2, "INT") for i in range(20)]
+            data = client.read_tags(tags)
+            assert len(data) == 20
+
+            if client.connection and client.connection.socket:
+                client.connection.socket.close()
+            client.connected = False
+
+            data = client.read_tags(tags)
+            assert len(data) == 20
+            assert client.connected is True
         finally:
             client.disconnect()
 


### PR DESCRIPTION
## Summary
- `_execute_packets_sequential` now uses `_send_receive_with_reconnect()` instead of `_send_receive()`, so multi-block reads trigger auto-reconnect on connection loss
- `_execute_packets_parallel` catches connection errors and falls back to sequential reconnect-aware execution after re-establishing the connection

## Root cause
When `read_tags()` batched many variables into multi-block packets, the optimized execution path bypassed `_send_receive_with_reconnect()`. Auto-reconnect only worked for the single-block path (few tags), silently failing for multi-block reads (many tags in production).

## Test plan
- [ ] Verify existing tests pass (`pytest tests/`)
- [ ] Verify mypy, ruff, and pre-commit all pass
- [ ] Manual test: connect with `auto_reconnect=True`, read 15+ tags via `read_tags()`, drop PLC connection, confirm reconnect fires

Closes #785

🤖 Generated with [Claude Code](https://claude.com/claude-code)