### PR TITLE
fix(server): treat a client disconnect as a normal end, not an error

### DIFF
--- a/snap7/server/__init__.py
+++ b/snap7/server/__init__.py
@@ -625,7 +625,6 @@ class Server:
 
             # Handle ISO connection setup
             if not connection.accept_connection():
-                logger.warning(f"Failed to establish ISO connection with {address}")
                 return
 
             logger.info(f"ISO connection established with {address}")
@@ -2607,9 +2606,6 @@ class ServerISOConnection:
             return True
 
         except (ConnectionResetError, ConnectionAbortedError, TimeoutError) as e:
-            # A peer that goes away before the ISO handshake completes is
-            # routine - port scans, health checks, a cancelled connect - and
-            # says nothing about this server.
             logger.info(f"Peer left before the ISO connection was established: {e}")
             return False
         except Exception as e:
@@ -2645,8 +2641,6 @@ class ServerISOConnection:
             pdu_len, pdu_type, eot_num = struct.unpack(">BBB", payload[:3])
 
             if pdu_type == self.COTP_DR:
-                # The peer is closing the connection the way ISO 8073 says to;
-                # confirm it and let the caller treat this as a normal end.
                 logger.debug("Received COTP DR from client")
                 try:
                     self.socket.sendall(self._build_tpkt(self._build_cotp_dc()))

--- a/snap7/server/__init__.py
+++ b/snap7/server/__init__.py
@@ -2606,6 +2606,12 @@ class ServerISOConnection:
             logger.debug("ISO connection established")
             return True
 
+        except (ConnectionResetError, ConnectionAbortedError, TimeoutError) as e:
+            # A peer that goes away before the ISO handshake completes is
+            # routine - port scans, health checks, a cancelled connect - and
+            # says nothing about this server.
+            logger.info(f"Peer left before the ISO connection was established: {e}")
+            return False
         except Exception as e:
             logger.error(f"Error accepting ISO connection: {e}")
             return False
@@ -2637,6 +2643,16 @@ class ServerISOConnection:
                 raise S7ConnectionError("Invalid COTP DT: too short")
 
             pdu_len, pdu_type, eot_num = struct.unpack(">BBB", payload[:3])
+
+            if pdu_type == self.COTP_DR:
+                # The peer is closing the connection the way ISO 8073 says to;
+                # confirm it and let the caller treat this as a normal end.
+                logger.debug("Received COTP DR from client")
+                try:
+                    self.socket.sendall(self._build_tpkt(self._build_cotp_dc()))
+                except OSError:
+                    pass  # the peer may already be gone
+                raise ConnectionAbortedError("Client requested disconnect")
 
             if pdu_type != self.COTP_DT:
                 raise S7ConnectionError(f"Expected COTP DT, got {pdu_type:#02x}")
@@ -2714,6 +2730,16 @@ class ServerISOConnection:
         )
 
         return base_pdu + pdu_size_param
+
+    def _build_cotp_dc(self) -> bytes:
+        """Build COTP Disconnect Confirm."""
+        return struct.pack(
+            ">BBHH",
+            5,  # PDU length
+            self.COTP_DC,  # PDU type
+            self.dst_ref,  # Destination reference
+            self.src_ref,  # Source reference
+        )
 
     def _recv_exact(self, size: int, deadline: float | None = None) -> bytes:
         """Receive exactly the specified bytes within one absolute deadline."""

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -327,6 +327,49 @@ class TestServerISOConnectionLimits:
         assert connection_confirm == bytes.fromhex("09d0000f000100c00109")
         assert connection_confirm[0] == len(connection_confirm) - 1
 
+    def test_disconnect_confirm_has_valid_length(self) -> None:
+        client_socket = MagicMock()
+        connection = ServerISOConnection(client_socket)
+        connection.dst_ref = 0x000F
+        connection.src_ref = 0x0001
+
+        disconnect_confirm = connection._build_cotp_dc()
+
+        assert disconnect_confirm == bytes.fromhex("05c0000f0001")
+        assert disconnect_confirm[0] == len(disconnect_confirm) - 1
+
+    def test_a_disconnect_request_ends_the_connection_normally(self) -> None:
+        # The client sends a COTP DR when it disconnects; treating it as an
+        # unexpected PDU logs an error for an ordinary goodbye.
+        client_socket = MagicMock()
+        connection = ServerISOConnection(client_socket)
+        connection._recv_exact = MagicMock(
+            side_effect=[
+                b"\x03\x00\x00\x0b",
+                b"\x06\x80\x00\x00\x01\x00\x00",
+            ]
+        )
+
+        with pytest.raises(ConnectionAbortedError):
+            connection.receive_data()
+
+        sent = b"".join(call.args[0] for call in client_socket.sendall.call_args_list)
+        assert sent[5:6] == bytes([connection.COTP_DC]), "the disconnect is confirmed"
+
+    def test_a_disconnect_request_is_confirmed_even_if_the_peer_is_gone(self) -> None:
+        client_socket = MagicMock()
+        client_socket.sendall.side_effect = OSError("broken pipe")
+        connection = ServerISOConnection(client_socket)
+        connection._recv_exact = MagicMock(
+            side_effect=[
+                b"\x03\x00\x00\x0b",
+                b"\x06\x80\x00\x00\x01\x00\x00",
+            ]
+        )
+
+        with pytest.raises(ConnectionAbortedError):
+            connection.receive_data()
+
     def test_partial_frame_timeout_closes_connection(self) -> None:
         client_socket = MagicMock()
         client_socket.recv.side_effect = [b"\x03", TimeoutError()]

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -339,8 +339,6 @@ class TestServerISOConnectionLimits:
         assert disconnect_confirm[0] == len(disconnect_confirm) - 1
 
     def test_a_disconnect_request_ends_the_connection_normally(self) -> None:
-        # The client sends a COTP DR when it disconnects; treating it as an
-        # unexpected PDU logs an error for an ordinary goodbye.
         client_socket = MagicMock()
         connection = ServerISOConnection(client_socket)
         connection._recv_exact = MagicMock(
@@ -828,6 +826,71 @@ class TestServerPLCControl(unittest.TestCase):
         """copy_ram_to_rom should succeed."""
         result = self.client.copy_ram_to_rom(timeout=1000)
         self.assertEqual(result, 0)
+
+
+@pytest.mark.server
+class TestHandshakeLogging(unittest.TestCase):
+    """A peer that leaves before the ISO handshake completes must not raise the log level."""
+
+    server: Server = None  # type: ignore
+    port: int = 0
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.server = Server()
+        cls.server.start(0)
+        assert cls.server.server_socket is not None
+        cls.port = cls.server.server_socket.getsockname()[1]
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        if cls.server:
+            cls.server.stop()
+            cls.server.destroy()
+
+    def _wait_for_record(self, logs, fragment: str, timeout: float = 10.0) -> None:
+        end = time.monotonic() + timeout
+        while time.monotonic() < end:
+            if any(fragment in record.getMessage() for record in logs.records):
+                return
+            time.sleep(0.02)
+        self.fail(f"log containing {fragment!r} did not appear, got: {[r.getMessage() for r in logs.records]}")
+
+    def _assert_no_warnings(self, logs) -> None:
+        warnings = [r.getMessage() for r in logs.records if r.levelno >= logging.WARNING]
+        self.assertEqual(warnings, [])
+
+    def test_connect_and_close_logs_no_warning(self) -> None:
+        with self.assertLogs("snap7.server", level="DEBUG") as logs:
+            sock = socket.create_connection(("127.0.0.1", self.port), timeout=2)
+            sock.close()
+            self._wait_for_record(logs, "Peer left before the ISO connection")
+        self._assert_no_warnings(logs)
+
+    def test_partial_tpkt_then_close_logs_no_warning(self) -> None:
+        with self.assertLogs("snap7.server", level="DEBUG") as logs:
+            sock = socket.create_connection(("127.0.0.1", self.port), timeout=2)
+            sock.sendall(b"\x03\x00")
+            sock.close()
+            self._wait_for_record(logs, "Peer left before the ISO connection")
+        self._assert_no_warnings(logs)
+
+    def test_malformed_tpkt_still_logs_an_error(self) -> None:
+        with self.assertLogs("snap7.server", level="DEBUG") as logs:
+            sock = socket.create_connection(("127.0.0.1", self.port), timeout=2)
+            sock.sendall(b"\x05\x00\x00\x08garbage!")
+            self._wait_for_record(logs, "Invalid TPKT version")
+            sock.close()
+        self.assertTrue(any(r.levelno == logging.ERROR for r in logs.records))
+        self.assertFalse(any(r.levelno == logging.WARNING for r in logs.records))
+
+    def test_client_connect_and_disconnect_logs_no_warning(self) -> None:
+        with self.assertLogs("snap7.server", level="DEBUG") as logs:
+            client = Client()
+            client.connect(ip, 0, 1, self.port)
+            client.disconnect()
+            self._wait_for_record(logs, "disconnected")
+        self._assert_no_warnings(logs)
 
 
 @pytest.mark.server


### PR DESCRIPTION
Fixes #846.

`Client.disconnect()` sends a COTP Disconnect Request, which `receive_data()` rejected as an unexpected PDU, so an ordinary goodbye from the library's own client was logged as an error:

```
ERROR  Error handling client ('127.0.0.1', 58143): Expected COTP DT, got 0x80
```

`COTP_DR` and `COTP_DC` were already defined in `ServerISOConnection` but never used on the receiving side. A DR is now confirmed with a DC and ends the connection through the path `_handle_client()` already treats as a normal disconnect. Sending the confirmation is best effort — a client that closes right after the request may already be gone, which is what the library's own client does.

`accept_connection()` logged a peer that leaves before the handshake completes the same way; that is routine, so it is reported at info level now.

**Measured**, before and after, on the four ways a client can leave — a clean disconnect after a request, a clean disconnect without one, a plain TCP close and an abrupt reset. All four logged an error before; none do now, and the normal disconnect reads:

```
DEBUG  Received COTP DR from client
INFO   Client ('127.0.0.1', 58156) disconnected
```

Three tests cover it: the DC framing, that a DR ends the connection and is confirmed, and that it still ends cleanly when the confirmation cannot be sent. Each fails without the change. `pytest` is 1774 passed, and `mypy` and `ruff` report the same counts as master.

One thing I did not touch: `snap7/connection.py` and `snap7/async_client.py` have the same `Expected COTP DT` check on the client side, so a device that sends a DR would be reported as an error there too. I have no hardware to see whether a real CPU does that, so I left it alone rather than guess.
