### PR TITLE
release: prepare 3.1.2 corrective release

### DIFF
--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -10,9 +10,22 @@ jobs:
   build:
     name: Build distribution 📦
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Verify release metadata
+        id: version
+        shell: bash
+        run: |
+          version=$(python -c 'import tomllib; print(tomllib.load(open("pyproject.toml", "rb"))["project"]["version"])')
+          git fetch origin master
+          git show origin/master:CHANGES.md | grep -Fx "$version"
+          test "$(git rev-list -n 1 "$version")" = "$GITHUB_SHA"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
@@ -49,7 +62,7 @@ jobs:
 
   test-published-package:
     name: Test published package
-    needs: publish
+    needs: [build, publish]
     strategy:
       matrix:
         os: ["ubuntu-24.04", "ubuntu-26.04", "macos-14", "macos-15", "windows-2022", "windows-2025"]
@@ -68,5 +81,5 @@ jobs:
       - name: Install and test python-snap7
         run: |
           uv venv
-          uv pip install python-snap7[test]
-          uv run python -c "import snap7; print('snap7 imported successfully')"
+          uv pip install "python-snap7[test]==${{ needs.build.outputs.version }}"
+          uv run python -c "import importlib.metadata; import snap7; assert importlib.metadata.version('python-snap7') == '${{ needs.build.outputs.version }}'"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,21 +1,34 @@
 CHANGES
 =======
 
-3.1.1
+3.1.2
 -----
 
-Bug fix and security release.
+Corrective bug-fix and robustness release superseding 3.1.1.
 
-### Security
+* Bound the server to 64 simultaneous clients by default and expose a
+  configurable `max_clients` limit.
+* Validate block-download targets and declared sizes, cap accumulated data at
+  the registered area's capacity, and discard abandoned transfer state.
+* Correct block-download parsing so registered DB numbers other than DB1 work.
+* Bound COTP request reassembly to 1 MiB and use one absolute receive deadline
+  across all fragments of a request.
+* Apply COTP TPDU-size validation consistently to sync and async clients.
+* Withdraw the vulnerability and CWE characterizations published with 3.1.1;
+  they were not supported by the affected code paths.
 
-* Validate COTP PDU size exponent to ISO 8073 range 7–13; reject
-  out-of-range values that could produce unbounded integers (CWE-190)
-* Prevent client infinite loop when server negotiates PDU length 0;
-  `_max_read_size()` / `_max_write_size()` now return at least 1 and
-  PDU lengths below 64 are rejected at negotiation time (CWE-754)
-* Server block download now rejects writes to unregistered memory areas,
-  preventing unbounded allocation from attacker-controlled block numbers
-  (CWE-862)
+3.1.1 (yanked)
+--------------
+
+This release was yanked because its security descriptions were inaccurate and
+its input-hardening was incomplete. Use 3.1.2 instead.
+
+### Robustness fixes
+
+* Reject invalid COTP TPDU-size values while retaining the safe default.
+* Reject invalid negotiated S7 PDU lengths instead of using them for chunk-size
+  calculations.
+* Reject block downloads to unregistered server memory areas.
 
 ### Bug fixes
 
@@ -34,8 +47,6 @@ Bug fix and security release.
 
 ### Thanks
 
