### PR TITLE
Added ability to pass connection parameters through the Logo constructor

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ CHANGES
 
 Major release: new `s7commplus` package with S7CommPlus protocol support.
 
+* Support LOGO reconnection/heartbeat options and preserve explicit TSAPs.
+
 * New `s7commplus` package for S7CommPlus protocol (S7-1200/1500)
 * S7CommPlus V1, V2 (TLS), and V3 support for S7-1200/1500
 * S7CommPlus area read/write (M, I, Q, counters, timers)

--- a/snap7/client.py
+++ b/snap7/client.py
@@ -600,15 +600,21 @@ class Client(ClientMixin):
         Returns:
             Self for method chaining
         """
+        # Remote TSAP: connection type, rack and slot encoded per S7.
+        self.remote_tsap = (self.connection_type << 8) | (rack << 5) | slot
+        return self._connect(address, rack, slot, tcp_port)
+
+    def _connect(self, address: str, rack: int, slot: int, tcp_port: int) -> "Client":
+        """Establish a connection using the configured local and remote TSAPs.
+
+        LOGO clients supply explicit TSAPs instead of deriving them from a
+        rack and slot. Both paths share connection and heartbeat setup.
+        """
         self.host = address
         self.port = tcp_port
         self.rack = rack
         self.slot = slot
         self._params[Parameter.RemotePort] = tcp_port
-
-        # Calculate TSAP values from rack/slot
-        # Remote TSAP: rack and slot encoded as per S7 specification
-        self.remote_tsap = (self.connection_type << 8) | (rack << 5) | slot
 
         try:
             start_time = time.time()

--- a/snap7/logo.py
+++ b/snap7/logo.py
@@ -74,7 +74,7 @@ class Logo(Client):
         Args:
             **kwargs: Ignored. Kept for backwards compatibility.
         """
-        super().__init__()
+        super().__init__(**kwargs)
         self._logo_tsap_snap7: Optional[int] = None
         self._logo_tsap_logo: Optional[int] = None
 

--- a/snap7/logo.py
+++ b/snap7/logo.py
@@ -7,6 +7,7 @@ Pure Python implementation without C library dependency.
 import re
 import struct
 import logging
+from collections.abc import Callable
 from typing import Optional
 
 from .type import WordLen, Area
@@ -67,14 +68,43 @@ class Logo(Client):
         For more information see examples for Siemens Logo 7 and 8
     """
 
-    def __init__(self, **kwargs: object) -> None:
+    def __init__(
+        self,
+        *,
+        auto_reconnect: bool = False,
+        max_retries: int = 3,
+        retry_delay: float = 1.0,
+        backoff_factor: float = 2.0,
+        max_delay: float = 30.0,
+        heartbeat_interval: float = 0,
+        on_disconnect: Optional[Callable[[], None]] = None,
+        on_reconnect: Optional[Callable[[], None]] = None,
+        **kwargs: object,
+    ) -> None:
         """
         Initialize Logo client.
 
         Args:
