### PR TITLE
fix(security): validate PDU sizes, prevent infinite loops, restrict server downloads

### DIFF
--- a/snap7/async_client.py
+++ b/snap7/async_client.py
@@ -1164,7 +1164,11 @@ class AsyncClient(ClientMixin):
         if response.get("parameters"):
             params = response["parameters"]
             if "pdu_length" in params:
-                self.pdu_length = params["pdu_length"]
+                negotiated = params["pdu_length"]
+                if negotiated < 64:
+                    logger.warning(f"Server negotiated implausible PDU length {negotiated}, using minimum 240")
+                    negotiated = 240
+                self.pdu_length = negotiated
                 self._params[Parameter.PDURequest] = self.pdu_length
                 logger.info(f"Negotiated PDU length: {self.pdu_length}")
 

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -2665,7 +2665,11 @@ class Client(ClientMixin):
         if response.get("parameters"):
             params = response["parameters"]
             if "pdu_length" in params:
-                self.pdu_length = params["pdu_length"]
+                negotiated = params["pdu_length"]
+                if negotiated < 64:
+                    logger.warning(f"Server negotiated implausible PDU length {negotiated}, using minimum 240")
+                    negotiated = 240
+                self.pdu_length = negotiated
                 self._params[Parameter.PDURequest] = self.pdu_length
                 logger.info(f"Negotiated PDU length: {self.pdu_length}")
 

--- a/snap7/client_base.py
+++ b/snap7/client_base.py
@@ -224,16 +224,22 @@ class ClientMixin:
 
         Calculated as PDU length minus overhead:
         12 bytes S7 header + 2 bytes param + 4 bytes data header = 18 bytes.
+
+        Returns at least 1 to prevent infinite loops in chunked reads
+        when the server negotiates an implausibly small PDU.
         """
-        return self.pdu_length - 18
+        return max(1, self.pdu_length - 18)
 
     def _max_write_size(self) -> int:
         """Maximum payload bytes for a single write request.
 
         Calculated as PDU length minus overhead:
         12 bytes S7 header + 14 bytes param + 4 bytes data header + 5 bytes padding = 35 bytes.
+
+        Returns at least 1 to prevent infinite loops in chunked writes
+        when the server negotiates an implausibly small PDU.
         """
-        return self.pdu_length - 35
+        return max(1, self.pdu_length - 35)
 
     def _map_area(self, area: Area) -> S7Area:
         """Map library area enum to native S7 area."""

--- a/snap7/connection.py
+++ b/snap7/connection.py
@@ -375,11 +375,19 @@ class ISOTCPConnection:
             if param_code == self.COTP_PARAM_PDU_SIZE:
                 # PDU Size parameter
                 if param_len == 1:
-                    # ISO 8073 code: size = 2^code
-                    self.pdu_size = 1 << param_data[0]
+                    # ISO 8073 code: size = 2^code, valid range 7-13
+                    exponent = param_data[0]
+                    if 7 <= exponent <= 13:
+                        self.pdu_size = 1 << exponent
+                    else:
+                        logger.warning(f"Invalid COTP PDU size exponent {exponent}, using default")
                 elif param_len == 2:
                     # Raw 2-byte value
-                    self.pdu_size = struct.unpack(">H", param_data)[0]
+                    raw = struct.unpack(">H", param_data)[0]
+                    if 128 <= raw <= 8192:
+                        self.pdu_size = raw
+                    else:
+                        logger.warning(f"Invalid COTP PDU size {raw}, using default")
                 logger.debug(f"Negotiated PDU size: {self.pdu_size}")
             else:
                 logger.debug(f"Unsupported COTP parameter: code={param_code:#04x}, length={param_len}")

--- a/snap7/server/__init__.py
+++ b/snap7/server/__init__.py
@@ -2420,7 +2420,9 @@ class Server:
             block_num = ctx["block_num"]
             block_data = ctx["data"]
 
-            # Store block data
+            # Store block data — only into pre-registered areas.
+            # Reject downloads to unknown areas to prevent unbounded memory
+            # allocation from attacker-controlled block numbers.
             if block_type == 0x41:  # DB
                 area_key = (S7Area.DB, block_num)
                 if area_key in self.memory_areas:
@@ -2430,9 +2432,9 @@ class Server:
                         copy_len = min(len(block_data), len(existing_area))
                         existing_area[0:copy_len] = block_data[0:copy_len]
                 else:
-                    # Create new area
-                    self.memory_areas[area_key] = bytearray(block_data)
-                    self.area_locks[area_key] = threading.Lock()
+                    logger.warning(f"Download rejected: area DB{block_num} not registered")
+                    del self._download_contexts[client_address]
+                    return self._build_error_response(request, 0x8104)
 
             logger.info(f"Download ended from {client_address}: stored {len(block_data)} bytes to {block_type:#02x}:{block_num}")
 


### PR DESCRIPTION
Correction (2026-08-10): The original security characterizations in this PR were not substantiated and have been withdrawn. The COTP exponent was bounded and did not drive an allocation; a zero negotiated PDU caused an exception rather than the claimed infinite loop; and the download parser defaulted targets to DB1 while the change did not bound accumulated download data. The changes retained value as input-hardening, but the CWE and vulnerability claims were inaccurate. Release 3.1.1 has been superseded by corrective release 3.1.2.