-* [S9S Security Electronic Service](https://s9s.de) — coordinated
-  security disclosure of input validation vulnerabilities
 * [@b1163646804](https://github.com/b1163646804) — multi-byte encoding
   support and testing (#788)
 * [@domelg](https://github.com/domelg) — server COTP fragmentation and
@@ -91,6 +102,17 @@ Feature and bug fix release for the pure Python S7 communication library.
 * Set `TCP_NODELAY` and `SO_KEEPALIVE` on all sockets (#677)
 * Export `get_ulint`, `get_lint`, `get_date_time_object` from `snap7.util` (#652)
 * Documentation restructured: API Reference + Internals sections
+
+### Security and robustness
+
+* Bound the legacy server to 64 simultaneous clients by default, enforce the
+  existing `MaxClients` parameter, and allow `max_clients` configuration.
+* Validate block-download targets and declared sizes before allocating transfer
+  state, cap accumulated data at the registered area's capacity, and clean up
+  abandoned upload/download state when a client disconnects.
+* Bound COTP request reassembly to 1 MiB and apply one absolute deadline across
+  all fragments of a request.
+* Apply COTP TPDU-size validation consistently to sync and async clients.
 
 ### Thanks
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "python-snap7"
-version = "3.1.1"
+version = "3.1.2"
 description = "Pure Python S7 communication library for Siemens PLCs"
 readme = "README.rst"
 authors = [

--- a/snap7/async_client.py
+++ b/snap7/async_client.py
@@ -239,9 +239,17 @@ class AsyncISOTCPConnection:
             param_data = data[offset + 2 : offset + 2 + param_len]
             if param_code == self.COTP_PARAM_PDU_SIZE:
                 if param_len == 1:
-                    self.pdu_size = 1 << param_data[0]
+                    exponent = param_data[0]
+                    if 7 <= exponent <= 13:
+                        self.pdu_size = 1 << exponent
+                    else:
+                        logger.warning(f"Invalid COTP PDU size exponent {exponent}, using default")
                 elif param_len == 2:
-                    self.pdu_size = struct.unpack(">H", param_data)[0]
+                    raw = struct.unpack(">H", param_data)[0]
+                    if 128 <= raw <= 8192:
+                        self.pdu_size = raw
+                    else:
+                        logger.warning(f"Invalid COTP PDU size {raw}, using default")
                 logger.debug(f"Negotiated PDU size: {self.pdu_size}")
             offset += 2 + param_len
 

--- a/snap7/server/__init__.py
+++ b/snap7/server/__init__.py
@@ -53,14 +53,18 @@ class Server:
         >>> server.stop()
     """
 
-    def __init__(self, log: bool = True, **kwargs: object) -> None:
+    def __init__(self, log: bool = True, max_clients: int = 64, **kwargs: object) -> None:
         """
         Initialize S7 server.
 
         Args:
             log: Enable event logging
+            max_clients: Maximum number of simultaneous client connections
             **kwargs: Ignored. Kept for backwards compatibility.
         """
+        if max_clients < 1:
+            raise ValueError("max_clients must be at least 1")
+
         self.server_socket: Optional[socket.socket] = None
         self.server_thread: Optional[threading.Thread] = None
         self.running = False
@@ -86,6 +90,7 @@ class Server:
         # Client connections
         self.clients: List[threading.Thread] = []
         self.client_lock = threading.Lock()
+        self.max_clients = max_clients
 
         # Event queue for pick_event
         self._event_queue: List[SrvEvent] = []
@@ -177,9 +182,13 @@ class Server:
 
         # Close all client connections
         with self.client_lock:
-            for client_thread in self.clients[:]:
-                if client_thread.is_alive():
-                    client_thread.join(timeout=1.0)
+            client_threads = self.clients[:]
+
+        for client_thread in client_threads:
+            if client_thread.is_alive():
+                client_thread.join(timeout=1.0)
+
+        with self.client_lock:
             self.clients.clear()
             self.client_count = 0
 
@@ -448,6 +457,10 @@ class Server:
         """
         if param == Parameter.LocalPort:
             self.port = value
+        elif param == Parameter.MaxClients:
+            if value < 1:
+                raise ValueError("MaxClients must be at least 1")
+            self.max_clients = value
         logger.debug(f"Set parameter {param} = {value}")
         return 0
 
@@ -481,7 +494,7 @@ class Server:
         param_values = {
             Parameter.LocalPort: self.port,
             Parameter.WorkInterval: 100,
-            Parameter.MaxClients: 1024,
+            Parameter.MaxClients: self.max_clients,
         }
         return param_values.get(param, 0)
 
@@ -579,6 +592,10 @@ class Server:
                     client_thread = threading.Thread(target=self._handle_client, args=(client_socket, address), daemon=True)
 
                     with self.client_lock:
+                        if self.client_count >= self.max_clients:
+                            logger.warning(f"Rejecting client {address}: maximum of {self.max_clients} clients reached")
+                            client_socket.close()
+                            continue
                         self.clients.append(client_thread)
                         self.client_count += 1
 
@@ -644,6 +661,11 @@ class Server:
                 if current_thread in self.clients:
                     self.clients.remove(current_thread)
                 self.client_count = max(0, self.client_count - 1)
+
+            if hasattr(self, "_download_contexts"):
+                self._download_contexts.pop(address, None)
+            if hasattr(self, "_upload_contexts"):
+                self._upload_contexts.pop(address, None)
 
             logger.info(f"Client {address} handler finished")
 
@@ -2301,21 +2323,54 @@ class Server:
         try:
             raw_params = request.get("raw_parameters", b"")
 
-            # Parse block address from parameters
-            block_type = 0x41  # Default to DB
-            block_num = 1
+            # Parse and validate the target before allocating transfer state.
+            if len(raw_params) < 6:
+                return self._build_error_response(request, 0x8104)
 
-            if len(raw_params) >= 6:
-                addr_len = raw_params[5]
-                if len(raw_params) >= 6 + addr_len:
-                    block_addr = raw_params[6 : 6 + addr_len]
-                    try:
-                        block_type = int(block_addr[0:2], 16)
-                        block_num = int(block_addr[2:7])
-                    except (ValueError, IndexError):
-                        pass
+            addr_len = raw_params[4]
+            address_end = 5 + addr_len
+            if addr_len < 7 or len(raw_params) < address_end:
+                return self._build_error_response(request, 0x8104)
+
+            block_addr = raw_params[5:address_end]
+            try:
+                block_type = int(block_addr[0:2], 16)
+                block_num = int(block_addr[2:7])
+            except (ValueError, IndexError):
+                return self._build_error_response(request, 0x8104)
 
             logger.info(f"Request download from {client_address}: type={block_type:#02x}, num={block_num}")
+
+            if block_type != 0x41:  # Only DB downloads are implemented.
+                return self._build_error_response(request, 0x8104)
+
+            area_key = (S7Area.DB, block_num)
+            if area_key not in self.memory_areas:
+                logger.warning(f"Download rejected: area DB{block_num} not registered")
+                return self._build_error_response(request, 0x8104)
+
+            area_capacity = len(self.memory_areas[area_key])
+
+            # The request includes an ASCII block length. Reject an oversized
+            # transfer early, while still enforcing the limit on every chunk.
+            if len(raw_params) <= address_end:
+                return self._build_error_response(request, 0x8104)
+
+            length_len = raw_params[address_end]
+            length_start = address_end + 1
+            length_end = length_start + length_len
+            if not length_len or len(raw_params) < length_end:
+                return self._build_error_response(request, 0x8104)
+
+            try:
+                declared_size = int(raw_params[length_start:length_end])
+            except ValueError:
+                return self._build_error_response(request, 0x8104)
+            if declared_size < 0 or declared_size > area_capacity:
+                logger.warning(
+                    f"Download rejected: declared size {declared_size} outside DB{block_num} capacity 0..{area_capacity}"
+                )
+                return self._build_error_response(request, 0x8104)
 
             # Store download context
             if not hasattr(self, "_download_contexts"):
@@ -2324,6 +2379,7 @@ class Server:
                 "block_type": block_type,
                 "block_num": block_num,
                 "data": bytearray(),
+                "max_size": declared_size,
             }
 
             # Build response acknowledging download
@@ -2370,7 +2426,14 @@ class Server:
             data_info = request.get("data", {})
             block_data = data_info.get("data", b"")
 
-            # Append data to context
+            # Bound accumulated data by the pre-registered target area. The
+            # final storage copy is not the only allocation: this bytearray is
+            # grown for every DOWNLOAD_BLOCK request.
+            if len(ctx["data"]) + len(block_data) > ctx["max_size"]:
+                logger.warning(f"Download rejected: data exceeds target capacity {ctx['max_size']}")
+                del self._download_contexts[client_address]
+                return self._build_error_response(request, 0x8104)
+
             ctx["data"].extend(block_data)
 
             logger.info(f"Download block from {client_address}: received {len(block_data)} bytes")
@@ -2488,6 +2551,9 @@ class Server:
 class ServerISOConnection:
     """ISO connection wrapper for server-side communication."""
 
+    RECEIVE_DEADLINE = 5.0
+    MAX_REASSEMBLED_SIZE = 1024 * 1024
+
     # COTP PDU types
     COTP_CR = 0xE0  # Connection Request
     COTP_CC = 0xD0  # Connection Confirm
@@ -2510,15 +2576,20 @@ class ServerISOConnection:
     def accept_connection(self) -> bool:
         """Accept ISO connection from client."""
         try:
+            deadline = time.monotonic() + self.RECEIVE_DEADLINE
+
             # Receive COTP Connection Request
-            tpkt_header = self._recv_exact(4)
+            tpkt_header = self._recv_exact(4, deadline)
             version, reserved, length = struct.unpack(">BBH", tpkt_header)
 
             if version != 3:
                 logger.error(f"Invalid TPKT version: {version}")
                 return False
+            if length < 4:
+                logger.error(f"Invalid TPKT length: {length}")
+                return False
 
-            payload = self._recv_exact(length - 4)
+            payload = self._recv_exact(length - 4, deadline)
 
             # Parse COTP Connection Request
             if not self._parse_cotp_cr(payload):
@@ -2545,8 +2616,10 @@ class ServerISOConnection:
         the concatenated payload.
         """
         fragments: list[bytes] = []
+        total_size = 0
+        deadline = time.monotonic() + self.RECEIVE_DEADLINE
         while True:
-            tpkt_header = self._recv_exact(4)
+            tpkt_header = self._recv_exact(4, deadline)
             version, reserved, length = struct.unpack(">BBH", tpkt_header)
 
             if version != 3:
@@ -2556,7 +2629,7 @@ class ServerISOConnection:
             if remaining <= 0:
                 raise S7ConnectionError("Invalid TPKT length")
 
-            payload = self._recv_exact(remaining)
+            payload = self._recv_exact(remaining, deadline)
 
             if len(payload) < 3:
                 raise S7ConnectionError("Invalid COTP DT: too short")
@@ -2566,7 +2639,11 @@ class ServerISOConnection:
             if pdu_type != self.COTP_DT:
                 raise S7ConnectionError(f"Expected COTP DT, got {pdu_type:#02x}")
 
-            fragments.append(payload[3:])
+            fragment = payload[3:]
+            total_size += len(fragment)
+            if total_size > self.MAX_REASSEMBLED_SIZE:
+                raise S7ConnectionError(f"Reassembled COTP request exceeds {self.MAX_REASSEMBLED_SIZE} bytes")
+            fragments.append(fragment)
 
             if eot_num & 0x80:
                 break
@@ -2637,12 +2714,30 @@ class ServerISOConnection:
 
         return base_pdu + pdu_size_param
 
-    def _recv_exact(self, size: int) -> bytes:
-        """Receive exactly the specified number of bytes."""
+    def _recv_exact(self, size: int, deadline: float | None = None) -> bytes:
+        """Receive exactly the specified bytes within one absolute deadline."""
+        if size < 0:
+            raise S7ConnectionError(f"Invalid receive size: {size}")
+
+        if deadline is None:
+            deadline = time.monotonic() + self.RECEIVE_DEADLINE
+
         data = bytearray()
 
         while len(data) < size:
-            chunk = self.socket.recv(size - len(data))
+            remaining_time = deadline - time.monotonic()
+            if remaining_time <= 0:
+                if data:
+                    raise S7ConnectionError("Receive deadline exceeded after partial frame")
+                raise TimeoutError("Receive deadline exceeded")
+
+            self.socket.settimeout(remaining_time)
+            try:
+                chunk = self.socket.recv(size - len(data))
+            except TimeoutError as e:
+                if data:
+                    raise S7ConnectionError("Receive deadline exceeded after partial frame") from e
+                raise
             if not chunk:
                 raise ConnectionResetError("Connection closed by peer")
             data.extend(chunk)

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -5,14 +5,16 @@ Uses the same Server fixture as test_client.py for integration tests.
 
 import asyncio
 import logging
+import struct
 from collections.abc import AsyncGenerator, Generator
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import pytest_asyncio
 
-from snap7.async_client import AsyncClient
+from snap7.async_client import AsyncClient, AsyncISOTCPConnection
 from snap7.server import Server
-from snap7.type import SrvArea, Area, Parameter
+from snap7.type import Area, Parameter, SrvArea
 
 logging.basicConfig(level=logging.WARNING)
 
@@ -299,6 +301,53 @@ def test_get_param_non_client_raises() -> None:
     c = AsyncClient()
     with pytest.raises(RuntimeError):
         c.get_param(Parameter.LocalPort)
+
+
+@pytest.mark.asyncio
+async def test_invalid_negotiated_pdu_length_uses_safe_default() -> None:
+    client = AsyncClient()
+    response = {"parameters": {"pdu_length": 0}}
+
+    with patch.object(client, "_send_receive", new=AsyncMock(return_value=response)):
+        await client._setup_communication()
+
+    assert client.pdu_length == 240
+    assert client._max_read_size() == 222
+    assert client._max_write_size() == 205
+
+
+@pytest.mark.parametrize(
+    ("parameter", "expected"),
+    [
+        (struct.pack(">BBB", 0xC0, 1, 0x0A), 1024),
+        (struct.pack(">BBH", 0xC0, 2, 2048), 2048),
+    ],
+)
+def test_async_cotp_accepts_valid_pdu_sizes(parameter: bytes, expected: int) -> None:
+    connection = AsyncISOTCPConnection("127.0.0.1")
+    base = struct.pack(">BBHHB", 6 + len(parameter), 0xD0, 0x0001, 0x0001, 0x00)
+
+    connection._parse_cotp_cc(base + parameter)
+
+    assert connection.pdu_size == expected
+
+
+@pytest.mark.parametrize(
+    "parameter",
+    [
+        struct.pack(">BBB", 0xC0, 1, 0x00),
+        struct.pack(">BBB", 0xC0, 1, 0xFF),
+        struct.pack(">BBH", 0xC0, 2, 127),
+        struct.pack(">BBH", 0xC0, 2, 8193),
+    ],
+)
+def test_async_cotp_ignores_invalid_pdu_sizes(parameter: bytes) -> None:
+    connection = AsyncISOTCPConnection("127.0.0.1")
+    base = struct.pack(">BBHHB", 6 + len(parameter), 0xD0, 0x0001, 0x0001, 0x00)
+
+    connection._parse_cotp_cc(base + parameter)
+
+    assert connection.pdu_size == 240
 
 
 # -------------------------------------------------------------------

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -2,7 +2,7 @@ import logging
 import struct
 import time
 from typing import Any, Tuple
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 import unittest
@@ -1049,6 +1049,17 @@ class TestPDUSplitting:
         client = Client()
         client.pdu_length = 480
         assert client._max_write_size() == 480 - 35
+
+    def test_invalid_negotiated_pdu_length_uses_safe_default(self) -> None:
+        client = Client()
+        response = {"parameters": {"pdu_length": 0}}
+
+        with patch.object(client, "_send_receive", return_value=response):
+            client._setup_communication()
+
+        assert client.pdu_length == 240
+        assert client._max_read_size() == 222
+        assert client._max_write_size() == 205
 
     def test_read_area_splits_large_request(self) -> None:
         """read_area should make multiple requests when size > max_read_size."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -1,15 +1,17 @@
 from ctypes import c_char
 import logging
+import socket
 import time
 from datetime import datetime
 
 import pytest
 import unittest
 from threading import Thread
+from unittest.mock import MagicMock
 
 from snap7.client import Client
-from snap7.error import server_errors, error_text
-from snap7.server import Server
+from snap7.error import server_errors, error_text, S7ConnectionError
+from snap7.server import Server, ServerISOConnection
 from snap7.type import SrvEvent, mkEvent, mkLog, SrvArea, Parameter, Block
 
 logging.basicConfig(level=logging.WARNING)
@@ -125,7 +127,7 @@ class TestServer(unittest.TestCase):
         # check the defaults
         self.assertEqual(self.server.get_param(Parameter.LocalPort), 12102)
         self.assertEqual(self.server.get_param(Parameter.WorkInterval), 100)
-        self.assertEqual(self.server.get_param(Parameter.MaxClients), 1024)
+        self.assertEqual(self.server.get_param(Parameter.MaxClients), 64)
 
         # invalid param for server
         self.assertRaises(Exception, self.server.get_param, Parameter.RemotePort)
@@ -143,10 +145,79 @@ class TestServerBeforeStart(unittest.TestCase):
     def test_set_param(self) -> None:
         self.server.set_param(Parameter.LocalPort, 1102)
 
+    def test_max_clients_parameter(self) -> None:
+        self.server.set_param(Parameter.MaxClients, 3)
+        self.assertEqual(self.server.get_param(Parameter.MaxClients), 3)
+        self.assertRaises(ValueError, self.server.set_param, Parameter.MaxClients, 0)
+
+    def test_max_clients_constructor_validation(self) -> None:
+        self.assertRaises(ValueError, Server, max_clients=0)
+
 
 @pytest.mark.server
 class TestServerRobustness(unittest.TestCase):
     """Test server robustness and edge cases."""
+
+    def test_max_clients_is_enforced(self) -> None:
+        server = Server(max_clients=1)
+        first = None
+        second = None
+        try:
+            server.start(0)
+            assert server.server_socket is not None
+            port = server.server_socket.getsockname()[1]
+
+            first = socket.create_connection(("127.0.0.1", port), timeout=1)
+            deadline = time.monotonic() + 2
+            while server.client_count != 1 and time.monotonic() < deadline:
+                time.sleep(0.01)
+            self.assertEqual(server.client_count, 1)
+
+            second = socket.create_connection(("127.0.0.1", port), timeout=1)
+            second.settimeout(2)
+            try:
+                self.assertEqual(second.recv(1), b"")
+            except ConnectionResetError:
+                pass
+
+            self.assertEqual(server.client_count, 1)
+        finally:
+            if first is not None:
+                first.close()
+            if second is not None:
+                second.close()
+            server.stop()
+
+    def test_download_target_and_size_are_bounded(self) -> None:
+        server = Server()
+        server.register_area(SrvArea.DB, 2, bytearray(4))
+        address = ("127.0.0.1", 12345)
+
+        start_pdu = server.protocol.build_download_request(0x41, 2, b"1234")
+        start_request = server._parse_request(start_pdu)
+        response = server._handle_request_download(start_request, address)
+
+        self.assertEqual(response[10:12], b"\x00\x00")
+        self.assertEqual(server._download_contexts[address]["block_num"], 2)
+        self.assertEqual(server._download_contexts[address]["max_size"], 4)
+
+        server._handle_download_block({"sequence": 1, "data": {"data": b"123"}}, address)
+        response = server._handle_download_block({"sequence": 2, "data": {"data": b"45"}}, address)
+
+        self.assertEqual(response[10:12], b"\x81\x04")
+        self.assertNotIn(address, server._download_contexts)
+
+    def test_oversized_download_is_rejected_before_context_allocation(self) -> None:
+        server = Server()
+        server.register_area(SrvArea.DB, 2, bytearray(4))
+        address = ("127.0.0.1", 12345)
+
+        pdu = server.protocol.build_download_request(0x41, 2, b"12345")
+        request = server._parse_request(pdu)
+        response = server._handle_request_download(request, address)
+
+        self.assertEqual(response[10:12], b"\x81\x04")
+        self.assertFalse(hasattr(server, "_download_contexts"))
 
     def test_multiple_server_instances(self) -> None:
         """Test multiple server instances on different ports."""
@@ -241,6 +312,33 @@ class TestServerRobustness(unittest.TestCase):
 
 ip = "127.0.0.1"
 SERVER_PORT = 12200
+
+
+@pytest.mark.server
+class TestServerISOConnectionLimits:
+    def test_partial_frame_timeout_closes_connection(self) -> None:
+        client_socket = MagicMock()
+        client_socket.recv.side_effect = [b"\x03", TimeoutError()]
+        connection = ServerISOConnection(client_socket)
+
+        with pytest.raises(S7ConnectionError, match="partial frame"):
+            connection._recv_exact(4, time.monotonic() + 1)
+
+    def test_reassembled_request_size_is_bounded(self) -> None:
+        client_socket = MagicMock()
+        connection = ServerISOConnection(client_socket)
+        connection.MAX_REASSEMBLED_SIZE = 4
+        connection._recv_exact = MagicMock(
+            side_effect=[
+                b"\x03\x00\x00\x0a",
+                b"\x02\xf0\x00abc",
+                b"\x03\x00\x00\x09",
+                b"\x02\xf0\x80de",
+            ]
+        )
+
+        with pytest.raises(S7ConnectionError, match="exceeds 4 bytes"):
+            connection.receive_data()
 
 
 @pytest.mark.server
@@ -353,6 +451,15 @@ class TestServerBlockOperations(unittest.TestCase):
         # Verify the data was written by reading it back
         read_back = self.client.db_read(1, 0, 4)
         self.assertEqual(read_back, download_data)
+
+    def test_download_uses_requested_block_number(self) -> None:
+        """Download data to DB2 rather than silently falling back to DB1."""
+        download_data = bytearray([0x12, 0x34, 0x56, 0x78])
+
+        result = self.client.download(download_data, block_num=2)
+
+        self.assertEqual(result, 0)
+        self.assertEqual(self.client.db_read(2, 0, 4), download_data)
 
 
 @pytest.mark.server

--- a/uv.lock
+++ b/uv.lock
@@ -885,7 +885,7 @@ wheels = [
 
 [[package]]
 name = "python-snap7"
-version = "3.1.1"
+version = "3.1.2"
 source = { editable = "." }
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary

- backport the validated server resource bounds and protocol robustness fixes
- correct the inaccurate 3.1.1 vulnerability/CWE descriptions and mark it yanked
- bump the maintenance release to 3.1.2
- require the release tag to match the maintenance branch and install the exact published version in smoke tests

This PR intentionally remains a draft until #810 is merged to master, preserving the project rule that shared fixes land on master first.

## Validation

- 1033 passed, 50 skipped
- full pre-commit suite passed