### PR TITLE
feat: S7CommPlus async client feature parity (#797)

### DIFF
--- a/s7commplus/async_client.py
+++ b/s7commplus/async_client.py
@@ -26,6 +26,7 @@ from .codec import (
     decode_header,
     encode_typed_value,
     encode_object_qualifier,
+    encode_pvalue_blob,
     parse_create_object_session_id,
     parse_server_session_version,
 )
@@ -39,10 +40,12 @@ from .client import (
     _build_area_read_payload,
     _build_area_write_payload,
     _build_symbolic_read_payload,
+    _build_symbolic_write_payload,
     _build_explore_payload,
     _build_invoke_payload,
     _build_explore_request,
     _parse_explore_datablocks,
+    _build_subscription_request,
 )
 from . import typeinfo
 from .protocol import Ids
@@ -504,6 +507,96 @@ class S7CommPlusAsyncClient:
         payload = _build_invoke_payload(state)
         await self._send_request(FunctionCode.INVOKE, payload)
 
+    async def get_cpu_state(self) -> str:
+        """Get PLC CPU operating state via S7CommPlus.
+
+        .. warning:: This method is **experimental** and may change.
+
+        Returns:
+            One of ``"RUN"``, ``"STOP"``, or ``"UNKNOWN"``.
+        """
+        payload = _build_explore_request(Ids.NATIVE_THE_CPU_EXEC_UNIT_RID, [])
+        response = await self._send_request(FunctionCode.EXPLORE, payload, integrity_tail=5, reassemble=True)
+        return "RUN" if response else "UNKNOWN"
+
+    async def upload_block(self, block_type: int, block_number: int) -> bytes:
+        """Upload (read) a program block from the PLC.
+
+        .. warning:: This method is **experimental** and may change.
+
+        Args:
+            block_type: Block type (e.g. 0x08 for DB, 0x0C for FC).
+            block_number: Block number.
+
+        Returns:
+            Raw block data.
+        """
+        payload = bytearray()
+        payload += struct.pack(">I", self._session_id)
+        payload += encode_uint32_vlq(1)  # item count
+        payload += encode_uint32_vlq(1)  # field count
+        payload += encode_uint32_vlq(block_type)
+        payload += encode_uint32_vlq(block_number)
+        payload += struct.pack(">I", 0)
+
+        response = await self._send_request(FunctionCode.GET_VAR_SUBSTREAMED, bytes(payload))
+        # Skip return code VLQ
+        offset = 0
+        _, consumed = decode_uint32_vlq(response, offset)
+        offset += consumed
+        return response[offset:]
+
+    async def download_block(self, block_type: int, block_number: int, data: bytes) -> None:
+        """Download (write) a program block to the PLC.
+
+        .. warning:: This method is **experimental** and may change.
+
+        Args:
+            block_type: Block type.
+            block_number: Block number.
+            data: Raw block data to write.
+        """
+        payload = bytearray()
+        payload += struct.pack(">I", self._session_id)
+        payload += encode_uint32_vlq(1)
+        payload += encode_uint32_vlq(block_type)
+        payload += encode_uint32_vlq(block_number)
+        payload += encode_pvalue_blob(data)
+        payload += struct.pack(">I", 0)
+
+        await self._send_request(FunctionCode.SET_VAR_SUBSTREAMED, bytes(payload))
+
+    async def create_subscription(self, items: list[tuple[int, int, int]], cycle_ms: int = 0) -> int:
+        """Create a data change subscription.
+
+        .. warning:: This method is **experimental** and may change.
+
+        Args:
+            items: List of (db_number, start_offset, size) tuples to monitor.
+            cycle_ms: Cycle time in milliseconds (0 = on change).
+
+        Returns:
+            Subscription object ID assigned by the PLC.
+        """
+        payload = _build_subscription_request(items, cycle_ms, self._session_id)
+        response = await self._send_request(FunctionCode.CREATE_OBJECT, payload)
+
+        sub_id, consumed = decode_uint32_vlq(response, 0)
+        logger.info(f"Subscription created, id={sub_id:#x}")
+        return sub_id
+
+    async def delete_subscription(self, subscription_id: int) -> None:
+        """Delete a data change subscription.
+
+        .. warning:: This method is **experimental** and may change.
+
+        Args:
+            subscription_id: ID returned by :meth:`create_subscription`.
+        """
+        payload = struct.pack(">I", subscription_id) + struct.pack(">I", 0)
+        await self._send_request(FunctionCode.DELETE_OBJECT, payload)
+        logger.info(f"Subscription {subscription_id:#x} deleted")
+
     async def read_symbolic(self, access_area: int, lids: list[int], symbol_crc: int = 0) -> bytes:
         """Read a variable using S7CommPlus symbolic (LID-based) access.
 
@@ -516,6 +609,15 @@ class S7CommPlusAsyncClient:
         if not results or results[0] is None:
             raise RuntimeError("Symbolic read failed")
         return results[0]
+
+    async def write_symbolic(self, access_area: int, lids: list[int], data: bytes, symbol_crc: int = 0) -> None:
+        """Write a variable using S7CommPlus symbolic (LID-based) access.
+
+        .. warning:: This method is **experimental** and may change.
+        """
+        payload = _build_symbolic_write_payload(access_area, lids, data, symbol_crc)
+        response = await self._send_request(FunctionCode.SET_MULTI_VARIABLES, payload)
+        _parse_write_response(response)
 
     async def list_datablocks(self) -> list[dict[str, Any]]:
         """List all datablocks on the PLC via EXPLORE.

--- a/tests/test_s7_server.py
+++ b/tests/test_s7_server.py
@@ -324,6 +324,39 @@ class TestAsyncClientServerIntegration:
             for r in results:
                 assert isinstance(r, float)
 
+    async def test_write_symbolic(self, server: S7CommPlusServer) -> None:
+        """Test write_symbolic sends a SetMultiVariables request."""
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+            # Write 4 bytes to DB1 via symbolic access (access_area for DB1)
+            access_area = 0x8A0E0001
+            await client.write_symbolic(access_area, [1, 4], struct.pack(">f", 55.5))
+            # Read back via db_read to verify
+            data = await client.db_read(1, 0, 4)
+            value = struct.unpack(">f", data)[0]
+            assert abs(value - 55.5) < 0.1
+
+    async def test_get_cpu_state(self, server: S7CommPlusServer) -> None:
+        """Test get_cpu_state returns a valid state string."""
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+            state = await client.get_cpu_state()
+            assert state in ("RUN", "STOP", "UNKNOWN")
+
+    async def test_set_plc_operating_state(self, server: S7CommPlusServer) -> None:
+        """Test set_plc_operating_state sends an INVOKE request."""
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+            # state 1 = STOP — the emulated server accepts INVOKE requests
+            await client.set_plc_operating_state(1)
+
+    async def test_explore_xml(self, server: S7CommPlusServer) -> None:
+        """Test explore_xml returns None on emulated server (no zlib blobs)."""
+        async with S7CommPlusAsyncClient() as client:
+            await client.connect("127.0.0.1", port=TEST_PORT)
+            result = await client.explore_xml()
+            assert result is None
+
 
 class TestSessionKeyServer:
     """Test the server's SessionKey handshake emulation."""


### PR DESCRIPTION
## Summary

Port the following public methods from `S7CommPlusClient` (sync) to `S7CommPlusAsyncClient`:

- `write_symbolic` -- symbolic (LID-based) variable write
- `get_cpu_state` -- read PLC CPU operating state via EXPLORE
- `upload_block` -- upload (read) a program block from the PLC
- `download_block` -- download (write) a program block to the PLC
- `create_subscription` -- create a data change subscription
- `delete_subscription` -- delete a data change subscription

All six methods follow the existing async patterns (awaiting `_send_request`, reusing the same module-level payload builders from `client.py`).

## Test plan

- [x] Added async integration tests for `write_symbolic`, `get_cpu_state`, `set_plc_operating_state`, and `explore_xml` against the emulated server
- [x] Full test suite passes locally (1499 passed)
- [x] `pre-commit run --all-files` passes (mypy, ruff check, ruff format)

Closes #797