### PR TITLE
Reduce CI test matrix duplication

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,4 +40,8 @@ jobs:
       - name: Install dependencies
         run: uv sync --extra test --extra s7commplus --python python${{ matrix.python-version }}
       - name: Run pytest
+        if: matrix.python-version != '3.14' || matrix.os != 'ubuntu-24.04'
+        run: uv run pytest
+      - name: Run pytest with coverage
+        if: matrix.python-version == '3.14' && matrix.os == 'ubuntu-24.04'
         run: uv run pytest --cov=snap7 --cov-report=term

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,8 +18,12 @@ jobs:
           - {python-version: "3.11", os: ubuntu-24.04}
           - {python-version: "3.12", os: ubuntu-24.04}
           - {python-version: "3.13", os: ubuntu-24.04}
+          - {python-version: "3.14", os: ubuntu-22.04}
           - {python-version: "3.14", os: ubuntu-24.04}
+          - {python-version: "3.14", os: ubuntu-26.04}
+          - {python-version: "3.14", os: macos-14}
           - {python-version: "3.14", os: macos-15}
+          - {python-version: "3.14", os: windows-2022}
           - {python-version: "3.14", os: windows-2025}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,9 +13,15 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
-        runs-on: ["ubuntu-22.04", "ubuntu-24.04", "ubuntu-26.04", "macos-14", "macos-15", "windows-2022", "windows-2025"]
-    runs-on: ${{ matrix.runs-on }}
+        include:
+          - {python-version: "3.10", os: ubuntu-24.04}
+          - {python-version: "3.11", os: ubuntu-24.04}
+          - {python-version: "3.12", os: ubuntu-24.04}
+          - {python-version: "3.13", os: ubuntu-24.04}
+          - {python-version: "3.14", os: ubuntu-24.04}
+          - {python-version: "3.14", os: macos-15}
+          - {python-version: "3.14", os: windows-2025}
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v7


### PR DESCRIPTION
## Summary

- test Python 3.10 through 3.14 on Ubuntu 24.04
- test Python 3.14 on every currently configured runner platform: Ubuntu 22.04/24.04/26.04, macOS 14/15, and Windows 2022/2025
- collect coverage once, on Python 3.14 with Ubuntu 24.04; all other matrix jobs run plain pytest
- reduce the regular pull-request matrix from 35 jobs to 11 while retaining all seven runner platforms

## Validation

- uv build
- Python 3.12 plain pytest: 1794 passed, 82 skipped in 67.00s
- Python 3.14 pytest with coverage: 1794 passed, 82 skipped in 69.02s; 75.47% coverage
- uv run pre-commit run --all-files