### PR TITLE
feat: session password set/clear for password-protected PLCs (#792)

### DIFF
--- a/snap7/async_client.py
+++ b/snap7/async_client.py
@@ -1070,6 +1070,53 @@ class AsyncClient(ClientMixin):
             raise S7ConnectionError("Not connected to PLC")
         return parse_protection_szl(await self.read_szl(0x0232, 0))
 
+    async def set_session_password(self, password: str) -> int:
+        """Set the session password to unlock a password-protected PLC.
+
+        Sends an S7 USERDATA request (function group 5, subfunction 1)
+        with the encoded password.
+
+        Args:
+            password: Plaintext password (max 8 ASCII characters).
+
+        Returns:
+            0 on success.
+
+        Raises:
+            ~snap7.error.S7ConnectionError: If not connected.
+            ~snap7.error.S7ProtocolError: If the PLC rejects the password.
+        """
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        encoded = self.protocol.encode_password(password)
+        request = self.protocol.build_set_session_password_request(encoded)
+        response = await self._send_receive(request)
+        self.protocol.check_userdata_response(response)
+        logger.info("Session password set successfully")
+        return 0
+
+    async def clear_session_password(self) -> int:
+        """Clear the session password, returning to the default protection level.
+
+        Sends an S7 USERDATA request (function group 5, subfunction 2).
+
+        Returns:
+            0 on success.
+
+        Raises:
+            ~snap7.error.S7ConnectionError: If not connected.
+            ~snap7.error.S7ProtocolError: If the PLC rejects the request.
+        """
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        request = self.protocol.build_clear_session_password_request()
+        response = await self._send_receive(request)
+        self.protocol.check_userdata_response(response)
+        logger.info("Session password cleared successfully")
+        return 0
+
     async def compress(self, timeout: int) -> int:
         """Compress PLC memory."""
         if not self.get_connected():

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -1931,6 +1931,59 @@ class Client(ClientMixin):
             raise S7ConnectionError("Not connected to PLC")
         return parse_protection_szl(self.read_szl(0x0232, 0))
 
+    def set_session_password(self, password: str) -> int:
+        """Set the session password to unlock a password-protected PLC.
+
+        Sends an S7 USERDATA request (function group 5, subfunction 1)
+        with the encoded password. After a successful call the PLC grants
+        higher-privilege access for the duration of this session.
+
+        Args:
+            password: Plaintext password (max 8 ASCII characters).
+
+        Returns:
+            0 on success.
+
+        Raises:
+            ~snap7.error.S7ConnectionError: If not connected.
+            ~snap7.error.S7ProtocolError: If the PLC rejects the password.
+        """
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        encoded = self.protocol.encode_password(password)
+
+        def build_request() -> bytes:
+            return self.protocol.build_set_session_password_request(encoded)
+
+        response = self._send_receive_with_reconnect(build_request)
+        self.protocol.check_userdata_response(response)
+        logger.info("Session password set successfully")
+        return 0
+
+    def clear_session_password(self) -> int:
+        """Clear the session password, returning to the default protection level.
+
+        Sends an S7 USERDATA request (function group 5, subfunction 2).
+
+        Returns:
+            0 on success.
+
+        Raises:
+            ~snap7.error.S7ConnectionError: If not connected.
+            ~snap7.error.S7ProtocolError: If the PLC rejects the request.
+        """
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        def build_request() -> bytes:
+            return self.protocol.build_clear_session_password_request()
+
+        response = self._send_receive_with_reconnect(build_request)
+        self.protocol.check_userdata_response(response)
+        logger.info("Session password cleared successfully")
+        return 0
+
     def read_szl(self, ssl_id: int, index: int = 0) -> S7SZL:
         """
         Read SZL (System Status List).

--- a/snap7/client_base.py
+++ b/snap7/client_base.py
@@ -147,29 +147,6 @@ class ClientMixin:
         self.connection_type = connection_type
         logger.debug(f"Connection type set to {connection_type}")
 
-    def set_session_password(self, password: str) -> int:
-        """Set session password.
-
-        Args:
-            password: Session password
-
-        Returns:
-            0 on success
-        """
-        self.session_password = password
-        logger.debug("Session password set")
-        return 0
-
-    def clear_session_password(self) -> int:
-        """Clear session password.
-
-        Returns:
-            0 on success
-        """
-        self.session_password = None
-        logger.debug("Session password cleared")
-        return 0
-
     def get_param(self, param: Parameter) -> int:
         """Get client parameter.
 

--- a/snap7/s7protocol.py
+++ b/snap7/s7protocol.py
@@ -65,6 +65,10 @@ class S7UserDataSubfunction(IntEnum):
     READ_SZL = 0x01  # SFun_ReadSZL
     SYSTEM_STATE = 0x02  # System state request
 
+    # Security subfunctions
+    SET_SESSION_PASSWORD = 0x01
+    CLEAR_SESSION_PASSWORD = 0x02
+
     # Clock subfunctions
     GET_CLOCK = 0x01
     SET_CLOCK = 0x02
@@ -1336,6 +1340,143 @@ class S7Protocol:
             return dt_class(full_year, month, day, hour, minute, second)
         except ValueError:
             return dt_class.now().replace(microsecond=0)
+
+    # ========================================================================
+    # Session Password PDU Builders (Security / Function Group 5)
+    # ========================================================================
+
+    @staticmethod
+    def encode_password(password: str) -> bytes:
+        """Encode an S7 session password into the 8-byte wire format.
+
+        The encoding pads or truncates the password to 8 characters, XORs each
+        byte with ``0x55``, then rotates each byte left by 3 bits.
+
+        Args:
+            password: Plaintext password (max 8 characters).
+
+        Returns:
+            8-byte encoded password block.
+        """
+        # Pad/truncate to exactly 8 bytes
+        raw = password.encode("ascii")[:8].ljust(8, b"\x00")
+        encoded = bytearray(8)
+        for i in range(8):
+            xored = raw[i] ^ 0x55
+            encoded[i] = ((xored << 3) | (xored >> 5)) & 0xFF
+        return bytes(encoded)
+
+    def build_set_session_password_request(self, encoded_password: bytes) -> bytes:
+        """Build USERDATA request to set the session password.
+
+        Uses function group 5 (Security), subfunction 1.
+
+        Args:
+            encoded_password: 8-byte encoded password from :meth:`encode_password`.
+
+        Returns:
+            Complete S7 PDU.
+        """
+        # Parameter section for USERDATA security request
+        param_data = struct.pack(
+            ">BBBBBBBB",
+            0x00,  # Reserved
+            0x01,  # Parameter count
+            0x12,  # Type/length header
+            0x04,  # Length of following data
+            0x11,  # Method (0x11 = request)
+            0x45,  # Type (4=request) | Group (5=grSecurity)
+            S7UserDataSubfunction.SET_SESSION_PASSWORD,  # Subfunction (0x01)
+            0x00,  # DataRef
+        )
+
+        # Data section: encoded password
+        data_section = (
+            struct.pack(
+                ">BBH",
+                0x0A,  # Return value (request)
+                0x00,  # Transport size
+                len(encoded_password),  # Length
+            )
+            + encoded_password
+        )
+
+        header = struct.pack(
+            ">BBHHHH",
+            0x32,  # Protocol ID
+            S7PDUType.USERDATA,  # PDU type (0x07)
+            0x0000,  # Reserved
+            self._next_sequence(),  # Sequence
+            len(param_data),  # Parameter length
+            len(data_section),  # Data length
+        )
+
+        return header + param_data + data_section
+
+    def build_clear_session_password_request(self) -> bytes:
+        """Build USERDATA request to clear the session password.
+
+        Uses function group 5 (Security), subfunction 2.
+
+        Returns:
+            Complete S7 PDU.
+        """
+        param_data = struct.pack(
+            ">BBBBBBBB",
+            0x00,  # Reserved
+            0x01,  # Parameter count
+            0x12,  # Type/length header
+            0x04,  # Length of following data
+            0x11,  # Method (0x11 = request)
+            0x45,  # Type (4=request) | Group (5=grSecurity)
+            S7UserDataSubfunction.CLEAR_SESSION_PASSWORD,  # Subfunction (0x02)
+            0x00,  # DataRef
+        )
+
+        data_section = struct.pack(
+            ">BBH",
+            0x0A,  # Return value (request)
+            0x00,  # Transport size
+            0x0000,  # Length (0 bytes)
+        )
+
+        header = struct.pack(
+            ">BBHHHH",
+            0x32,  # Protocol ID
+            S7PDUType.USERDATA,  # PDU type (0x07)
+            0x0000,  # Reserved
+            self._next_sequence(),  # Sequence
+            len(param_data),  # Parameter length
+            len(data_section),  # Data length
+        )
+
+        return header + param_data + data_section
+
+    def check_userdata_response(self, response: Dict[str, Any]) -> None:
+        """Check a USERDATA response for errors.
+
+        Verifies both the parameter-level error code and the data section
+        return code.
+
+        Args:
+            response: Parsed S7 response from :meth:`parse_response`.
+
+        Raises:
+            ~snap7.error.S7ProtocolError: If the response indicates an error.
+        """
+        params = response.get("parameters", {})
+        if isinstance(params, dict):
+            param_error = params.get("error_code", 0)
+            if param_error != 0:
+                error_msg = get_protocol_error_message(param_error)
+                raise S7ProtocolError(f"USERDATA request failed: {error_msg} (0x{param_error:04x})")
+
+        data_info = response.get("data", {})
+        if isinstance(data_info, dict):
+            return_code = data_info.get("return_code", 0xFF)
+            if return_code != 0xFF:
+                desc = get_return_code_description(return_code)
+                raise S7ProtocolError(f"USERDATA request failed: {desc} (0x{return_code:02x})")
 
     def build_cpu_state_request(self) -> bytes:
         """

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -11,6 +11,7 @@ import pytest
 import pytest_asyncio
 
 from snap7.async_client import AsyncClient
+from snap7.error import S7ConnectionError
 from snap7.server import Server
 from snap7.type import SrvArea, Area, Parameter
 
@@ -265,13 +266,20 @@ def test_error_text() -> None:
     assert "Not connected" in c.error_text(0x0003)
 
 
-def test_set_clear_session_password() -> None:
+@pytest.mark.asyncio
+async def test_set_session_password_requires_connection() -> None:
+    """set_session_password sends a USERDATA PDU and requires a connection."""
     c = AsyncClient()
-    assert c.session_password is None
-    c.set_session_password("secret")
-    assert c.session_password == "secret"
-    c.clear_session_password()
-    assert c.session_password is None
+    with pytest.raises(S7ConnectionError, match="Not connected"):
+        await c.set_session_password("secret")
+
+
+@pytest.mark.asyncio
+async def test_clear_session_password_requires_connection() -> None:
+    """clear_session_password sends a USERDATA PDU and requires a connection."""
+    c = AsyncClient()
+    with pytest.raises(S7ConnectionError, match="Not connected"):
+        await c.clear_session_password()
 
 
 def test_set_connection_params() -> None:

--- a/tests/test_s7protocol.py
+++ b/tests/test_s7protocol.py
@@ -578,3 +578,109 @@ class TestPlcControlParams:
         proto = S7Protocol()
         with pytest.raises(ValueError, match="Unknown PLC control operation"):
             proto.build_plc_control_request("invalid")
+
+
+class TestSessionPassword:
+    """Tests for session password encoding and PDU building."""
+
+    def setup_method(self) -> None:
+        self.proto = S7Protocol()
+
+    def test_encode_password_known_vector(self) -> None:
+        """Verify encoding against known Sharp7/rs-snap7 test vector.
+
+        'hello' (0x68 0x65 0x6C 0x6C 0x6F) XOR 0x55 each ->
+        (0x3D 0x30 0x39 0x39 0x3A), then rotate left 3 bits each ->
+        (0xE9 0x81 0xC9 0xC9 0xD1).  Remaining bytes are 0x00 XOR 0x55 = 0x55,
+        rotated left 3 = 0xAA.
+        """
+        encoded = S7Protocol.encode_password("hello")
+        assert len(encoded) == 8
+        assert encoded == bytes([0xE9, 0x81, 0xC9, 0xC9, 0xD1, 0xAA, 0xAA, 0xAA])
+
+    def test_encode_password_empty(self) -> None:
+        """Empty password encodes as 8 bytes of 0x00 XOR 0x55 rotated."""
+        encoded = S7Protocol.encode_password("")
+        # 0x00 XOR 0x55 = 0x55; 0x55 rotated left 3 = 0xAA
+        assert encoded == bytes([0xAA] * 8)
+
+    def test_encode_password_max_length(self) -> None:
+        """8-character password uses all 8 bytes."""
+        encoded = S7Protocol.encode_password("ABCDEFGH")
+        assert len(encoded) == 8
+        # Verify first byte: 'A' (0x41) XOR 0x55 = 0x14, rotated left 3 = 0xA0
+        assert encoded[0] == 0xA0
+
+    def test_encode_password_truncates_long(self) -> None:
+        """Passwords longer than 8 characters are truncated."""
+        enc_long = S7Protocol.encode_password("ABCDEFGHIJK")
+        enc_8 = S7Protocol.encode_password("ABCDEFGH")
+        assert enc_long == enc_8
+
+    def test_set_session_password_request_structure(self) -> None:
+        """Verify the set session password PDU structure."""
+        encoded = self.proto.encode_password("test")
+        request = self.proto.build_set_session_password_request(encoded)
+
+        # S7 header
+        assert request[0] == 0x32  # Protocol ID
+        assert request[1] == 0x07  # USERDATA PDU type
+
+        # Parameter section offset = 10 (USERDATA header)
+        # param[4] = 0x11 (method = request)
+        assert request[14] == 0x11
+        # param[5] = 0x45 (type 4 | group 5 = Security)
+        assert request[15] == 0x45
+        # param[6] = 0x01 (subfunction = set password)
+        assert request[16] == 0x01
+
+        # Data section starts after 10 + 8 = 18
+        # data[0] = 0x0A (return value for request)
+        assert request[18] == 0x0A
+        # data[2:4] = length = 8
+        data_len = struct.unpack(">H", request[20:22])[0]
+        assert data_len == 8
+        # data[4:12] = encoded password
+        assert request[22:30] == encoded
+
+    def test_clear_session_password_request_structure(self) -> None:
+        """Verify the clear session password PDU structure."""
+        request = self.proto.build_clear_session_password_request()
+
+        assert request[0] == 0x32  # Protocol ID
+        assert request[1] == 0x07  # USERDATA PDU type
+
+        # param[5] = 0x45 (type 4 | group 5 = Security)
+        assert request[15] == 0x45
+        # param[6] = 0x02 (subfunction = clear password)
+        assert request[16] == 0x02
+
+        # Data section length = 0
+        data_len = struct.unpack(">H", request[20:22])[0]
+        assert data_len == 0
+
+    def test_check_userdata_response_success(self) -> None:
+        """Successful USERDATA response should not raise."""
+        response: dict[str, Any] = {
+            "parameters": {"error_code": 0, "group": 5, "subfunction": 1},
+            "data": {"return_code": 0xFF},
+        }
+        self.proto.check_userdata_response(response)  # should not raise
+
+    def test_check_userdata_response_param_error(self) -> None:
+        """USERDATA response with parameter error should raise."""
+        response: dict[str, Any] = {
+            "parameters": {"error_code": 0xD602},
+            "data": {"return_code": 0xFF},
+        }
+        with pytest.raises(S7ProtocolError, match="USERDATA request failed"):
+            self.proto.check_userdata_response(response)
+
+    def test_check_userdata_response_data_error(self) -> None:
+        """USERDATA response with data-level error should raise."""
+        response: dict[str, Any] = {
+            "parameters": {"error_code": 0},
+            "data": {"return_code": 0x03},  # "Accessing the object not allowed"
+        }
+        with pytest.raises(S7ProtocolError, match="USERDATA request failed"):
+            self.proto.check_userdata_response(response)


### PR DESCRIPTION
## Summary

- Add `set_session_password(password)` and `clear_session_password()` to both `snap7.Client` (sync) and `snap7.AsyncClient` (async)
- These send real S7 USERDATA PDUs (function group 5, Security) to unlock/lock password-protected PLCs, replacing the previous no-op stubs in `ClientMixin`
- Password encoding matches the Sharp7/rs-snap7 wire format: XOR each byte with `0x55`, rotate left by 3 bits, padded to 8 bytes

## Changes

- **snap7/s7protocol.py**: Add `encode_password()`, `build_set_session_password_request()`, `build_clear_session_password_request()`, and `check_userdata_response()` to `S7Protocol`
- **snap7/client.py**: Override `set_session_password` / `clear_session_password` with real protocol operations (uses `_send_receive_with_reconnect` for auto-reconnect support)
- **snap7/async_client.py**: Same async overrides using `_send_receive`
- **snap7/client_base.py**: Remove old no-op stubs from `ClientMixin` (both concrete clients now implement the real protocol)
- **tests/test_s7protocol.py**: Unit tests for password encoding (known test vectors), PDU structure, and `check_userdata_response` error handling
- **tests/test_async_client.py**: Update async tests to verify connection-required behavior

## Test plan

- [x] `uv run pytest tests/ -x -q` -- all 1639 tests pass
- [x] `uv run pre-commit run --all-files` -- all hooks pass (mypy, ruff, formatting)
- [ ] End-to-end test against a password-protected PLC (requires hardware)

Closes #792