### PR TITLE
fix(server): validate SessionKey handshake emulation

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ Major release: new `s7commplus` package with S7CommPlus protocol support.
 * S7CommPlus symbolic data subscriptions and notification decoding (experimental)
 * TIA Portal XML import for SymbolTable (`SymbolTable.from_tia_xml()`) (experimental)
 * S7CommPlus CPU state reading and block transfer (upload/download)
+* Correct the SessionKey emulator fingerprint encoding and reject missing or
+  malformed authentication structures during integration tests.
 * **Symbolic (LID-based) access for optimized DBs** (experimental):
   `Tag.from_access_string("8A0E0001.A", "REAL")` creates a symbolic Tag;
   `client.read_tag(tag)` routes to S7CommPlus LID-based access via the

--- a/s7commplus/server.py
+++ b/s7commplus/server.py
@@ -39,6 +39,7 @@ from .codec import (
     encode_header,
     encode_pvalue_blob,
     encode_typed_value,
+    skip_typed_value,
 )
 from .connection import _S7_CIPHERS, _set_s7_groups
 from .protocol import (
@@ -53,7 +54,7 @@ from .protocol import (
     ProtocolVersion,
     SoftDataType,
 )
-from .vlq import decode_uint32_vlq, encode_uint32_vlq, encode_uint64_vlq
+from .vlq import decode_uint32_vlq, decode_uint64_vlq, encode_uint32_vlq, encode_uint64_vlq
 
 logger = logging.getLogger(__name__)
 
@@ -234,6 +235,7 @@ class S7CommPlusServer:
         # encrypted for a real Siemens PLC. Tests may therefore provide the
         # negotiated key explicitly to exercise V3 framing end to end.
         self._session_key = session_key
+        self._accepted_session_key_setups = 0
 
         # When True, the server closes the TCP connection after responding
         # to a GetMultiVariables request (emulating firmware like S7-1200
@@ -775,10 +777,7 @@ class S7CommPlusServer:
             # Public key fingerprint (attribute 233) as WString
             response += bytes([ElementID.ATTRIBUTE])
             response += encode_uint32_vlq(Ids.OBJECT_VARIABLE_TYPE_NAME)
-            fp_bytes = self._public_key_fingerprint.encode("utf-16-be")
-            response += bytes([0x00, DataType.WSTRING])
-            response += encode_uint32_vlq(len(fp_bytes))
-            response += fp_bytes
+            response += bytes([0x00]) + encode_typed_value(DataType.WSTRING, self._public_key_fingerprint)
 
             # Session challenge (attribute 303) as USINT array
             response += bytes([ElementID.ATTRIBUTE])
@@ -971,8 +970,18 @@ class S7CommPlusServer:
         response += self._build_response_header(FunctionCode.SET_MULTI_VARIABLES, seq_num)
 
         if self._is_session_setup_write(request_data):
-            logger.debug("SetMultiVariables: accepting session setup write")
-            response += encode_uint64_vlq(0)  # ReturnValue: success
+            return_value = 0
+            if self._session_key is not None:
+                if self._is_valid_session_key_setup(request_data):
+                    with self._lock:
+                        self._accepted_session_key_setups += 1
+                    logger.debug("SetMultiVariables: accepted authenticated session setup write")
+                else:
+                    return_value = 1
+                    logger.warning("SetMultiVariables: rejected missing or malformed SecurityKey setup")
+            else:
+                logger.debug("SetMultiVariables: accepting session setup write")
+            response += encode_uint64_vlq(return_value)
             response += encode_uint32_vlq(0)  # Empty error list
             response += encode_uint32_vlq(0)  # IntegrityId
             return bytes(response)
@@ -1028,6 +1037,110 @@ class S7CommPlusServer:
             ObjectId.SERVER_SESSION_VERSION,
             LegitimationId.SESSION_SETUP_LEGITIMATION,
         )
