### PR TITLE
fix(tls): allow TLS 1.3 and restrict offered groups in async client

### DIFF
--- a/s7commplus/async_client.py
+++ b/s7commplus/async_client.py
@@ -9,7 +9,7 @@ import ssl
 import struct
 from typing import Any, Optional
 
-from .connection import _S7_CIPHERS
+from .connection import _S7_CIPHERS, _set_s7_groups
 from .protocol import (
     DataType,
     ElementID,
@@ -251,9 +251,9 @@ class S7CommPlusAsyncClient:
 
         ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
         ctx.minimum_version = ssl.TLSVersion.TLSv1_2
-        ctx.maximum_version = ssl.TLSVersion.TLSv1_2
 
         ctx.set_ciphers(_S7_CIPHERS)
+        _set_s7_groups(ctx)
         ctx.options |= ssl.OP_NO_TICKET
         ctx.options |= 0x00080000  # SSL_OP_NO_ENCRYPT_THEN_MAC
         ctx.options |= 0x00000001  # SSL_OP_NO_EXTENDED_MASTER_SECRET (OpenSSL 3.0+)


### PR DESCRIPTION
Port the client-side TLS compatibility fix to the async client, which was missed when the change landed for the sync connection and server.

- Remove maximum_version=TLSv1_2 pin, which blocked TLS 1.3 PLCs. minimum_version=TLSv1_2 stays as the floor for older firmware.
- Restrict offered groups via _set_s7_groups. Siemens PLCs RST when they see unsupported groups in the ClientHello, regardless of TLS version.

The async context now matches `_setup_ssl_context` in `connection.py` sharing  `_S7_CIPHERS` and `_set_s7_groups` so the cipher string cannot drift between them.

Tested against a S7 1517TF, FW 3.1.5, no special secure connection required, no password (browsing and random read both worked).

Closes #814 