### PR TITLE
chore(ci): fix deprecation warnings and update OS matrix

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -54,7 +54,7 @@ jobs:
     needs: publish
     strategy:
       matrix:
-        os: ["ubuntu-24.04", "macos-14", "windows-2022"]
+        os: ["ubuntu-24.04", "ubuntu-26.04", "macos-14", "macos-15", "windows-2022", "windows-2025"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -65,7 +65,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Install and test python-snap7
         run: |
           uv venv

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -56,7 +56,7 @@ jobs:
     needs: publish
     strategy:
       matrix:
-        os: ["ubuntu-24.04", "macos-14", "windows-2022"]
+        os: ["ubuntu-24.04", "ubuntu-26.04", "macos-14", "macos-15", "windows-2022", "windows-2025"]
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     runs-on: ${{ matrix.os }}
     permissions:
@@ -69,7 +69,7 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v7
         with:
-          enable-cache: true
+          enable-cache: false
       - name: Install and test python-snap7
         run: |
           uv venv

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        runs-on: ["ubuntu-22.04", "ubuntu-24.04", "macos-14", "macos-15", "windows-2022", "windows-2025"]
+        runs-on: ["ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04", "macos-14", "macos-15", "windows-2022", "windows-2025"]
     runs-on: ${{ matrix.runs-on }}
     steps:
       - name: Checkout

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",
 ]
-license = {text = "MIT"}
+license = "MIT"
 requires-python = ">=3.10"
 keywords = ["snap7", "s7", "siemens", "plc"]
 


### PR DESCRIPTION
Fixes all warnings from the CI/publish workflows:

- **setuptools deprecation**: `license = {text = "MIT"}` → `license = "MIT"` (PEP 639)
- **uv cache warnings**: disable cache in test-published-package jobs (no checkout, so `cache-dependency-glob` matches nothing)
- **OS matrix**: add `ubuntu-26.04` to test workflow; add `ubuntu-26.04`, `macos-15`, `windows-2025` to publish test workflows