### PR TITLE
chore(ci): suppress empty workdir warning in publish smoke tests

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -66,6 +66,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: false
+          ignore-empty-workdir: true
       - name: Install and test python-snap7
         run: |
           uv venv

--- a/.github/workflows/publish-test-pypi.yml
+++ b/.github/workflows/publish-test-pypi.yml
@@ -70,6 +70,7 @@ jobs:
         uses: astral-sh/setup-uv@v7
         with:
           enable-cache: false
+          ignore-empty-workdir: true
       - name: Install and test python-snap7
         run: |
           uv venv


### PR DESCRIPTION
Add `ignore-empty-workdir: true` to `astral-sh/setup-uv` in the test-published-package jobs. These jobs don't check out the repo (they just pip install from PyPI), so the workdir is empty by design.