### PR TITLE
fix(s7commplus): make session setup atomic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,8 @@ Major release: new `s7commplus` package with S7CommPlus protocol support.
 * S7CommPlus symbolic data subscriptions and notification decoding (experimental)
 * TIA Portal XML import for SymbolTable (`SymbolTable.from_tia_xml()`) (experimental)
 * S7CommPlus CPU state reading and block transfer (upload/download)
+* Fix the legacy SecurityKey descriptor to identify the newly generated
+  session key instead of an all-zero placeholder.
 * **Symbolic (LID-based) access for optimized DBs** (experimental):
   `Tag.from_access_string("8A0E0001.A", "REAL")` creates a symbolic Tag;
   `client.read_tag(tag)` routes to S7CommPlus LID-based access via the

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ CHANGES
 
 Major release: new `s7commplus` package with S7CommPlus protocol support.
 
+* Correct legacy GetVarSubStreamed qualifiers and reject unusable authentication challenges.
+
 * New `s7commplus` package for S7CommPlus protocol (S7-1200/1500)
 * S7CommPlus V1, V2 (TLS), and V3 support for S7-1200/1500
 * S7CommPlus area read/write (M, I, Q, counters, timers)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,8 @@ Major release: new `s7commplus` package with S7CommPlus protocol support.
 * S7CommPlus CPU state reading and block transfer (upload/download)
 * Fix the legacy SecurityKey descriptor to identify the newly generated
   session key instead of an all-zero placeholder.
+* Keep SessionKey activation and public connection state pending until the PLC
+  accepts session setup, with complete cleanup on rejection or transport error.
 * **Symbolic (LID-based) access for optimized DBs** (experimental):
   `Tag.from_access_string("8A0E0001.A", "REAL")` creates a symbolic Tag;
   `client.read_tag(tag)` routes to S7CommPlus LID-based access via the

--- a/doc/connecting.rst
+++ b/doc/connecting.rst
@@ -138,6 +138,11 @@ with the ``s7commplus`` extra:
 
    pip install 'python-snap7[s7commplus]'
 
+For a source checkout, use ``python -m pip install -e '.[s7commplus]'``.
+If the legacy SessionKey authentication path cannot import its dependencies,
+connection setup raises an error with these installation instructions and
+releases the connection; it does not continue with an unauthenticated setup.
+
 .. note::
 
    Older S7-1200 firmware (FW < 4.5) negotiates V1 of the S7CommPlus

--- a/s7commplus/async_client.py
+++ b/s7commplus/async_client.py
@@ -101,6 +101,8 @@ class S7CommPlusAsyncClient:
         self._subscription_container_id: int = 0
         self._sequence_number: int = 0
         self._protocol_version: int = 0
+        self._transport_connected = False
+        self._session_ready = False
         self._connected = False
         self._lock = asyncio.Lock()
 
@@ -188,6 +190,7 @@ class S7CommPlusAsyncClient:
 
         # TCP connect
         self._reader, self._writer = await asyncio.open_connection(host, port)
+        self._transport_connected = True
 
         try:
             # Step 1: COTP handshake with S7CommPlus TSAP values
@@ -208,7 +211,22 @@ class S7CommPlusAsyncClient:
             if self._tls_active:
                 self._protocol_version = ProtocolVersion.V2
 
