### PR TITLE
feat: Force I/O support for commissioning and diagnostics (#796)

### DIFF
--- a/snap7/__init__.py
+++ b/snap7/__init__.py
@@ -22,7 +22,7 @@ from .partner import Partner
 from .logo import Logo
 from .util.db import Row, DB
 from .tags import NodeS7Tag, PLC4XTag, Tag, from_browse, load_csv, load_json, load_tia_xml, parse_tag
-from .type import Area, Block, WordLen, SrvEvent, SrvArea
+from .type import Area, Block, ForceEntry, WordLen, SrvEvent, SrvArea
 
 __all__ = [
     "Client",
@@ -42,6 +42,7 @@ __all__ = [
     "from_browse",
     "Area",
     "Block",
+    "ForceEntry",
     "WordLen",
     "SrvEvent",
     "SrvArea",

--- a/snap7/async_client.py
+++ b/snap7/async_client.py
@@ -22,10 +22,12 @@ from .datatypes import S7WordLen
 from .error import S7Error, S7ConnectionError, S7ProtocolError, S7TimeoutError
 from .client_base import ClientMixin
 from .szl import parse_cp_info_szl, parse_cpu_info_szl, parse_order_code_szl, parse_protection_szl
+from .client import _parse_force_szl
 from .type import (
     Area,
     Block,
     BlocksList,
+    ForceEntry,
     S7CpuInfo,
     TS7BlockInfo,
     S7CpInfo,
@@ -1069,6 +1071,62 @@ class AsyncClient(ClientMixin):
         if not self.get_connected():
             raise S7ConnectionError("Not connected to PLC")
         return parse_protection_szl(await self.read_szl(0x0232, 0))
+
+    # ---------------------------------------------------------------
+    # Force I/O
+    # ---------------------------------------------------------------
+
+    _FORCE_AREAS: frozenset[int] = frozenset({Area.PE, Area.PA})
+
+    async def force_bit(self, area: Area, byte_offset: int, bit: int, value: bool) -> None:
+        """Force a single I/O bit in the process image.
+
+        Async equivalent of :meth:`snap7.client.Client.force_bit`.
+        """
+        if area not in self._FORCE_AREAS:
+            raise ValueError(f"Force is only supported for PE (inputs) and PA (outputs), got {area!r}")
+        if not 0 <= bit <= 7:
+            raise ValueError(f"Bit must be 0-7, got {bit}")
+
+        current = await self.read_area(area, 0, byte_offset, 1)
+        if value:
+            current[0] |= 1 << bit
+        else:
+            current[0] &= ~(1 << bit)
+        await self.write_area(area, 0, byte_offset, current)
+        logger.info(f"Forced {area.name} byte {byte_offset} bit {bit} = {value}")
+
+    async def cancel_force(self, area: Area, byte_offset: int, bit: int) -> None:
+        """Cancel a forced I/O bit by clearing it in the process image.
+
+        Async equivalent of :meth:`snap7.client.Client.cancel_force`.
+        """
+        if area not in self._FORCE_AREAS:
+            raise ValueError(f"Cancel force is only supported for PE (inputs) and PA (outputs), got {area!r}")
+        if not 0 <= bit <= 7:
+            raise ValueError(f"Bit must be 0-7, got {bit}")
+
+        current = await self.read_area(area, 0, byte_offset, 1)
+        current[0] &= ~(1 << bit)
+        await self.write_area(area, 0, byte_offset, current)
+        logger.info(f"Cancelled force on {area.name} byte {byte_offset} bit {bit}")
+
+    async def read_force_table(self) -> list[ForceEntry]:
+        """Read the PLC force table via SZL 0x0025.
+
+        Async equivalent of :meth:`snap7.client.Client.read_force_table`.
+        """
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        try:
+            szl = await self.read_szl(0x0025, 0x0000)
+        except (S7ProtocolError, RuntimeError):
+            logger.debug("SZL 0x0025 not available; returning empty force table")
+            return []
+
+        raw = bytes(szl.Data[: szl.Header.LengthDR])
+        return _parse_force_szl(raw)
 
     async def compress(self, timeout: int) -> int:
         """Compress PLC memory."""

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -36,6 +36,7 @@ from .type import (
     Area,
     Block,
     BlocksList,
+    ForceEntry,
     S7CpuInfo,
     TS7BlockInfo,
     S7DataItem,
@@ -231,6 +232,31 @@ def _encode_scalar(datatype: str, buf: bytearray, offset: int, value: Any, bit: 
         util.set_dtl(buf, offset, value)
         return
     raise ValueError(f"Unsupported tag datatype: {datatype}")
+
+
+def _parse_force_szl(raw: bytes) -> list[ForceEntry]:
+    """Parse SZL 0x0025 (force table) data into :class:`ForceEntry` items.
+
+    Each SZL 0x0025 entry is 8 bytes:
+      - bytes 0-1: area code (big-endian, 0x0081=PE, 0x0082=PA)
+      - bytes 2-3: byte offset (big-endian)
+      - byte 4:    bit number (0-7)
+      - byte 5:    force value (0x00=False, 0x01=True)
+      - bytes 6-7: reserved
+
+    Returns an empty list if *raw* is too short or contains no entries.
+    """
+    entry_size = 8
+    entries: list[ForceEntry] = []
+    offset = 0
+    while offset + entry_size <= len(raw):
+        area_code = struct.unpack(">H", raw[offset : offset + 2])[0]
+        byte_off = struct.unpack(">H", raw[offset + 2 : offset + 4])[0]
+        bit_num = raw[offset + 4]
+        val = raw[offset + 5] != 0
+        entries.append(ForceEntry(area=area_code, byte_offset=byte_off, bit=bit_num, value=val))
+        offset += entry_size
+    return entries
 
 
 class _OptimizationPlan:
@@ -1930,6 +1956,98 @@ class Client(ClientMixin):
         if not self.get_connected():
             raise S7ConnectionError("Not connected to PLC")
         return parse_protection_szl(self.read_szl(0x0232, 0))
+
+    # ---------------------------------------------------------------
+    # Force I/O
+    # ---------------------------------------------------------------
+
+    _FORCE_AREAS: frozenset[int] = frozenset({Area.PE, Area.PA})
+
+    def force_bit(self, area: Area, byte_offset: int, bit: int, value: bool) -> None:
+        """Force a single I/O bit in the process image.
+
+        Performs a read-modify-write on the specified byte to set or clear
+        the target bit without affecting neighbouring bits. This writes
+        directly to the process image, so the value may be overwritten by
+        the PLC's scan cycle. It is equivalent to the approach used by
+        rs-snap7.
+
+        Only the I/O areas (PE = inputs, PA = outputs) are supported.
+
+        Args:
+            area: Memory area (:attr:`~snap7.type.Area.PE` or
+                :attr:`~snap7.type.Area.PA`).
+            byte_offset: Byte offset within the area.
+            bit: Bit number (0-7) within the byte.
+            value: Desired bit value.
+
+        Raises:
+            ValueError: If *area* is not PE or PA, or *bit* is out of range.
+        """
+        if area not in self._FORCE_AREAS:
+            raise ValueError(f"Force is only supported for PE (inputs) and PA (outputs), got {area!r}")
+        if not 0 <= bit <= 7:
+            raise ValueError(f"Bit must be 0-7, got {bit}")
+
+        current = self.read_area(area, 0, byte_offset, 1)
+        if value:
+            current[0] |= 1 << bit
+        else:
+            current[0] &= ~(1 << bit)
+        self.write_area(area, 0, byte_offset, current)
+        logger.info(f"Forced {area.name} byte {byte_offset} bit {bit} = {value}")
+
+    def cancel_force(self, area: Area, byte_offset: int, bit: int) -> None:
+        """Cancel a forced I/O bit by clearing it in the process image.
+
+        Clears the specified bit. On a real PLC the scan cycle will
+        restore the natural I/O state once the force is released; on the
+        emulated server the bit stays at 0 until explicitly written.
+
+        Args:
+            area: Memory area (:attr:`~snap7.type.Area.PE` or
+                :attr:`~snap7.type.Area.PA`).
+            byte_offset: Byte offset within the area.
+            bit: Bit number (0-7) within the byte.
+
+        Raises:
+            ValueError: If *area* is not PE or PA, or *bit* is out of range.
+        """
+        if area not in self._FORCE_AREAS:
+            raise ValueError(f"Cancel force is only supported for PE (inputs) and PA (outputs), got {area!r}")
+        if not 0 <= bit <= 7:
+            raise ValueError(f"Bit must be 0-7, got {bit}")
+
+        current = self.read_area(area, 0, byte_offset, 1)
+        current[0] &= ~(1 << bit)
+        self.write_area(area, 0, byte_offset, current)
+        logger.info(f"Cancelled force on {area.name} byte {byte_offset} bit {bit}")
+
+    def read_force_table(self) -> list[ForceEntry]:
+        """Read the PLC force table via SZL 0x0025.
+
+        On a real PLC this returns bits that have been forced through the
+        CPU's built-in force mechanism (e.g. via TIA Portal). Bits set
+        through :meth:`force_bit` (process-image writes) do **not** appear
+        here because they bypass the CPU force table.
+
+        Returns:
+            List of :class:`~snap7.type.ForceEntry` instances describing
+            each forced bit.  Returns an empty list when no bits are
+            currently forced or when the PLC does not support SZL 0x0025.
+        """
+        if not self.get_connected():
+            raise S7ConnectionError("Not connected to PLC")
+
+        try:
+            szl = self.read_szl(0x0025, 0x0000)
+        except (S7ProtocolError, RuntimeError):
+            # PLC does not support force table SZL or returned an error
+            logger.debug("SZL 0x0025 not available; returning empty force table")
+            return []
+
+        raw = bytes(szl.Data[: szl.Header.LengthDR])
+        return _parse_force_szl(raw)
 
     def read_szl(self, ssl_id: int, index: int = 0) -> S7SZL:
         """

--- a/snap7/type.py
+++ b/snap7/type.py
@@ -21,7 +21,7 @@ from ctypes import (
 )
 from datetime import datetime, date, timedelta
 from enum import IntEnum
-from typing import Dict, Union, Literal
+from typing import Dict, NamedTuple, Union, Literal
 
 CDataArrayType = Union[
     Array[c_byte], Array[c_int], Array[c_int16], Array[c_int32], Array[c_uint8], Array[c_uint16], Array[c_uint32]
@@ -389,3 +389,19 @@ class S7Protection(Structure):
         ("bart_sch", word),
         ("anl_sch", word),
     ]
+
+
+class ForceEntry(NamedTuple):
+    """A single entry in the I/O force table.
+
+    Attributes:
+        area: Memory area (:attr:`Area.PE` for inputs, :attr:`Area.PA` for outputs).
+        byte_offset: Byte offset of the forced bit.
+        bit: Bit number (0-7) within the byte.
+        value: Forced value (True/False).
+    """
+
+    area: int  # Area enum value (PE=0x81, PA=0x82)
+    byte_offset: int
+    bit: int
+    value: bool

--- a/snap7/type.py
+++ b/snap7/type.py
@@ -392,16 +392,13 @@ class S7Protection(Structure):
 
 
 class ForceEntry(NamedTuple):
-    """A single entry in the I/O force table.
+    """A single entry in the I/O force table."""
 
-    Attributes:
-        area: Memory area (:attr:`Area.PE` for inputs, :attr:`Area.PA` for outputs).
-        byte_offset: Byte offset of the forced bit.
-        bit: Bit number (0-7) within the byte.
-        value: Forced value (True/False).
-    """
-
-    area: int  # Area enum value (PE=0x81, PA=0x82)
+    area: int
+    """Memory area (:attr:`Area.PE` for inputs, :attr:`Area.PA` for outputs)."""
     byte_offset: int
+    """Byte offset of the forced bit."""
     bit: int
+    """Bit number (0-7) within the byte."""
     value: bool
+    """Forced value (True/False)."""

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -382,3 +382,43 @@ async def test_get_block_info(client: AsyncClient) -> None:
 @pytest.mark.asyncio
 async def test_get_pdu_length_after_connect(client: AsyncClient) -> None:
     assert client.get_pdu_length() > 0
+
+
+# -------------------------------------------------------------------
+# Force I/O
+# -------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_force_bit(client: AsyncClient) -> None:
+    """Force a single input bit and verify it reads back correctly."""
+    await client.write_area(Area.PE, 0, 0, bytearray([0x00]))
+    await client.force_bit(Area.PE, 0, 3, True)
+    data = await client.read_area(Area.PE, 0, 0, 1)
+    assert data[0] & (1 << 3)
+
+
+@pytest.mark.asyncio
+async def test_cancel_force(client: AsyncClient) -> None:
+    """Cancel force clears the bit in the process image."""
+    await client.write_area(Area.PA, 0, 0, bytearray([0x00]))
+    await client.force_bit(Area.PA, 0, 2, True)
+    data = await client.read_area(Area.PA, 0, 0, 1)
+    assert data[0] & (1 << 2)
+    await client.cancel_force(Area.PA, 0, 2)
+    data = await client.read_area(Area.PA, 0, 0, 1)
+    assert not (data[0] & (1 << 2))
+
+
+@pytest.mark.asyncio
+async def test_force_bit_invalid_area(client: AsyncClient) -> None:
+    """Force should reject non-I/O areas."""
+    with pytest.raises(ValueError):
+        await client.force_bit(Area.MK, 0, 0, True)
+
+
+@pytest.mark.asyncio
+async def test_read_force_table(client: AsyncClient) -> None:
+    """read_force_table should return a list (possibly empty)."""
+    result = await client.read_force_table()
+    assert isinstance(result, list)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -801,6 +801,84 @@ class TestClient(unittest.TestCase):
         self.assertEqual(0, result.bart_sch)
         self.assertEqual(0, result.anl_sch)
 
+    # ---------------------------------------------------------------
+    # Force I/O
+    # ---------------------------------------------------------------
+
+    def test_force_bit_pe(self) -> None:
+        """Force a single input bit and verify it reads back correctly."""
+        # Clear the byte first
+        self.client.write_area(Area.PE, 0, 0, bytearray([0x00]))
+        # Force bit 3 to True
+        self.client.force_bit(Area.PE, 0, 3, True)
+        data = self.client.read_area(Area.PE, 0, 0, 1)
+        self.assertTrue(data[0] & (1 << 3))
+        # Other bits should still be 0
+        self.assertEqual(data[0] & ~(1 << 3), 0)
+
+    def test_force_bit_pa(self) -> None:
+        """Force a single output bit and verify it reads back correctly."""
+        self.client.write_area(Area.PA, 0, 0, bytearray([0x00]))
+        self.client.force_bit(Area.PA, 0, 5, True)
+        data = self.client.read_area(Area.PA, 0, 0, 1)
+        self.assertTrue(data[0] & (1 << 5))
+
+    def test_force_bit_preserves_other_bits(self) -> None:
+        """Forcing one bit must not disturb other bits in the byte."""
+        self.client.write_area(Area.PE, 0, 0, bytearray([0b10100101]))
+        self.client.force_bit(Area.PE, 0, 1, True)
+        data = self.client.read_area(Area.PE, 0, 0, 1)
+        self.assertEqual(data[0], 0b10100111)
+
+    def test_force_bit_clear(self) -> None:
+        """Force a bit to False (clear it)."""
+        self.client.write_area(Area.PE, 0, 0, bytearray([0xFF]))
+        self.client.force_bit(Area.PE, 0, 4, False)
+        data = self.client.read_area(Area.PE, 0, 0, 1)
+        self.assertEqual(data[0], 0xFF & ~(1 << 4))
+
+    def test_cancel_force(self) -> None:
+        """Cancel force clears the bit in the process image."""
+        self.client.write_area(Area.PA, 0, 0, bytearray([0x00]))
+        self.client.force_bit(Area.PA, 0, 2, True)
+        data = self.client.read_area(Area.PA, 0, 0, 1)
+        self.assertTrue(data[0] & (1 << 2))
+        # Cancel - bit should be cleared
+        self.client.cancel_force(Area.PA, 0, 2)
+        data = self.client.read_area(Area.PA, 0, 0, 1)
+        self.assertFalse(data[0] & (1 << 2))
+
+    def test_cancel_force_preserves_other_bits(self) -> None:
+        """Cancelling a force must not disturb other bits."""
+        self.client.write_area(Area.PE, 0, 0, bytearray([0b11111111]))
+        self.client.cancel_force(Area.PE, 0, 6)
+        data = self.client.read_area(Area.PE, 0, 0, 1)
+        self.assertEqual(data[0], 0xFF & ~(1 << 6))
+
+    def test_force_bit_invalid_area(self) -> None:
+        """Force should reject non-I/O areas."""
+        with self.assertRaises(ValueError):
+            self.client.force_bit(Area.MK, 0, 0, True)
+        with self.assertRaises(ValueError):
+            self.client.force_bit(Area.DB, 0, 0, True)
+
+    def test_cancel_force_invalid_area(self) -> None:
+        """Cancel force should reject non-I/O areas."""
+        with self.assertRaises(ValueError):
+            self.client.cancel_force(Area.MK, 0, 0)
+
+    def test_force_bit_invalid_bit(self) -> None:
+        """Force should reject bit numbers outside 0-7."""
+        with self.assertRaises(ValueError):
+            self.client.force_bit(Area.PE, 0, 8, True)
+        with self.assertRaises(ValueError):
+            self.client.force_bit(Area.PE, 0, -1, True)
+
+    def test_read_force_table(self) -> None:
+        """read_force_table should return a list (possibly empty)."""
+        result = self.client.read_force_table()
+        self.assertIsInstance(result, list)
+
     def test_get_pg_block_info(self) -> None:
         valid_db_block = (
             b"pp\x01\x01\x05\n\x00c\x00\x00\x00t\x00\x00\x00\x00\x01\x8d\xbe)2\xa1\x01"

--- a/tests/test_s7protocol.py
+++ b/tests/test_s7protocol.py
@@ -578,3 +578,39 @@ class TestPlcControlParams:
         proto = S7Protocol()
         with pytest.raises(ValueError, match="Unknown PLC control operation"):
             proto.build_plc_control_request("invalid")
+
+
+class TestParseForceTable:
+    """Unit tests for _parse_force_szl (SZL 0x0025 parser)."""
+
+    def test_empty_data(self) -> None:
+        from snap7.client import _parse_force_szl
+
+        assert _parse_force_szl(b"") == []
+
+    def test_single_entry(self) -> None:
+        from snap7.client import _parse_force_szl
+        from snap7.type import ForceEntry
+
+        # PE byte 10, bit 3, value True
+        raw = struct.pack(">HHBBxx", 0x0081, 10, 3, 0x01)
+        result = _parse_force_szl(raw)
+        assert len(result) == 1
+        assert result[0] == ForceEntry(area=0x0081, byte_offset=10, bit=3, value=True)
+
+    def test_multiple_entries(self) -> None:
+        from snap7.client import _parse_force_szl
+        from snap7.type import ForceEntry
+
+        raw = struct.pack(">HHBBxx", 0x0081, 0, 0, 0x01)  # PE byte 0 bit 0 = True
+        raw += struct.pack(">HHBBxx", 0x0082, 5, 7, 0x00)  # PA byte 5 bit 7 = False
+        result = _parse_force_szl(raw)
+        assert len(result) == 2
+        assert result[0] == ForceEntry(area=0x0081, byte_offset=0, bit=0, value=True)
+        assert result[1] == ForceEntry(area=0x0082, byte_offset=5, bit=7, value=False)
+
+    def test_truncated_data(self) -> None:
+        from snap7.client import _parse_force_szl
+
+        # 5 bytes is less than one 8-byte entry
+        assert _parse_force_szl(b"\x00\x81\x00\x02\x03") == []


### PR DESCRIPTION
## Summary

- Add `force_bit(area, byte_offset, bit, value)` and `cancel_force(area, byte_offset, bit)` to both `Client` and `AsyncClient` for manipulating individual I/O bits in the process image (PE/PA areas) during commissioning and diagnostics
- Add `read_force_table()` to read the PLC's CPU force table via SZL 0x0025
- Add `ForceEntry` NamedTuple to `snap7.type` for structured force table results, exported from both `snap7` and `s7` packages

The force/cancel operations perform read-modify-write on the process image, matching the approach used by [rs-snap7](https://github.com/cool0looc/rs-snap7). Only I/O areas (PE=inputs, PA=outputs) are accepted; other areas raise `ValueError`.

Closes #796

## Test plan

- [x] 10 sync client integration tests against emulated server (force/cancel on PE and PA, bit preservation, invalid area/bit rejection, read_force_table)
- [x] 4 async client integration tests (force, cancel, invalid area, read_force_table)
- [x] 4 unit tests for `_parse_force_szl` SZL 0x0025 parser (empty, single entry, multiple entries, truncated)
- [x] Full test suite passes (1513 passed, 17 skipped)
- [x] mypy clean, ruff clean, pre-commit passes