### PR TITLE
fix(classic): validate framing and preserve read/write element boundaries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,11 @@ CHANGES
 
 Major release: new `s7commplus` package with S7CommPlus protocol support.
 
+* Fix classic S7 TPKT bounds and COTP Class 0 header validation in sync/async clients.
+* Reject incomplete reads and mismatched or missing read/write acknowledgements.
+* Size read/write chunks in whole elements and preserve ctypes write datatypes;
+  correct BIT lengths and timer/counter index addressing.
+
 * New `s7commplus` package for S7CommPlus protocol (S7-1200/1500)
 * S7CommPlus V1, V2 (TLS), and V3 support for S7-1200/1500
 * S7CommPlus area read/write (M, I, Q, counters, timers)

--- a/snap7/async_client.py
+++ b/snap7/async_client.py
@@ -18,7 +18,7 @@ from datetime import datetime
 
 from .connection import TPDUSize
 from .s7protocol import S7Protocol, get_return_code_description
-from .datatypes import S7WordLen
+from .datatypes import S7DataTypes, S7WordLen
 from .error import S7Error, S7ConnectionError, S7ProtocolError, S7TimeoutError
 from .client_base import ClientMixin
 from .szl import parse_cp_info_szl, parse_cpu_info_szl, parse_order_code_szl, parse_protection_szl
@@ -161,7 +161,7 @@ class AsyncISOTCPConnection:
                 raise S7ConnectionError(f"Invalid TPKT version: {version}")
 
             remaining = length - 4
-            if remaining <= 0:
+            if length < 7:
                 raise S7ConnectionError("Invalid TPKT length")
 
             payload = await self._recv_exact(remaining)
@@ -170,6 +170,10 @@ class AsyncISOTCPConnection:
             if len(payload) < 3:
                 raise S7ConnectionError("Invalid COTP DT: too short")
             pdu_len, pdu_type, eot_num = struct.unpack(">BBB", payload[:3])
+            if pdu_len != 2:
+                raise S7ConnectionError("Invalid COTP DT header length")
+            if eot_num & 0x7F:
+                raise S7ConnectionError("Invalid Class 0 COTP TPDU number")
             if pdu_type != self.COTP_DT:
                 raise S7ConnectionError(f"Expected COTP DT, got {pdu_type:#02x}")
             return payload[3:]
@@ -219,6 +223,8 @@ class AsyncISOTCPConnection:
     def _build_tpkt(self, payload: bytes) -> bytes:
         """Build TPKT frame."""
         length = len(payload) + 4
+        if not 7 <= length <= 65535:
+            raise S7ConnectionError("Invalid TPKT length: expected 7..65535 bytes")
         return struct.pack(">BBH", 3, 0, length) + payload
 
     def _parse_cotp_cc(self, data: bytes) -> None:
@@ -532,7 +538,7 @@ class AsyncClient(ClientMixin):
         else:
             word_len = S7WordLen.BYTE
 