-            # Step 5: Version-specific validation
+            # Step 5: Session setup. A transport and CreateObject response do
+            # not make the public client usable until the PLC accepts setup.
+            if self._server_session_version is None:
+                from snap7.error import S7ConnectionError
+
+                raise S7ConnectionError(
+                    "PLC did not provide a usable ServerSessionVersion attribute; S7CommPlus session setup cannot continue"
+                )
+            self._session_setup_ok = await self._setup_session()
+            if not self._session_setup_ok:
+                from snap7.error import S7ConnectionError
+
+                raise S7ConnectionError("S7CommPlus session setup was rejected by the PLC")
+            self._session_ready = True
+
+            # Step 6: Version-specific validation
             if self._protocol_version >= ProtocolVersion.V3:
                 if not use_tls:
                     logger.warning(
@@ -224,20 +242,11 @@ class S7CommPlusAsyncClient:
                 self._integrity_id_write = 0
                 logger.info("V2 IntegrityId tracking enabled")
 
+            self._protection_level = await self._get_effective_protection_level()
+            if self._protection_level is not None:
+                logger.info(f"PLC reports protection level: {self._protection_level}")
+
             self._connected = True
-
-            # Step 6: Session setup - echo ServerSessionVersion back to PLC
-            if self._server_session_version is not None:
-                self._session_setup_ok = await self._setup_session()
-            else:
-                logger.warning("PLC did not provide ServerSessionVersion - session setup incomplete")
-                self._session_setup_ok = False
-
-            # Only a session that completed setup answers attribute reads.
-            if self._session_setup_ok:
-                self._protection_level = await self._get_effective_protection_level()
-                if self._protection_level is not None:
-                    logger.info(f"PLC reports protection level: {self._protection_level}")
 
             logger.info(
                 f"Async S7CommPlus connected to {host}:{port}, "
@@ -452,13 +461,15 @@ class S7CommPlusAsyncClient:
 
     async def disconnect(self) -> None:
         """Disconnect from PLC."""
-        if self._connected and self._session_id:
+        if self._session_ready and self._session_id:
             try:
                 await self._delete_session()
             except Exception:
                 pass
 
         self._connected = False
+        self._session_ready = False
+        self._transport_connected = False
         self._session_id = 0
         self._subscription_container_id = 0
         self._sequence_number = 0
@@ -838,7 +849,7 @@ class S7CommPlusAsyncClient:
             Response payload (after the 10-byte response header).
         """
         async with self._lock:
-            if not self._connected or self._writer is None or self._reader is None:
+            if not (self._connected or self._transport_connected) or self._writer is None or self._reader is None:
                 raise RuntimeError("Not connected")
 
             seq_num = self._next_sequence_number()
@@ -1080,20 +1091,15 @@ class S7CommPlusAsyncClient:
         payload += encode_object_qualifier(protocol_version=self._protocol_version)
         payload += struct.pack(">I", 0)
 
-        try:
-            resp_payload = await self._send_request(FunctionCode.SET_MULTI_VARIABLES, bytes(payload))
-            if len(resp_payload) >= 1:
-                return_value, _ = decode_uint64_vlq(resp_payload, 0)
-                if return_value != 0:
-                    logger.warning(f"SetupSession: PLC returned error {return_value}")
-                    return False
-                else:
-                    logger.info("Session setup completed successfully")
-                    return True
-            return False
-        except Exception as e:
-            logger.warning(f"SetupSession failed: {e}")
-            return False
+        resp_payload = await self._send_request(FunctionCode.SET_MULTI_VARIABLES, bytes(payload))
+        if len(resp_payload) >= 1:
+            return_value, _ = decode_uint64_vlq(resp_payload, 0)
+            if return_value != 0:
+                logger.warning(f"SetupSession: PLC returned error {return_value}")
+                return False
+            logger.info("Session setup completed successfully")
+            return True
+        return False
 
     async def _delete_session(self) -> None:
         """Send DeleteObject to close the session."""

--- a/s7commplus/connection.py
+++ b/s7commplus/connection.py
@@ -349,6 +349,7 @@ class S7CommPlusConnection:
         self._sequence_number: int = 0
         self._protocol_version: int = 0  # Detected from PLC response
         self._tls_active: bool = False
+        self._session_ready = False
         self._connected = False
         # ServerSessionVersion is captured as its raw typed value (flags+datatype+data)
         # so it can be echoed back verbatim — real S7-1500 PLCs send it as a Struct.
@@ -492,16 +493,21 @@ class S7CommPlusConnection:
             if self._tls_active:
                 self._protocol_version = ProtocolVersion.V2
 
-            # Step 5: Session setup - echo ServerSessionVersion back to PLC
-            if self._server_session_version is not None:
-                self._session_setup_ok = self._setup_session()
-            else:
-                logger.warning(
-                    "PLC did not provide a usable ServerSessionVersion attribute; "
-                    "S7CommPlus session setup cannot continue. No automatic fallback "
-                    "to the classic PUT/GET protocol is performed."
+            # Step 5: Session setup - echo ServerSessionVersion back to PLC.
+            # Transport establishment and CreateObject alone do not make the
+            # public client usable.
+            if self._server_session_version is None:
+                from snap7.error import S7ConnectionError
+
+                raise S7ConnectionError(
+                    "PLC did not provide a usable ServerSessionVersion attribute; S7CommPlus session setup cannot continue"
                 )
-                self._session_setup_ok = False
+            self._session_setup_ok = self._setup_session()
+            if not self._session_setup_ok:
+                from snap7.error import S7ConnectionError
+
+                raise S7ConnectionError("S7CommPlus session setup was rejected by the PLC")
+            self._session_ready = True
 
             # Step 6: Version-specific post-setup
             if self._protocol_version >= ProtocolVersion.V3:
@@ -520,8 +526,6 @@ class S7CommPlusConnection:
                 self._integrity_id_write = 0
                 logger.info("V2 IntegrityId tracking enabled")
 
-            self._connected = True
-
             if self._session_key is not None and self._session_setup_ok:
                 self._session_activate()
                 self._post_auth_legitimation(password=self._connect_password)
@@ -532,6 +536,8 @@ class S7CommPlusConnection:
                 self._protection_level = self._get_effective_protection_level()
                 if self._protection_level is not None:
                     logger.info(f"PLC reports protection level: {self._protection_level}")
+
+            self._connected = True
 
             logger.info(
                 f"S7CommPlus connected to {self.host}:{self.port}, "
@@ -742,13 +748,14 @@ class S7CommPlusConnection:
 
     def disconnect(self) -> None:
         """Disconnect from PLC."""
-        if self._connected and self._session_id:
+        if self._session_ready and self._session_id:
             try:
                 self._delete_session()
             except Exception:
                 pass
 
         self._connected = False
+        self._session_ready = False
         self._session_setup_ok = False
         self._tls_active = False
         self._ssl_object = None
@@ -760,6 +767,12 @@ class S7CommPlusConnection:
         self._sequence_number = 0
         self._protocol_version = 0
         self._server_session_version = None
+        self._public_key_checksum = None
+        self._public_key_fingerprint = None
+        self._session_challenge = None
+        self._session_key = None
+        self._session_auth_public_key = b""
+        self._session_auth_family = 0
         self._with_integrity_id = False
         self._integrity_id_read = 0
         self._integrity_id_write = 0
@@ -786,7 +799,7 @@ class S7CommPlusConnection:
         Returns:
             Response payload (after the 10-byte response header)
         """
-        if not self._connected:
+        if not (self._connected or self._session_ready):
             from snap7.error import S7ConnectionError
 
             raise S7ConnectionError("Not connected")
@@ -1350,13 +1363,6 @@ class S7CommPlusConnection:
 
         request += bytes(payload)
 
-        if include_security_key:
-            self._session_key = session_key
-            self._with_integrity_id = True
-            self._integrity_id_read = 0
-            self._integrity_id_write = 0
-            logger.info("SecurityKey blob included in session setup, IntegrityId tracking enabled")
-
         # Outer S7+ frame is always V2 for the setup write, even if the PLC
         # negotiated V1 on the initial CreateObject.
         frame = encode_header(ProtocolVersion.V2, len(request)) + request
@@ -1388,6 +1394,12 @@ class S7CommPlusConnection:
                 logger.warning(f"SetupSession: PLC returned error {return_value}")
                 return False
             else:
+                if include_security_key and auth_result is not None:
+                    self._session_key = session_key
+                    self._with_integrity_id = True
+                    self._integrity_id_read = 0
+                    self._integrity_id_write = 0
+                    logger.info("SecurityKey accepted by PLC, IntegrityId tracking enabled")
                 logger.info("Session setup completed successfully")
                 return True
         return False

--- a/s7commplus/connection.py
+++ b/s7commplus/connection.py
@@ -1294,6 +1294,15 @@ class S7CommPlusConnection:
             logger.info(f"SessionKey auth blob generated ({len(blob)} bytes)")
             return blob, session_key
 
+        except ImportError as e:
+            from snap7.error import S7ConnectionError
+
+            raise S7ConnectionError(
+                "Cannot load S7CommPlus SessionKey authentication dependencies. "
+                "Install them with python -m pip install 'python-snap7[s7commplus]' "
+                "(or python -m pip install -e '.[s7commplus]' for a source checkout). "
+                f"Original error: {e}"
+            ) from e
         except Exception as e:
             logger.warning(f"SessionKey auth failed: {e}")
             return None

--- a/s7commplus/connection.py
+++ b/s7commplus/connection.py
@@ -1326,7 +1326,7 @@ class S7CommPlusConnection:
             payload += encode_uint32_vlq(LegitimationId.SESSION_SETUP_LEGITIMATION)  # 1830
             payload += encode_uint32_vlq(ObjectId.SERVER_SESSION_VERSION)  # 306
             payload += encode_uint32_vlq(1)  # ItemNumber for SecurityKey
-            payload += self._encode_security_key_struct(blob)
+            payload += self._encode_security_key_struct(blob, session_key)
         else:
             payload += encode_uint32_vlq(1)  # ItemCount
             payload += encode_uint32_vlq(1)  # AddressCount
@@ -1524,7 +1524,7 @@ class S7CommPlusConnection:
 
         logger.info("Post-auth legitimation completed")
 
-    def _encode_security_key_struct(self, blob: bytes) -> bytes:
+    def _encode_security_key_struct(self, blob: bytes, session_key: bytes) -> bytes:
         """Encode the SecurityKey PObject struct (Struct 1800) wrapping the auth blob.
 
         Matches the wire format from TIA Portal / HarpoS7 PoC:
@@ -1533,9 +1533,13 @@ class S7CommPlusConnection:
         """
         from .session_auth.utils import derive_key_id
 
-        public_key_id = derive_key_id(self._session_auth_public_key or b"\x00" * 24)
-        # The symmetric key ID is derived from the session key
-        symmetric_key_id = derive_key_id(self._session_key or b"\x00" * 24)
+        if not self._session_auth_public_key:
+            raise ValueError("SessionKey authentication requires public key material")
+        if not session_key:
+            raise ValueError("SessionKey authentication requires generated session key material")
+
+        public_key_id = derive_key_id(self._session_auth_public_key)
+        symmetric_key_id = derive_key_id(session_key)
 
         # Determine key flags from family
         from .session_auth.blob_metadata import get_public_key_flags, get_symmetric_key_flags

--- a/s7commplus/connection.py
+++ b/s7commplus/connection.py
@@ -1414,18 +1414,17 @@ class S7CommPlusConnection:
         return False
 
     def _build_get_var_substreamed(self, in_object_id: int, address: int, seq_field: int = 1) -> bytes:
-        """Build a GET_VAR_SUBSTREAMED payload (reused by legitimation).
+        """Build the captured GET_VAR_SUBSTREAMED layout for legacy sessions.
 
-        The ObjectQualifier KEY_QUALIFIER carries the next sequence number.
-        ``seq_field`` is the two-byte request sequence field; the IntegrityId
-        is spliced before the final four-byte fill by ``send_request``.
+        TIA's V1-initial requests use the same zero-valued VLQ qualifier and
+        two-byte request field as the reference driver's V2 requests. Using
+        a fixed-width qualifier plus that field adds two bytes (#872).
+        IntegrityId is inserted before the final four-byte fill.
         """
         return _build_get_var_substreamed_payload(
             in_object_id,
             address,
-            key_qualifier=self._sequence_number,
             sequence_field=seq_field,
-            protocol_version=ProtocolVersion.V1,
         )
 
     def _session_activate(self) -> None:
@@ -1474,30 +1473,13 @@ class S7CommPlusConnection:
             integrity_tail=4,
         )
 
-        # Extract the 20-byte challenge from the response.
-        # Response format (per thomas-v2 GetVarSubstreamedResponse):
-        #   UInt64Vlq ReturnValue | byte unknown | PValue(datatype + count_vlq + length_vlq + data) | UInt32Vlq IntegrityId
-        legit_challenge: bytes = self._session_challenge or b""
-        if len(challenge_resp) >= 26:
-            offset = 0
-            retval, c = decode_uint64_vlq(challenge_resp, offset)
-            offset += c
-            if retval != 0:
-                logger.warning(f"Legitimation challenge read returned error: 0x{retval:X}")
-            offset += 1  # unknown byte
-            offset += 1  # datatype tag (0x10 = BLOB/USIntArray)
-            _count, c = decode_uint32_vlq(challenge_resp, offset)
-            offset += c
-            length, c = decode_uint32_vlq(challenge_resp, offset)
-            offset += c
-            if offset + length <= len(challenge_resp) and length == 20:
-                legit_challenge = bytes(challenge_resp[offset : offset + length])
-                logger.info(f"Legitimation challenge: {legit_challenge.hex()}")
-
-        if not legit_challenge:
+        # Never substitute the earlier CreateObject challenge when this read
+        # fails: it belongs to a different authentication exchange.
+        legit_challenge = _parse_get_var_substreamed_response(challenge_resp)
+        if len(legit_challenge) != 20:
             from snap7.error import S7ConnectionError
 
-            raise S7ConnectionError("Post-auth legitimation failed: no challenge available")
+            raise S7ConnectionError("Post-auth legitimation failed: expected a 20-byte challenge")
 
         # Step 2: Solve the challenge
         from .session_auth.legitimate import solve_legitimate_challenge_real_plc

--- a/tests/test_s7_auth_dependency.py
+++ b/tests/test_s7_auth_dependency.py
@@ -1,0 +1,78 @@
+"""Exercise the real SessionKey import path without optional cryptography."""
+
+import subprocess
+import sys
+import textwrap
+
+
+def test_missing_cryptography_aborts_connect_and_releases_socket() -> None:
+    # A fresh interpreter avoids already-imported crypto modules masking a
+    # missing dependency. Only the transport and PLC session data are mocked.
+    script = textwrap.dedent("""
+        import importlib.abc
+        import sys
+        from unittest.mock import MagicMock
+
+        class NoCryptography(importlib.abc.MetaPathFinder):
+            def find_spec(self, fullname, path=None, target=None):
+                if fullname == "cryptography" or fullname.startswith("cryptography."):
+                    raise ModuleNotFoundError("No module named 'cryptography'", name="cryptography")
+
+        sys.meta_path.insert(0, NoCryptography())
+
+        from snap7.error import S7ConnectionError
+        from s7commplus.connection import S7CommPlusConnection
+        from s7commplus.protocol import ProtocolVersion
+
+        conn = S7CommPlusConnection("127.0.0.1")
+        sockets = []
+
+        def open_transport(timeout):
+            sock = MagicMock()
+            sockets.append(sock)
+            conn._iso_conn.socket = sock
+            conn._iso_conn.connected = True
+
+        def create_session():
+            conn._protocol_version = ProtocolVersion.V1
+            conn._session_id = 7
+            conn._server_session_version = b"version"
+            conn._session_challenge = bytes(range(20))
+            conn._public_key_fingerprint = "01:BD426B091F08731A"
+
+        conn._iso_conn.connect = MagicMock(side_effect=open_transport)
+        conn._init_ssl = MagicMock()
+        conn._create_session = MagicMock(side_effect=create_session)
+        conn._send_s7_data = MagicMock()
+
+        for _ in range(2):
+            try:
+                conn.connect()
+            except S7ConnectionError as exc:
+                assert "python-snap7[s7commplus]" in str(exc)
+                assert ".[s7commplus]" in str(exc)
+                assert isinstance(exc.__cause__, ModuleNotFoundError)
+            else:
+                raise AssertionError("Missing cryptography did not abort connect")
+            conn._send_s7_data.assert_not_called()
+            assert not conn.connected
+            assert not conn._session_ready
+            assert not conn.session_setup_ok
+            assert conn.session_id == 0
+            assert conn._session_key is None
+            assert conn._session_auth_public_key == b""
+            assert conn._iso_conn.socket is None
+            assert not conn._iso_conn.connected
+            sockets[-1].close.assert_called_once()
+            conn.disconnect()
+            conn.disconnect()
+
+        # TLS uses a different auth path and must not require legacy crypto.
+        conn._tls_active = True
+        conn._protocol_version = ProtocolVersion.V2
+        conn._session_challenge = bytes(range(20))
+        conn._public_key_fingerprint = "01:BD426B091F08731A"
+        assert conn._try_session_key_auth() is None
+    """)
+    result = subprocess.run([sys.executable, "-c", script], capture_output=True, text=True, timeout=30)
+    assert result.returncode == 0, result.stdout + result.stderr

--- a/tests/test_s7_legacy_request_layout.py
+++ b/tests/test_s7_legacy_request_layout.py
@@ -1,0 +1,69 @@
+"""Legacy substreamed request and challenge regressions from issue #872."""
+
+import hashlib
+import hmac
+import struct
+from unittest.mock import MagicMock
+
+import pytest
+
+from snap7.error import S7ConnectionError
+from s7commplus.codec import encode_header
+from s7commplus.connection import S7CommPlusConnection
+from s7commplus.protocol import FunctionCode, ProtocolVersion
+
+
+def test_v1_substreamed_request_matches_accepted_tia_packet() -> None:
+    # Issue #872: s7-1500.pcapng frame 94, without its session-specific HMAC.
+    # Session ID / sequence / qualifier / integrity ID match that capture.
+    expected = bytes.fromhex(
+        "310000058600000003000003b334"
+        "000003b3200401822c"
+        "000004e88969001200000000896a001300896b000400000001"
+        "01"  # IntegrityId, immediately after ObjectQualifier
+        "00000000"
+    )
+    conn = S7CommPlusConnection("127.0.0.1")
+    conn._session_id = 0x3B3
+    conn._sequence_number = 3  # request header sequence from the same frame
+    payload = conn._build_get_var_substreamed(0x3B3, 300)
+    conn._connected = True
+    conn._session_key = bytes(range(24))
+    conn._with_integrity_id = True
+    conn._integrity_id_read = 1
+    conn._send_s7_data = MagicMock()
+    body = struct.pack(">BHHHHB", 0x32, 0, FunctionCode.GET_VAR_SUBSTREAMED, 0, 3, 0x34) + bytes(4)
+    conn._recv_s7_data = MagicMock(return_value=encode_header(ProtocolVersion.V2, len(body)) + body)
+    conn.send_request(FunctionCode.GET_VAR_SUBSTREAMED, payload)
+    frame = conn._send_s7_data.call_args.args[0]
+    assert frame[37:-4] == expected
+    assert frame[5:37] == hmac.new(bytes(range(24)), expected, hashlib.sha256).digest()
+    assert len(frame) + 7 == 101  # includes TPKT + COTP, as in the capture
+
+
+@pytest.mark.parametrize(
+    "response",
+    [b"\x01", b"", b"\x00\x00\x10\x02\x01\x42\x00", bytes.fromhex("00000000000002fb00000000000000000000001700009d6c00000000")],
+)
+def test_failed_legacy_challenge_does_not_reuse_createobject_challenge(response: bytes) -> None:
+    conn = S7CommPlusConnection("127.0.0.1")
+    conn._session_challenge = bytes(range(20))
+    conn.send_request = MagicMock(return_value=response)
+    with pytest.raises(S7ConnectionError):
+        conn._post_auth_legitimation()
+    conn.send_request.assert_called_once()
+
+
+def test_legacy_legitimation_uses_the_new_challenge(monkeypatch: pytest.MonkeyPatch) -> None:
+    challenge = bytes(range(20))
+    conn = S7CommPlusConnection("127.0.0.1")
+    conn._session_challenge = b"old challenge value!"
+    conn._session_key = bytes(range(24))
+    response = b"\x00\x00\x10\x02\x14" + challenge + b"\x00"
+    conn.send_request = MagicMock(side_effect=[response, b"\x00"])
+    solve = MagicMock(return_value=bytes(248))
+    monkeypatch.setattr("s7commplus.session_auth.legitimate.solve_legitimate_challenge_real_plc", solve)
+    conn._post_auth_legitimation("password")
+    assert solve.call_args.args[0] == challenge
+    assert solve.call_args.args[-1] == "password"
+    assert conn.send_request.call_count == 2

--- a/tests/test_s7_v2.py
+++ b/tests/test_s7_v2.py
@@ -752,6 +752,126 @@ class TestSessionKeySelection:
             conn._encode_security_key_struct(bytes(180), b"")
 
 
+class TestAtomicSessionSetup:
+    def test_rejected_setup_does_not_activate_generated_key(self) -> None:
+        from s7commplus.session_auth.keys import KeyFamily, get_public_key
+
+        conn = S7CommPlusConnection("127.0.0.1")
+        conn._protocol_version = ProtocolVersion.V1
+        conn._session_id = 7
+        conn._server_session_version = bytes([0x00, DataType.UDINT, 0x01])
+        conn._session_auth_public_key = get_public_key("01:BD426B091F08731A")
+        conn._session_auth_family = KeyFamily.S7_1200
+        generated_key = bytes(range(24))
+        conn._try_session_key_auth = MagicMock(return_value=(bytes(180), generated_key))
+        conn._send_s7_data = MagicMock()
+        response = struct.pack(">BHHHHB", Opcode.RESPONSE, 0, FunctionCode.SET_MULTI_VARIABLES, 0, 0, 0)
+        response += bytes([1])
+        conn._recv_s7_data = MagicMock(
+            return_value=encode_header(ProtocolVersion.V2, len(response))
+            + response
+            + struct.pack(">BBH", 0x72, ProtocolVersion.V2, 0)
+        )
+
+        assert not conn._setup_session()
+        assert conn._session_key is None
+        assert not conn._with_integrity_id
+
+    def test_malformed_setup_response_does_not_activate_generated_key(self) -> None:
+        from s7commplus.session_auth.keys import KeyFamily, get_public_key
+
+        conn = S7CommPlusConnection("127.0.0.1")
+        conn._protocol_version = ProtocolVersion.V1
+        conn._session_id = 7
+        conn._server_session_version = bytes([0x00, DataType.UDINT, 0x01])
+        conn._session_auth_public_key = get_public_key("01:BD426B091F08731A")
+        conn._session_auth_family = KeyFamily.S7_1200
+        generated_key = bytes(range(24))
+        conn._try_session_key_auth = MagicMock(return_value=(bytes(180), generated_key))
+        conn._send_s7_data = MagicMock()
+        conn._recv_s7_data = MagicMock(return_value=encode_header(ProtocolVersion.V2, 0))
+
+        with pytest.raises(S7ConnectionError, match="response too short"):
+            conn._setup_session()
+        assert conn._session_key is None
+        assert not conn._with_integrity_id
+
+    def test_sync_rejected_setup_clears_pending_authentication_state(self) -> None:
+        conn = S7CommPlusConnection("127.0.0.1")
+        conn._iso_conn.connect = MagicMock()
+        conn._iso_conn.disconnect = MagicMock()
+        conn._init_ssl = MagicMock()
+
+        def create_session() -> None:
+            conn._protocol_version = ProtocolVersion.V1
+            conn._session_id = 7
+            conn._server_session_version = bytes([0x00, DataType.UDINT, 0x01])
+
+        def reject_setup() -> bool:
+            conn._session_key = bytes(24)
+            conn._with_integrity_id = True
+            return False
+
+        conn._create_session = MagicMock(side_effect=create_session)
+        conn._setup_session = MagicMock(side_effect=reject_setup)
+
+        with pytest.raises(S7ConnectionError, match="session setup was rejected"):
+            conn.connect()
+
+        assert not conn.connected
+        assert not conn.session_setup_ok
+        assert conn._session_key is None
+        assert not conn._with_integrity_id
+        assert not conn._session_ready
+
+    def test_sync_setup_exception_cleans_intermediate_state(self) -> None:
+        conn = S7CommPlusConnection("127.0.0.1")
+        conn._iso_conn.connect = MagicMock()
+        conn._iso_conn.disconnect = MagicMock()
+        conn._init_ssl = MagicMock()
+
+        def create_session() -> None:
+            conn._protocol_version = ProtocolVersion.V1
+            conn._session_id = 7
+            conn._server_session_version = bytes([0x00, DataType.UDINT, 0x01])
+
+        conn._create_session = MagicMock(side_effect=create_session)
+        conn._setup_session = MagicMock(side_effect=OSError("socket closed during setup"))
+
+        with pytest.raises(OSError, match="socket closed during setup"):
+            conn.connect()
+        assert not conn.connected
+        assert conn.session_id == 0
+        assert not conn._session_ready
+
+    @pytest.mark.asyncio
+    async def test_async_rejected_setup_never_becomes_connected(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = S7CommPlusAsyncClient()
+        reader = MagicMock()
+        writer = MagicMock()
+        writer.wait_closed = AsyncMock()
+        monkeypatch.setattr("s7commplus.async_client.asyncio.open_connection", AsyncMock(return_value=(reader, writer)))
+        client._cotp_connect = AsyncMock()
+        client._init_ssl = AsyncMock()
+
+        async def create_session() -> None:
+            client._protocol_version = ProtocolVersion.V1
+            client._session_id = 7
+            client._server_session_version = bytes([0x00, DataType.UDINT, 0x01])
+
+        client._create_session = AsyncMock(side_effect=create_session)
+        client._setup_session = AsyncMock(return_value=False)
+
+        with pytest.raises(S7ConnectionError, match="session setup was rejected"):
+            await client.connect("127.0.0.1")
+
+        assert not client.connected
+        assert not client.session_setup_ok
+        assert not client._session_ready
+        assert not client._transport_connected
+        writer.close.assert_called_once()
+
+
 class TestProtocolVersionV2:
     """Test V2 protocol version constant."""
 

--- a/tests/test_s7_v2.py
+++ b/tests/test_s7_v2.py
@@ -719,6 +719,38 @@ class TestSessionKeySelection:
         assert conn._try_session_key_auth() is None
         assert conn._session_key is None
 
+    def test_security_key_descriptor_uses_pending_generated_key(self) -> None:
+        from s7commplus.session_auth.keys import KeyFamily, get_public_key
+        from s7commplus.session_auth.utils import derive_key_id
+        from s7commplus.vlq import encode_uint64_vlq
+
+        conn = S7CommPlusConnection("127.0.0.1")
+        conn._session_auth_public_key = get_public_key("01:BD426B091F08731A")
+        conn._session_auth_family = KeyFamily.S7_1200
+        generated_key = bytes(range(24))
+
+        assert conn._session_key is None
+        encoded = conn._encode_security_key_struct(bytes(180), generated_key)
+        symmetric_id = int.from_bytes(derive_key_id(generated_key), "little")
+        symmetric_descriptor = (
+            encode_uint32_vlq(1804)
+            + bytes([0x00, DataType.STRUCT])
+            + struct.pack(">I", Ids.SECURITY_KEY_ID)
+            + encode_uint32_vlq(1826)
+            + bytes([0x00, DataType.ULINT])
+            + encode_uint64_vlq(symmetric_id)
+        )
+        assert symmetric_descriptor in encoded
+
+    def test_security_key_descriptor_rejects_missing_key_material(self) -> None:
+        conn = S7CommPlusConnection("127.0.0.1")
+        with pytest.raises(ValueError, match="public key material"):
+            conn._encode_security_key_struct(bytes(180), bytes(24))
+
+        conn._session_auth_public_key = bytes(40)
+        with pytest.raises(ValueError, match="generated session key material"):
+            conn._encode_security_key_struct(bytes(180), b"")
+
 
 class TestProtocolVersionV2:
     """Test V2 protocol version constant."""


### PR DESCRIPTION
S7CommPlus could expose a connected client or activate generated SessionKey material before SetupSession succeeded. Keep key material pending, track internal readiness separately, and fail connection setup when ServerSessionVersion is missing or setup is rejected. Sync/async failures clear intermediate authentication state. This also addresses the false success indication reported in #877; its underlying CreateObject rejection still needs a failing Python capture.

Fail with an actionable installation error when legacy SessionKey authentication dependencies cannot load, instead of silently sending a different unauthenticated SetupSession.

The Python/TIA captures in #872 also reveal a legacy GetVarSubStreamed qualifier mismatch: the Python request has two extra bytes. Use the captured zero-valued qualifier/request layout and reject failed or malformed challenge replies without reusing the earlier CreateObject challenge. A packet regression matches the accepted TIA request bytes and verifies generated HMAC framing with a synthetic key. Hardware retesting is still needed; this does not claim the PLC connection issue is resolved.

Dependency #859 is merged. This PR now targets master and includes a forward merge of master; no pushed history was rewritten.

Validation after merging master: 2,037 passed, 78 skipped; source/wheel builds passed. Full mypy has the same 207 diagnostics as the updated baseline, with no new diagnostics. Regression coverage includes missing dependencies, failure-state cleanup, captured request layout, rejected challenge replies, and successful use of a fresh challenge.

Hardware evidence: russwing verified that missing cryptography prevents SetupSession from being sent and closes the ISO connection cleanly. Their subsequent report in #876 confirms successful connections using TLS after fixing group selection; their earlier plaintext reset is not evidence that the atomic-setup change fails on that CPU. Rejected/malformed-SetupSession guards still lack direct hardware coverage.

Fixes #831
Related: #872, #877, #876