+
+    def _is_valid_session_key_setup(self, request_data: bytes) -> bool:
+        """Validate the SecurityKey shape and configured public-key descriptor."""
+        if self._session_key is None or self._public_key_fingerprint is None:
+            return False
+
+        try:
+            from .session_auth.blob_metadata import get_public_key_flags, get_symmetric_key_flags
+            from .session_auth.keys import get_public_key, parse_fingerprint
+            from .session_auth.utils import derive_key_id
+
+            family, _ = parse_fingerprint(self._public_key_fingerprint)
+            public_key = get_public_key(self._public_key_fingerprint)
+            expected_public_id = int.from_bytes(derive_key_id(public_key), "little")
+
+            offset = 4  # InObjectId
+
+            def read_u32() -> int:
+                nonlocal offset
+                value, consumed = decode_uint32_vlq(request_data, offset)
+                offset += consumed
+                return value
+
+            def read_u64() -> int:
+                nonlocal offset
+                value, consumed = decode_uint64_vlq(request_data, offset)
+                offset += consumed
+                return value
+
+            def expect_bytes(expected: bytes) -> None:
+                nonlocal offset
+                end = offset + len(expected)
+                if request_data[offset:end] != expected:
+                    raise ValueError("unexpected SecurityKey field")
+                offset = end
+
+            def read_udint(attribute_id: int) -> int:
+                if read_u32() != attribute_id:
+                    raise ValueError("unexpected SecurityKey attribute")
+                expect_bytes(bytes([0x00, DataType.UDINT]))
+                return read_u32()
+
+            def read_key_descriptor() -> tuple[int, int]:
+                nonlocal offset
+                expect_bytes(bytes([0x00, DataType.STRUCT]))
+                if struct.unpack_from(">I", request_data, offset)[0] != Ids.SECURITY_KEY_ID:
+                    raise ValueError("unexpected key descriptor type")
+                offset += 4
+                if read_u32() != 1826:
+                    raise ValueError("missing key id")
+                expect_bytes(bytes([0x00, DataType.ULINT]))
+                key_id = read_u64()
+                key_flags = read_udint(1827)
+                if read_udint(1828) != 0:
+                    raise ValueError("invalid internal key flags")
+                expect_bytes(b"\x00")
+                return key_id, key_flags
+
+            if read_u32() != 2 or read_u32() != 2:
+                return False
+            if read_u32() != LegitimationId.SESSION_SETUP_LEGITIMATION:
+                return False
+            if read_u32() != ObjectId.SERVER_SESSION_VERSION or read_u32() != 1:
+                return False
+
+            expect_bytes(bytes([0x00, DataType.STRUCT]))
+            if struct.unpack_from(">I", request_data, offset)[0] != Ids.STRUCT_SECURITY_KEY:
+                return False
+            offset += 4
+            if read_udint(1801) != 0:
+                return False
+            if read_u32() != 1802:
+                return False
+            expect_bytes(bytes([0x00, DataType.USINT, 0x00]))
+
+            if read_u32() != 1803:
+                return False
+            public_id, public_flags = read_key_descriptor()
+            if read_u32() != 1804:
+                return False
+            _symmetric_id, symmetric_flags = read_key_descriptor()
+
+            if read_u32() != 1805:
+                return False
+            expect_bytes(bytes([0x00, DataType.BLOB, 0x00]))
+            blob_length = read_u32()
+            if blob_length == 0 or offset + blob_length > len(request_data):
+                return False
+            offset += blob_length
+            expect_bytes(b"\x00")
+
+            if read_u32() != 2 or offset + 2 > len(request_data):
+                return False
+            flags = request_data[offset]
+            datatype = request_data[offset + 1]
+            offset = skip_typed_value(request_data, offset + 2, datatype, flags)
+
+            return (
+                public_id == expected_public_id
+                and public_flags == get_public_key_flags(family)
+                and symmetric_flags == get_symmetric_key_flags(family) | 0x10000
+            )
+        except (IndexError, LookupError, ValueError, struct.error):
+            return False
 
     def _handle_get_var_substreamed(self, seq_num: int, session_id: int, request_data: bytes) -> bytes:
         """Handle GetVarSubStreamed — return legitimation challenge or finalization data.

--- a/tests/test_s7_server.py
+++ b/tests/test_s7_server.py
@@ -12,10 +12,10 @@ import pytest
 from snap7.error import S7ConnectionError
 from s7commplus.async_client import S7CommPlusAsyncClient
 from s7commplus.client import S7CommPlusClient
-from s7commplus.connection import S7CommPlusConnection, _parse_get_var_substreamed_response, _verify_v3_hmac
+from s7commplus.connection import _parse_get_var_substreamed_response, _verify_v3_hmac
 from s7commplus.protocol import DataType, ElementID, Ids, LegitimationId, ObjectId, ProtocolVersion
 from s7commplus.server import CPUState, DataBlock, S7CommPlusServer
-from s7commplus.vlq import encode_uint32_vlq
+from s7commplus.vlq import decode_uint64_vlq, encode_uint32_vlq
 
 # Use a high port to avoid conflicts
 TEST_PORT = 11120
@@ -487,10 +487,10 @@ class TestSessionKeyServer:
         )
         response = srv._handle_create_object(seq_num=1, request_data=b"")
 
-        # Attribute 233 (fingerprint): 0xA3 + VLQ(233) + 0x00 + 0x15(WSTRING) + VLQ(len) + utf-16-be
+        # Attribute 233 uses the ordinary UTF-8 S7CommPlus WString codec.
         attr_233_marker = bytes([ElementID.ATTRIBUTE]) + encode_uint32_vlq(Ids.OBJECT_VARIABLE_TYPE_NAME)
         assert attr_233_marker in response, "Attribute 233 not found"
-        fp_bytes = TEST_FINGERPRINT.encode("utf-16-be")
+        fp_bytes = TEST_FINGERPRINT.encode("utf-8")
         assert fp_bytes in response, "Fingerprint WString content not found"
 
         # Attribute 303 (challenge): 0xA3 + VLQ(303) + 0x10(array flag) + 0x02(USINT)
@@ -543,29 +543,40 @@ class TestSessionKeyServer:
         response = srv._handle_set_var_substreamed(seq_num=1, session_id=1, request_data=b"\x00" * 248)
         assert len(response) > 0
 
+    def test_session_key_server_rejects_malformed_security_key(self) -> None:
+        srv = S7CommPlusServer(
+            public_key_fingerprint=TEST_FINGERPRINT,
+            session_challenge=TEST_CHALLENGE,
+            session_key=TEST_SESSION_KEY,
+        )
+        malformed = struct.pack(">I", 1)
+        malformed += encode_uint32_vlq(2) + encode_uint32_vlq(2)
+        malformed += encode_uint32_vlq(LegitimationId.SESSION_SETUP_LEGITIMATION)
+        malformed += encode_uint32_vlq(ObjectId.SERVER_SESSION_VERSION)
+        malformed += encode_uint32_vlq(1) + bytes([0x00, DataType.STRUCT])
+
+        response = srv._handle_set_multi_variables(seq_num=1, session_id=1, request_data=malformed)
+        return_value, _ = decode_uint64_vlq(response, 10)
+        assert return_value != 0
+        assert srv._accepted_session_key_setups == 0
+
 
 class TestSessionKeyIntegration:
-    """Integration tests: client connecting to a SessionKey-enabled server.
-
-    When the session_auth module is available (PR #761 branch), the full
-    SessionKey handshake is exercised. When it's not available (master),
-    the client falls back gracefully and the server still works for
-    basic read/write after a partial session setup.
-    """
+    """Integration tests: client connecting to a SessionKey-enabled server."""
 
     @pytest.fixture()
     def session_key_server(self, monkeypatch: pytest.MonkeyPatch) -> Generator[S7CommPlusServer, None, None]:
         # The emulator does not own Siemens' private key, so make the client-side
         # key exchange deterministic and configure the matching negotiated key.
-        from s7commplus.session_auth import legitimate
-        from s7commplus.session_auth.keys import KeyFamily
+        from s7commplus.session_auth import legacy_auth, legitimate
 
-        def authenticate(_connection: S7CommPlusConnection) -> tuple[bytes, bytes]:
-            _connection._session_auth_public_key = bytes(40)
-            _connection._session_auth_family = KeyFamily.S7_1200
+        def authenticate(challenge: bytes, public_key: bytes, family: int) -> tuple[bytes, bytes]:
+            assert challenge == TEST_CHALLENGE
+            assert public_key
+            assert int(family) == 1
             return bytes(180), TEST_SESSION_KEY
 
-        monkeypatch.setattr(S7CommPlusConnection, "_try_session_key_auth", authenticate)
+        monkeypatch.setattr(legacy_auth, "authenticate_real_plc", authenticate)
         monkeypatch.setattr(legitimate, "solve_legitimate_challenge_real_plc", lambda *args: bytes(248))
         srv = S7CommPlusServer(
             public_key_fingerprint=TEST_FINGERPRINT,
@@ -590,7 +601,27 @@ class TestSessionKeyIntegration:
         assert client.session_setup_ok
         assert client._connection is not None
         assert client._connection._session_key == TEST_SESSION_KEY
+        assert session_key_server._accepted_session_key_setups == 1
         client.disconnect()
+
+    def test_unknown_fingerprint_cannot_bypass_session_key_setup(self) -> None:
+        srv = S7CommPlusServer(
+            public_key_fingerprint="01:0000000000000000",
+            session_challenge=TEST_CHALLENGE,
+            session_key=TEST_SESSION_KEY,
+        )
+        srv.start(port=SESSION_KEY_PORT)
+        time.sleep(0.1)
+        client = S7CommPlusClient()
+        try:
+            client.connect("127.0.0.1", port=SESSION_KEY_PORT)
+            assert client._connection is not None
+            assert client._connection._session_key is None
+            assert not client.session_setup_ok
+            assert srv._accepted_session_key_setups == 0
+        finally:
+            client.disconnect()
+            srv.stop()
 
     def test_read_write_after_session_setup(self, session_key_server: S7CommPlusServer) -> None:
         """Read/write works after successful session setup with SessionKey server."""


### PR DESCRIPTION
## Summary

- encode the emulator public-key fingerprint with the normal UTF-8 S7CommPlus WString codec
- exercise the real SessionKey selection path in the integration test instead of bypassing it
- validate the submitted SecurityKey structure, public-key descriptor, flags and encrypted blob
- reject malformed handshakes and unknown fingerprints

## Validation

- `uv run --frozen --extra test --extra s7commplus pytest -q` (1,910 passed, 78 skipped)
- `uv run --frozen pre-commit run --all-files`
- `uv build --no-sources`

Fixes #829