-        max_chunk = self._max_read_size()
+        max_chunk = self._read_chunk_count(word_len)
         if size <= max_chunk:
             request = self.protocol.build_read_request(
                 area=s7_area, db_number=db_number, start=start, word_len=word_len, count=size
@@ -548,7 +554,11 @@ class AsyncClient(ClientMixin):
         while remaining > 0:
             chunk_size = min(remaining, max_chunk)
             request = self.protocol.build_read_request(
-                area=s7_area, db_number=db_number, start=start + offset, word_len=word_len, count=chunk_size
+                area=s7_area,
+                db_number=db_number,
+                start=start + offset * self._element_address_step(word_len),
+                word_len=word_len,
+                count=chunk_size,
             )
             response = await self._send_receive(request)
             values = self.protocol.extract_read_data(response, word_len, chunk_size)
@@ -574,7 +584,7 @@ class AsyncClient(ClientMixin):
         else:
             word_len = S7WordLen.BYTE
 
-        max_chunk = self._max_write_size()
+        max_chunk = self._write_chunk_bytes(word_len, len(data))
         if len(data) <= max_chunk:
             request = self.protocol.build_write_request(
                 area=s7_area, db_number=db_number, start=start, word_len=word_len, data=bytes(data)
@@ -590,7 +600,11 @@ class AsyncClient(ClientMixin):
             chunk_size = min(remaining, max_chunk)
             chunk_data = data[offset : offset + chunk_size]
             request = self.protocol.build_write_request(
-                area=s7_area, db_number=db_number, start=start + offset, word_len=word_len, data=bytes(chunk_data)
+                area=s7_area,
+                db_number=db_number,
+                start=start + offset // S7DataTypes.get_size_bytes(word_len) * self._element_address_step(word_len),
+                word_len=word_len,
+                data=bytes(chunk_data),
             )
             response = await self._send_receive(request)
             self.protocol.check_write_response(response)

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -23,7 +23,7 @@ from ctypes import (
 
 from .connection import ISOTCPConnection
 from .s7protocol import S7Protocol, get_return_code_description
-from .datatypes import S7WordLen
+from .datatypes import S7DataTypes, S7WordLen
 from .error import S7Error, S7ConnectionError, S7ProtocolError, S7StalePacketError, S7TimeoutError
 from .client_base import ClientMixin
 from .log import PLCLoggerAdapter, OperationLogger
@@ -985,7 +985,8 @@ class Client(ClientMixin):
             area: Memory area to read from
             db_number: DB number (for DB area only)
             start: Start address
-            size: Number of items to read (for TM/CT: timers/counters, for others: bytes)
+            size: Number of elements of the selected word length (bytes by default).
+                BIT values are returned as one byte per bit; TM/CT use two-byte elements.
             word_len: Optional word length override. If None, defaults to area-based logic
                 (TIMER for TM, COUNTER for CT, BYTE for others).
 
@@ -1007,7 +1008,7 @@ class Client(ClientMixin):
         else:
             s7_word_len = S7WordLen.BYTE
 
-        max_chunk = self._max_read_size()
+        max_chunk = self._read_chunk_count(s7_word_len)
         if size <= max_chunk:
             # Single request - use reconnect-aware send/receive
             def build_request() -> bytes:
@@ -1026,7 +1027,7 @@ class Client(ClientMixin):
         remaining = size
         while remaining > 0:
             chunk_size = min(remaining, max_chunk)
-            chunk_offset = offset
+            chunk_offset = offset * self._element_address_step(s7_word_len)
 
             def build_chunk_request(o: int = chunk_offset, cs: int = chunk_size) -> bytes:
                 return self.protocol.build_read_request(
@@ -1074,7 +1075,7 @@ class Client(ClientMixin):
         else:
             s7_word_len = S7WordLen.BYTE
 
-        max_chunk = self._max_write_size()
+        max_chunk = self._write_chunk_bytes(s7_word_len, len(data))
         if len(data) <= max_chunk:
             # Single request
             def build_request() -> bytes:
@@ -1093,7 +1094,7 @@ class Client(ClientMixin):
         while remaining > 0:
             chunk_size = min(remaining, max_chunk)
             chunk_data = data[offset : offset + chunk_size]
-            chunk_offset = offset
+            chunk_offset = offset // S7DataTypes.get_size_bytes(s7_word_len) * self._element_address_step(s7_word_len)
 
             def build_chunk_request(o: int = chunk_offset, cd: bytes = bytes(chunk_data)) -> bytes:
                 return self.protocol.build_write_request(
@@ -1390,15 +1391,20 @@ class Client(ClientMixin):
                 area = Area(s7_item.Area)
                 db_number = s7_item.DBNumber
                 start = s7_item.Start
-                size = s7_item.Amount
+                word_len = WordLen(s7_item.WordLen)
+                size = S7DataTypes.get_size_bytes(S7WordLen(word_len), s7_item.Amount)
+                if s7_item.Amount < 0:
+                    raise ValueError("Item amount must be non-negative")
+                if size and not s7_item.pData:
+                    raise ValueError("Write item requires a data pointer")
 
-                # Extract data from pData
+                # Extract all elements from pData, retaining the request datatype.
                 data = bytearray(size)
                 if s7_item.pData:
                     for i in range(size):
                         data[i] = s7_item.pData[i]
 
-                self.write_area(area, db_number, start, data)
+                self.write_area(area, db_number, start, data, word_len)
             return 0
 
         # Handle dict list

--- a/snap7/client_base.py
+++ b/snap7/client_base.py
@@ -9,7 +9,7 @@ import logging
 import struct
 from typing import Optional
 
-from .datatypes import S7Area
+from .datatypes import S7Area, S7DataTypes, S7WordLen
 from .error import S7ProtocolError
 
 from .type import (
@@ -217,6 +217,32 @@ class ClientMixin:
         when the server negotiates an implausibly small PDU.
         """
         return max(1, self.pdu_length - 35)
+
+    def _read_chunk_count(self, word_len: S7WordLen) -> int:
+        """Convert the response byte budget to whole requested elements."""
+        width = S7DataTypes.get_size_bytes(word_len)
+        count = min(self.pdu_length - 18, 8191) // width
+        if self.pdu_length < 24 or count < 1:
+            raise S7ProtocolError("Negotiated PDU cannot hold one read element")
+        # Represent each BIT as one byte in the public API, one bit per request.
+        return 1 if word_len == S7WordLen.BIT else count
+
+    def _write_chunk_bytes(self, word_len: S7WordLen, size: int) -> int:
+        """Keep write chunks aligned to elements and within the PDU budget."""
+        width = S7DataTypes.get_size_bytes(word_len)
+        if size % width:
+            raise ValueError("Write data length must be a multiple of the element width")
+        chunk = min(self.pdu_length - 35, 8191) // width * width
+        if chunk < width:
+            raise S7ProtocolError("Negotiated PDU cannot hold one write element")
+        return 1 if word_len == S7WordLen.BIT else chunk
+
+    @staticmethod
+    def _element_address_step(word_len: S7WordLen) -> int:
+        """BIT and timer/counter starts use indices; other starts use bytes."""
+        if word_len in (S7WordLen.BIT, S7WordLen.TIMER, S7WordLen.COUNTER):
+            return 1
+        return S7DataTypes.get_size_bytes(word_len)
 
     def _map_area(self, area: Area) -> S7Area:
         """Map library area enum to native S7 area."""

--- a/snap7/connection.py
+++ b/snap7/connection.py
@@ -211,7 +211,7 @@ class ISOTCPConnection:
 
             # Receive remaining data
             remaining = length - 4
-            if remaining <= 0:
+            if length < 7:
                 raise S7ConnectionError("Invalid TPKT length")
 
             payload = self._recv_exact(remaining)
@@ -286,6 +286,8 @@ class ISOTCPConnection:
         - Length (2 bytes): Total frame length including header
         """
         length = len(payload) + 4
+        if not 7 <= length <= 65535:
+            raise S7ConnectionError("Invalid TPKT length: expected 7..65535 bytes")
         return struct.pack(">BBH", 3, 0, length) + payload
 
     def _build_cotp_cr(self) -> bytes:
@@ -415,6 +417,11 @@ class ISOTCPConnection:
             raise S7ConnectionError("Invalid COTP DT: too short")
 
         pdu_len, pdu_type, eot_num = struct.unpack(">BBB", cotp_pdu[:3])
+
+        if pdu_len != 2:
+            raise S7ConnectionError("Invalid COTP DT header length")
+        if eot_num & 0x7F:
+            raise S7ConnectionError("Invalid Class 0 COTP TPDU number")
 
         if pdu_type != self.COTP_DT:
             raise S7ConnectionError(f"Expected COTP DT, got {pdu_type:#02x}")

--- a/snap7/datatypes.py
+++ b/snap7/datatypes.py
@@ -89,7 +89,9 @@ class S7DataTypes:
             raise ValueError(f"Start address must be non-negative, got {start}")
 
         # Convert start address to byte.bit format
-        if word_len == S7WordLen.BIT:
+        if word_len in (S7WordLen.TIMER, S7WordLen.COUNTER):
+            address = start  # Timer/counter element index, not a bit address.
+        elif word_len == S7WordLen.BIT:
             # For bit access: byte address + bit offset
             byte_addr = start // 8
             bit_addr = start % 8

--- a/snap7/s7protocol.py
+++ b/snap7/s7protocol.py
@@ -248,6 +248,7 @@ class S7Protocol:
         raw = response.get("raw_data", b"")
         if not raw:
             raise S7ProtocolError("No raw data in multi-read response")
+        self._validate_area_response(response, S7Function.READ_AREA, block_count)
 
         results: List[bytearray] = []
         offset = 0
@@ -299,6 +300,8 @@ class S7Protocol:
         """
         # Calculate count from data length
         item_size = S7DataTypes.get_size_bytes(word_len, 1)
+        if len(data) % item_size:
+            raise ValueError("Write data length must be a multiple of the element width")
         count = len(data) // item_size
 
         # Parameter length: function + item count + address spec
@@ -334,23 +337,25 @@ class S7Protocol:
         # Data section uses different transport size codes than address specification:
         # - 0x03 = BIT
         # - 0x04 = BYTE/WORD/DWORD (byte-oriented data)
-        # - 0x05 = INT
-        # - 0x06 = DINT
+        # - 0x05 = INT/DINT
         # - 0x07 = REAL
-        # - 0x09 = OCTET STRING
+        # - 0x09 = OCTET STRING (CHAR, COUNTER, TIMER)
         transport_size_map = {
             S7WordLen.BIT: 0x03,
             S7WordLen.BYTE: 0x04,
-            S7WordLen.CHAR: 0x04,
+            S7WordLen.CHAR: 0x09,
             S7WordLen.WORD: 0x04,
             S7WordLen.INT: 0x05,
             S7WordLen.DWORD: 0x04,
-            S7WordLen.DINT: 0x06,
+            S7WordLen.DINT: 0x05,
             S7WordLen.REAL: 0x07,
-            S7WordLen.COUNTER: 0x04,
-            S7WordLen.TIMER: 0x04,
+            S7WordLen.COUNTER: 0x09,
+            S7WordLen.TIMER: 0x09,
         }
         transport_size = transport_size_map.get(word_len, 0x04)
+
+        # BIT values occupy one byte each; BYTE/WORD/INT lengths are in bits.
+        data_length = len(data) if transport_size in (0x03, 0x07, 0x09) else len(data) * 8
 
         # Data section
         data_section = (
@@ -358,7 +363,7 @@ class S7Protocol:
                 ">BBH",
                 0x00,  # Reserved/Error
                 transport_size,  # Transport size (proper S7 data section format)
-                len(data) * 8,  # Bit length (data length in bits)
+                data_length,
             )
             + data
         )
@@ -1587,7 +1592,15 @@ class S7Protocol:
                 raise S7ProtocolError("Data section extends beyond PDU")
 
             data_section = pdu[offset : offset + data_len]
-            response["data"] = self._parse_data_section(data_section)
+            if (response.get("parameters") or {}).get("function_code") == S7Function.WRITE_AREA:
+                # WRITE data is an array of acknowledgement codes, not a READ item header.
+                response["data"] = {"return_code": data_section[0]}
+            else:
+                # Other functions (notably block upload) do not carry READ item headers.
+                response["data"] = self._parse_data_section(
+                    data_section,
+                    validate_length=(response.get("parameters") or {}).get("function_code") == S7Function.READ_AREA,
+                )
             response["raw_data"] = data_section
 
         return response
@@ -1682,7 +1695,7 @@ class S7Protocol:
             "error_code": error_code,
         }
 
-    def _parse_data_section(self, data_section: bytes) -> Dict[str, Any]:
+    def _parse_data_section(self, data_section: bytes, *, validate_length: bool = True) -> Dict[str, Any]:
         """Parse S7 data section."""
         if len(data_section) == 1:
             # Simple return code (for write responses)
@@ -1697,12 +1710,16 @@ class S7Protocol:
             # Transport size 0x09 (octet string): byte length (USERDATA responses)
             # Transport size 0x00: byte length (USERDATA requests)
             # Transport size 0x04 (byte): bit length (READ_AREA responses)
-            if transport_size in (0x00, 0x09):
+            if transport_size in (0x00, 0x03, 0x06, 0x07, 0x09):
                 # USERDATA uses byte length directly
-                actual_data = data_section[4 : 4 + data_length]
+                byte_length = data_length
             else:
                 # READ_AREA responses use bit length
-                actual_data = data_section[4 : 4 + (data_length // 8)]
+                byte_length = data_length // 8
+
+            if validate_length and 4 + byte_length > len(data_section):
+                raise S7ProtocolError("Read data item is truncated")
+            actual_data = data_section[4 : 4 + byte_length]
 
             return {"return_code": return_code, "transport_size": transport_size, "data_length": data_length, "data": actual_data}
         else:
@@ -1731,9 +1748,30 @@ class S7Protocol:
             raise S7ProtocolError(f"Read operation failed: {desc} (0x{return_code:02x})")
 
         raw_data = data_info.get("data", b"")
+        self._validate_area_response(response, S7Function.READ_AREA, 1)
+        expected = S7DataTypes.get_size_bytes(word_len, count)
+        if len(raw_data) != expected:
+            raise S7ProtocolError(f"Read response size mismatch: expected {expected} bytes, received {len(raw_data)}")
+        transport_size = data_info.get("transport_size")
+        expected_length = count if word_len == S7WordLen.BIT else expected
+        if transport_size in (0x04, 0x05):
+            expected_length = expected * 8
+        elif transport_size not in (0x03, 0x06, 0x07, 0x09):
+            raise S7ProtocolError("Invalid read response transport size")
+        if data_info.get("data_length") != expected_length:
+            raise S7ProtocolError("Read response declared length does not match requested size")
 
         # Return raw bytes directly - caller handles type conversion
         return list(raw_data)
+
+    @staticmethod
+    def _validate_area_response(response: Dict[str, Any], function: S7Function, count: int) -> None:
+        """Require the response to acknowledge the requested operation and item count."""
+        parameters = response.get("parameters") or {}
+        if parameters.get("function_code") != function:
+            raise S7ProtocolError("Unexpected S7 response function")
+        if parameters.get("item_count") != count:
+            raise S7ProtocolError("Unexpected S7 response item count")
 
     def check_write_response(self, response: Dict[str, Any]) -> None:
         """
@@ -1752,15 +1790,20 @@ class S7Protocol:
             error_msg = f"Write operation failed with S7 error code: {header_error:#06x}"
             raise S7ProtocolError(error_msg)
 
-        # For successful writes, check the data section return code if present
+        self._validate_area_response(response, S7Function.WRITE_AREA, 1)
+        if len(response.get("raw_data", b"")) != 1:
+            raise S7ProtocolError("Write response must contain one item acknowledgement")
+
+        # For successful writes, check the data section return code.
         if response.get("data"):
             data_info = response["data"]
-            return_code = data_info.get("return_code", 0xFF)  # Default to success
+            return_code = data_info.get("return_code", 0)
 
             if return_code != 0xFF:  # 0xFF = Success
                 desc = get_return_code_description(return_code)
                 raise S7ProtocolError(f"Write operation failed: {desc} (0x{return_code:02x})")
-        # If no data and no header error, the write was successful (ACK without data)
+        else:
+            raise S7ProtocolError("Missing write acknowledgement")
 
 
 # ---------------------------------------------------------------------------

--- a/snap7/server/__init__.py
+++ b/snap7/server/__init__.py
@@ -1505,7 +1505,9 @@ class Server:
             address = struct.unpack(">I", b"\x00" + address_bytes)[0]  # Pad to 4 bytes
 
             # Convert bit address to byte address
-            if word_len == S7WordLen.BIT:
+            if word_len in (S7WordLen.TIMER, S7WordLen.COUNTER):
+                start_address = address * 2  # Backing memory stores two bytes per element.
+            elif word_len == S7WordLen.BIT:
                 byte_addr = address // 8
                 start_address = byte_addr
             else:
@@ -1540,7 +1542,7 @@ class Server:
             # Transport size 0x09 (octet string): byte length (USERDATA responses)
             # Transport size 0x00: byte length (USERDATA requests)
             # Transport size 0x04 (byte): bit length (READ_AREA responses)
-            if transport_size in (0x00, 0x09):
+            if transport_size in (0x00, 0x03, 0x06, 0x07, 0x09):
                 # USERDATA uses byte length directly
                 actual_data = data_section[4 : 4 + data_length]
             else:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1192,6 +1192,7 @@ class TestPDUSplitting:
                 "data_length": 1,
                 "parameters": {"function_code": 0x05, "item_count": 1},
                 "data": {"return_code": 0xFF},
+                "raw_data": b"\xff",
                 "error_code": 0,
             }
 

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -45,13 +45,10 @@ class TestTPKTConformance:
         assert frame[4:] == payload
 
     def test_tpkt_empty_payload(self) -> None:
-        """Empty payload produces a 4-byte frame."""
+        """RFC 1006 requires at least seven bytes including the header."""
         conn = ISOTCPConnection("127.0.0.1")
-        frame = conn._build_tpkt(b"")
-
-        assert len(frame) == 4
-        length = struct.unpack(">H", frame[2:4])[0]
-        assert length == 4
+        with pytest.raises(S7ConnectionError, match="TPKT length"):
+            conn._build_tpkt(b"")
 
     def test_tpkt_large_payload(self) -> None:
         """Length field correctly handles large payloads."""

--- a/tests/test_hypothesis.py
+++ b/tests/test_hypothesis.py
@@ -391,7 +391,7 @@ def test_address_encoding_is_12_bytes(area: S7Area, db_number: int, start: int, 
 # ---------------------------------------------------------------------------
 
 
-@given(st.binary(min_size=1, max_size=500))
+@given(st.binary(min_size=3, max_size=500))
 def test_tpkt_frame_structure(payload: bytes) -> None:
     """TPKT frame should have correct version, reserved byte, and length."""
     from snap7.connection import ISOTCPConnection

--- a/tests/test_lean_regressions.py
+++ b/tests/test_lean_regressions.py
@@ -1,0 +1,270 @@
+"""Public-path regressions for Lean-derived findings #862 through #870.
+
+Malformed vectors originate in the issue reproductions and lean-s7's pinned
+30c36b91804620c88c0dde2f2f4053093828629a conformance/v1 corpus.
+These are differential tests, not a formal verification of Python.
+"""
+
+import struct
+from collections.abc import Callable
+from ctypes import POINTER, c_uint8, cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from snap7.async_client import AsyncClient, AsyncISOTCPConnection
+from snap7.client import Client
+from snap7.connection import ISOTCPConnection
+from snap7.error import S7ConnectionError, S7ProtocolError
+from snap7.type import Area, S7DataItem, WordLen
+
+
+@pytest.mark.parametrize("connection_type", [ISOTCPConnection, AsyncISOTCPConnection])
+@pytest.mark.parametrize("size", [0, 1, 2, 65532])
+def test_tpkt_encode_rejects_out_of_bounds(
+    connection_type: type[ISOTCPConnection] | type[AsyncISOTCPConnection], size: int
+) -> None:
+    with pytest.raises(S7ConnectionError, match="TPKT length"):
+        connection_type("example.invalid")._build_tpkt(bytes(size))
+
+
+@pytest.mark.parametrize("connection_type", [ISOTCPConnection, AsyncISOTCPConnection])
+@pytest.mark.parametrize("size", [3, 65531])
+def test_tpkt_encode_valid_boundaries(connection_type: type[ISOTCPConnection] | type[AsyncISOTCPConnection], size: int) -> None:
+    payload = bytes(size)
+    frame = connection_type("example.invalid")._build_tpkt(payload)
+    assert int.from_bytes(frame[2:4], "big") == size + 4
+    assert frame[4:] == payload
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("length", [0, 4, 5, 6])
+async def test_receive_rejects_short_tpkt_before_body(asynchronous: bool, length: int) -> None:
+    header = struct.pack(">BBH", 3, 0, length)
+    if asynchronous:
+        conn = AsyncISOTCPConnection("example.invalid")
+        conn.connected = True
+        receive = AsyncMock(return_value=header)
+        conn._recv_exact = receive
+        with pytest.raises(S7ConnectionError, match="TPKT length"):
+            await conn.receive_data()
+    else:
+        sync_conn = ISOTCPConnection("example.invalid")
+        sync_conn.connected = True
+        receive = MagicMock(return_value=header)
+        sync_conn._recv_exact = receive
+        with pytest.raises(S7ConnectionError, match="TPKT length"):
+            sync_conn.receive_data()
+        sync_conn.connected = False
+    receive.assert_called_once_with(4)
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("frame", ["03f08032", "01f08032", "02f08132", "02f07f32"])
+async def test_cotp_rejects_invalid_header(asynchronous: bool, frame: str) -> None:
+    payload = bytes.fromhex(frame)
+    if asynchronous:
+        conn = AsyncISOTCPConnection("example.invalid")
+        conn.connected = True
+        conn._recv_exact = AsyncMock(side_effect=[struct.pack(">BBH", 3, 0, len(payload) + 4), payload])
+        with pytest.raises(S7ConnectionError):
+            await conn.receive_data()
+    else:
+        with pytest.raises(S7ConnectionError):
+            ISOTCPConnection("example.invalid")._parse_cotp_data(payload)
+
+
+@pytest.mark.parametrize("eot", [0, 0x80])
+def test_cotp_accepts_zero_tpdu_number(eot: int) -> None:
+    assert ISOTCPConnection("example.invalid")._parse_cotp_data(bytes((2, 0xF0, eot, 0x32))) == b"\x32"
+
+
+class Peer:
+    """Replace transport only, preserving request construction and response parsing."""
+
+    def __init__(self, reply: Callable[[bytes], tuple[bytes, bytes]]) -> None:
+        self.reply = reply
+        self.requests: list[bytes] = []
+
+    def send_data(self, request: bytes) -> None:
+        self.requests.append(request)
+
+    def receive_data(self) -> bytes:
+        request = self.requests[-1]
+        params, data = self.reply(request)
+        return b"\x32\x03\x00\x00" + request[4:6] + struct.pack(">HH", len(params), len(data)) + b"\x00\x00" + params + data
+
+    def disconnect(self) -> None:
+        pass
+
+
+def client_for(peer: Peer, asynchronous: bool, pdu: int = 480) -> Client | AsyncClient:
+    if asynchronous:
+        client = AsyncClient()
+        transport = MagicMock()
+        transport.send_data = AsyncMock(side_effect=peer.send_data)
+        transport.receive_data = AsyncMock(side_effect=peer.receive_data)
+        client.connection = transport
+        client.connected = True
+        client.pdu_length = pdu
+        return client
+    sync_client = Client()
+    sync_client.connection = peer  # type: ignore[assignment]
+    sync_client.connected = True
+    sync_client.pdu_length = pdu
+    return sync_client
+
+
+async def read(client: Client | AsyncClient, area: Area, start: int, count: int, word_len: WordLen) -> bytearray:
+    if isinstance(client, Client):
+        return client.read_area(area, 1, start, count, word_len)
+    return await client.read_area(area, 1, start, count)
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("data", ["ff040020aa", "ff040008aa", "ff040028aabbccddee", "ff04001faabbccdd"])
+async def test_short_or_wrong_size_read_is_not_success(asynchronous: bool, data: str) -> None:
+    client = client_for(Peer(lambda _: (b"\x04\x01", bytes.fromhex(data))), asynchronous)
+    with pytest.raises(S7ProtocolError):
+        await read(client, Area.DB, 0, 4, WordLen.Byte)
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize(
+    "params,data", [("0401", "ff040008aa"), ("0501", ""), ("0500", "ff"), ("0502", "ffff"), ("0501", "ffff"), ("", "")]
+)
+async def test_write_requires_matching_acknowledgement(asynchronous: bool, params: str, data: str) -> None:
+    client = client_for(Peer(lambda _: (bytes.fromhex(params), bytes.fromhex(data))), asynchronous)
+    with pytest.raises(S7ProtocolError):
+        if isinstance(client, Client):
+            client.db_write(1, 0, bytearray(b"\xbb"))
+        else:
+            await client.db_write(1, 0, bytearray(b"\xbb"))
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("params,data", [("0501", "ff"), ("0400", "ff040008aa"), ("0402", "ff040008aa")])
+async def test_read_requires_matching_function_and_count(asynchronous: bool, params: str, data: str) -> None:
+    client = client_for(Peer(lambda _: (bytes.fromhex(params), bytes.fromhex(data))), asynchronous)
+    with pytest.raises(S7ProtocolError):
+        await read(client, Area.DB, 0, 1, WordLen.Byte)
+
+
+@pytest.mark.parametrize(
+    "asynchronous,area,word_len,width",
+    [
+        (False, Area.DB, WordLen.Word, 2),
+        (False, Area.DB, WordLen.DWord, 4),
+        (False, Area.TM, WordLen.Timer, 2),
+        (True, Area.TM, WordLen.Timer, 2),
+        (True, Area.CT, WordLen.Counter, 2),
+    ],
+)
+@pytest.mark.parametrize("pdu", [240, 480])
+async def test_element_chunks_obey_budget_and_cover_exact_bytes(
+    asynchronous: bool, area: Area, word_len: WordLen, width: int, pdu: int
+) -> None:
+    spans: list[tuple[int, int]] = []
+
+    def reply(request: bytes) -> tuple[bytes, bytes]:
+        count = int.from_bytes(request[16:18], "big")
+        address = int.from_bytes(request[21:24], "big")
+        start = address * width if area in (Area.TM, Area.CT) else address // 8
+        spans.append((start, count))
+        payload = bytes(i % 251 for i in range(start, start + count * width))
+        assert 18 + len(payload) <= pdu
+        return b"\x04\x01", b"\xff\x04" + struct.pack(">H", len(payload) * 8) + payload
+
+    client = client_for(Peer(reply), asynchronous, pdu)
+    result = await read(client, area, 0, 500, word_len)
+    assert result == bytes(i % 251 for i in range(500 * width))
+    max_count = (pdu - 18) // width
+    assert spans == [(i * width, min(max_count, 500 - i)) for i in range(0, 500, max_count)]
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_truncated_later_chunk_raises(asynchronous: bool) -> None:
+    def reply(request: bytes) -> tuple[bytes, bytes]:
+        count = int.from_bytes(request[16:18], "big")
+        start = int.from_bytes(request[21:24], "big")
+        payload = bytes(count if start == 0 else count - 1)
+        return b"\x04\x01", b"\xff\x04" + struct.pack(">H", count * 8) + payload
+
+    client = client_for(Peer(reply), asynchronous, 240)
+    with pytest.raises(S7ProtocolError, match="truncated"):
+        await read(client, Area.DB, 0, 500, WordLen.Byte)
+
+
+@pytest.mark.parametrize(
+    "word_len,payload",
+    [
+        (WordLen.Word, b"\x11\x22\x33\x44"),
+        (WordLen.DWord, bytes(range(8))),
+        (WordLen.Real, struct.pack(">ff", 1.0, 2.0)),
+        (WordLen.Bit, b"\x01\x00"),
+    ],
+)
+def test_ctypes_writes_keep_type_and_all_elements(word_len: WordLen, payload: bytes) -> None:
+    peer = Peer(lambda _: (b"\x05\x01", b"\xff"))
+    client = client_for(peer, False)
+    assert isinstance(client, Client)
+    buffer = (c_uint8 * len(payload))(*payload)
+    item = S7DataItem()
+    item.Area, item.DBNumber, item.Start = Area.DB, 1, 11
+    item.WordLen, item.Amount = word_len, 2
+    item.pData = cast(buffer, POINTER(c_uint8))
+    assert client.write_multi_vars([item]) == 0
+    assert b"".join(request[28:] for request in peer.requests) == payload
+    assert all(request[15] == word_len for request in peer.requests)
+    if word_len == WordLen.Bit:
+        assert [int.from_bytes(r[21:24], "big") for r in peer.requests] == [11, 12]
+        assert all(r[26:28] == b"\x00\x01" for r in peer.requests)
+    else:
+        assert peer.requests[0][16:18] == b"\x00\x02"
+        expected_transport = 7 if word_len == WordLen.Real else 4
+        expected_length = len(payload) if word_len == WordLen.Real else len(payload) * 8
+        assert peer.requests[0][25] == expected_transport
+        assert int.from_bytes(peer.requests[0][26:28], "big") == expected_length
+
+
+def test_word_writes_do_not_split_elements() -> None:
+    peer = Peer(lambda _: (b"\x05\x01", b"\xff"))
+    client = client_for(peer, False, 240)
+    assert isinstance(client, Client)
+    payload = bytearray(i % 251 for i in range(1000))
+    client.write_area(Area.DB, 1, 0, payload, WordLen.Word)
+    assert b"".join(r[28:] for r in peer.requests) == payload
+    offset = 0
+    for request in peer.requests:
+        assert len(request) <= 240
+        assert int.from_bytes(request[21:24], "big") // 8 == offset
+        assert len(request[28:]) % 2 == 0
+        offset += len(request[28:])
+    peer.requests.clear()
+    with pytest.raises(ValueError, match="element width"):
+        client.write_area(Area.DB, 1, 0, bytearray(3), WordLen.Word)
+    assert not peer.requests
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+@pytest.mark.parametrize("area", [Area.TM, Area.CT])
+async def test_timer_counter_writes_advance_element_indices(asynchronous: bool, area: Area) -> None:
+    peer = Peer(lambda _: (b"\x05\x01", b"\xff"))
+    client = client_for(peer, asynchronous, 240)
+    data = bytearray(i % 251 for i in range(600))
+    if isinstance(client, Client):
+        client.write_area(area, 0, 5, data)
+    else:
+        await client.write_area(area, 0, 5, data)
+    assert b"".join(r[28:] for r in peer.requests) == data
+    assert [int.from_bytes(r[21:24], "big") for r in peer.requests] == [5, 107, 209]
+    assert all(r[25] == 9 and int.from_bytes(r[26:28], "big") == len(r[28:]) for r in peer.requests)
+
+
+@pytest.mark.parametrize("asynchronous", [False, True])
+async def test_pdu_too_small_for_element_fails_without_send(asynchronous: bool) -> None:
+    peer = Peer(lambda _: (b"\x04\x01", b"\xff\x04\x00\x10\x00\x00"))
+    client = client_for(peer, asynchronous, 19)
+    with pytest.raises(S7ProtocolError, match="PDU"):
+        await read(client, Area.TM, 0, 1, WordLen.Timer)
+    assert not peer.requests

--- a/tests/test_s7protocol.py
+++ b/tests/test_s7protocol.py
@@ -492,7 +492,10 @@ class TestExtractReadData:
     def test_success(self) -> None:
         from snap7.datatypes import S7WordLen
 
-        response = {"data": {"return_code": 0xFF, "data": b"\x01\x02\x03"}}
+        response = {
+            "parameters": {"function_code": 4, "item_count": 1},
+            "data": {"return_code": 0xFF, "transport_size": 4, "data_length": 24, "data": b"\x01\x02\x03"},
+        }
         result = self.proto.extract_read_data(response, S7WordLen.BYTE, 3)
         assert result == [1, 2, 3]
 
@@ -507,15 +510,30 @@ class TestCheckWriteResponse:
 
     def test_data_section_error(self) -> None:
         with pytest.raises(S7ProtocolError, match="Write operation failed"):
-            self.proto.check_write_response({"error_code": 0, "data": {"return_code": 0x05}})
+            self.proto.check_write_response(
+                {
+                    "parameters": {"function_code": 5, "item_count": 1},
+                    "raw_data": b"\x05",
+                    "error_code": 0,
+                    "data": {"return_code": 0x05},
+                }
+            )
 
     def test_success_with_data(self) -> None:
         # Should not raise
-        self.proto.check_write_response({"error_code": 0, "data": {"return_code": 0xFF}})
+        self.proto.check_write_response(
+            {
+                "parameters": {"function_code": 5, "item_count": 1},
+                "raw_data": b"\xff",
+                "error_code": 0,
+                "data": {"return_code": 0xFF},
+            }
+        )
 
     def test_success_without_data(self) -> None:
-        # ACK without data section — should not raise
-        self.proto.check_write_response({"error_code": 0})
+        # A bare ACK does not acknowledge a WRITE item.
+        with pytest.raises(S7ProtocolError):
+            self.proto.check_write_response({"error_code": 0})
 
 
 class TestValidatePDUReference:


### PR DESCRIPTION
Classic S7 could return an incomplete read as success, acknowledge a write with a READ reply, exceed the negotiated PDU when reading multi-byte elements, or silently truncate ctypes writes. This PR fixes the nine Lean-derived findings #862–#870 in one classic-protocol correctness change.

| Findings | Result |
| --- | --- |
| #862, #864, #866 | Sync/async TPKT encoding rejects lengths outside 7–65535; receive rejects undersized frames before reading the body. |
| #863, #865 | Sync/async COTP Data parsing requires header length 2 and zero Class 0 TPDU-number bits. |
| #867, #868 | Read items must contain the declared and requested bytes. Read/write replies must identify the expected function and item count; writes require exactly one item acknowledgement. |
| #869 | Read budgets are converted from bytes to whole elements, with correct byte or element-index advancement. At PDU 480, 500 WORDs use `(start_byte, count)` spans `(0, 231), (462, 231), (924, 38)`. |
| #870 | ctypes writes copy `Amount * element_width` bytes and retain WordLen. Write chunks preserve whole elements; BIT values use individual bit addresses. |

The element handling also corrects native timer/counter index encoding and the matching emulator interpretation, and uses the native Snap7 transport-size/length conventions for typed writes. Upload responses retain their distinct data layout. The existing single-request/multi-request architecture is preserved; this does not add a new batching API.

Validation:

- Full local suite: 1,987 passed, 78 skipped.
- 79 focused regression cases exercise raw frames and public client methods with only transport replaced. The initial 73-case suite produced 63 failures and 10 passes on unchanged master, then all passed with the fixes; six additional cases cover timer/counter write offsets and insufficient PDU budgets.
- `uv run --frozen pre-commit run --all-files` and `uv build --no-sources` pass.
- Full mypy still reports the same 208 pre-existing diagnostics in 20 files as unchanged master, with no new diagnostics.

References: [RFC 1006 §6](https://www.rfc-editor.org/rfc/rfc1006.html#section-6), [RFC 2126 §6.5](https://www.rfc-editor.org/rfc/rfc2126.html#section-6.5), [native Snap7 read/write implementation](https://github.com/SCADACS/snap7/blob/master/src/core/s7_micro_client.cpp), and the issue-linked pinned lean-s7 vectors. These are executable regression/differential checks, not a formal verification of Python. No real-PLC validation is claimed.

Refs #862, #863, #864, #865, #866, #867, #868, #869, #870.