+            auto_reconnect: Reconnect automatically after connection loss.
+            max_retries: Maximum number of reconnection attempts.
+            retry_delay: Initial reconnection delay in seconds.
+            backoff_factor: Multiplier for successive retry delays.
+            max_delay: Maximum reconnection delay in seconds.
+            heartbeat_interval: Heartbeat interval in seconds (0 disables it).
+            on_disconnect: Callback invoked when the connection is lost.
+            on_reconnect: Callback invoked after successful reconnection.
             **kwargs: Ignored. Kept for backwards compatibility.
         """
-        super().__init__(**kwargs)
+        super().__init__(
+            auto_reconnect=auto_reconnect,
+            max_retries=max_retries,
+            retry_delay=retry_delay,
+            backoff_factor=backoff_factor,
+            max_delay=max_delay,
+            heartbeat_interval=heartbeat_interval,
+            on_disconnect=on_disconnect,
+            on_reconnect=on_reconnect,
+        )
         self._logo_tsap_snap7: Optional[int] = None
         self._logo_tsap_logo: Optional[int] = None
 
@@ -105,10 +135,9 @@ class Logo(Client):
         self.host = ip_address
         self.port = tcp_port
 
-        # Connect using parent Client implementation
-        # For Logo, rack and slot are not used in the standard way
-        # but we still need to establish the connection
-        super().connect(ip_address, 0, 0, tcp_port)
+        # Share connection/heartbeat setup without replacing the explicit
+        # LOGO destination TSAP with an S7 rack/slot-derived address.
+        self._connect(ip_address, 0, 0, tcp_port)
 
         return self
 

--- a/tests/test_logo_reconnect_options.py
+++ b/tests/test_logo_reconnect_options.py
@@ -1,0 +1,36 @@
+"""LOGO connection options and explicit TSAP regression."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from snap7.logo import Logo
+
+
+def test_logo_reconnect_preserves_options_and_tsaps(monkeypatch: pytest.MonkeyPatch) -> None:
+    disconnected, reconnected = MagicMock(), MagicMock()
+    client = Logo(
+        auto_reconnect=True,
+        max_retries=2,
+        retry_delay=0,
+        backoff_factor=3,
+        max_delay=4,
+        heartbeat_interval=9,
+        on_disconnect=disconnected,
+        on_reconnect=reconnected,
+        legacy_option="ignored",
+    )
+    transport = MagicMock()
+    monkeypatch.setattr("snap7.client.ISOTCPConnection", transport)
+    monkeypatch.setattr(client, "_setup_communication", MagicMock())
+    monkeypatch.setattr(client, "_start_heartbeat", MagicMock())
+    client.connect("127.0.0.1", 0x1000, 0x2000, 1102)
+    client.connected = False
+    client._do_reconnect()
+    transport.assert_called_with(host="127.0.0.1", port=1102, local_tsap=0x1000, remote_tsap=0x2000)
+    disconnected.assert_called_once_with()
+    reconnected.assert_called_once_with()
+    assert client._auto_reconnect
+    assert (client._max_retries, client._retry_delay, client._backoff_factor, client._max_delay) == (2, 0, 3, 4)
+    assert client._heartbeat_interval == 9
+    client.disconnect()


### PR DESCRIPTION
Hi @gijzelaerr, thanks for your snap7 library! It really helps us to integrate S7 protocol support for our [ThingsBoard IoT Gateway](https://github.com/thingsboard/thingsboard-gateway)!

### PR Description

I added the ability to pass connection parameters through the Logo constructor, so the following parameters are available for the Logo client: 
- `auto_reconnect: bool = False,`
- `max_retries: int = 3,`
- `retry_delay: float = 1.0,`
- `backoff_factor: float = 2.0,`
- `max_delay: float = 30.0,`
- `heartbeat_interval: float = 0,`
- `on_disconnect: Optional[Callable[[], None]] = None,`
- `on_reconnect: Optional[Callable[[], None]] = None,`

Let me know if the solution is optimal, or if it is better to explicitly declare these variables in the client LOGO constructor.
So I'd be happy to make any changes)

### Problem & Motivation

The root problem is that Logo inherit from the Client class, but it doesn't allow passing the parameters described above. We tested the Logo client with auto reconnector and other parmeters and everything works pretty well.

For now, our workaround is just to monkey-patch the Logo class:

```python
from typing import Optional

from snap7 import Logo


class LogoClient(Logo):
    def __init__(self,
                 auto_reconnect: bool = True,
                 max_retries: int = 3,
                 retry_delay: float = 1.0,
                 max_delay: float = 10.0,
                 heartbeat_interval: float = 30.0) -> None:
        super(Logo, self).__init__(auto_reconnect=auto_reconnect,
                                   max_retries=max_retries,
                                   retry_delay=retry_delay,
                                   max_delay=max_delay,
                                   heartbeat_interval=heartbeat_interval)
        self._logo_tsap_snap7: Optional[int] = None
        self._logo_tsap_logo: Optional[int] = None

```