### PR TITLE
fix(s7commplus): do not narrow TLS groups to secp256r1 when X25519 is unavailable

### DIFF
--- a/s7commplus/connection.py
+++ b/s7commplus/connection.py
@@ -107,9 +107,19 @@ _S7_CIPHERS = (
     "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256"
 )
 
-# Siemens PLCs only accept a small set of TLS groups.  X25519 is preferred
-# but unavailable on older OpenSSL/CPython; fall back to prime256v1.
-_S7_PREFERRED_GROUPS = ("X25519", "prime256v1")
+# Siemens PLCs only accept a small set of TLS groups. X25519 is the group an
+# S7-1500 negotiates in practice, so it is the only one worth naming here.
+#
+# There is deliberately NO fallback group. `set_ecdh_curve` can only name
+# X25519 on OpenSSL builds that expose it as a curve (it raises on OpenSSL
+# 3.0); where it raises, narrowing to something else is not a graceful
+# degradation but a different, wrong answer — it restricts supported_groups to
+# that group ALONE, and a PLC that wanted X25519 then RSTs during the
+# handshake. Leaving the context untouched is strictly better: OpenSSL's
+# default group list already offers X25519, and an untouched context also lets
+# the documented OPENSSL_CONF `Groups` override actually take effect (a
+# set_ecdh_curve call here would silently overwrite it).
+_S7_PREFERRED_GROUPS = ("X25519",)
 
 
 def _set_s7_groups(ctx: ssl.SSLContext) -> None:
@@ -119,7 +129,11 @@ def _set_s7_groups(ctx: ssl.SSLContext) -> None:
             return
         except (ssl.SSLError, ValueError):
             continue
-    logger.warning("Could not restrict TLS groups — PLC may reject unsupported groups in ClientHello")
+    logger.debug(
+        "Could not restrict TLS groups to X25519 on this OpenSSL build; leaving "
+        "the default group list, which offers X25519. If a PLC still rejects the "
+        "handshake, restrict groups via OPENSSL_CONF (Groups = x25519)."
+    )
 
 
 def _verify_v3_hmac(protected: bytes, session_key: bytes) -> bytes:

--- a/tests/test_s7_tls.py
+++ b/tests/test_s7_tls.py
@@ -1,5 +1,7 @@
 """Tests for S7CommPlus async client TLS support."""
 
+import contextlib
+import ssl
 import struct
 import tempfile
 import time
@@ -8,7 +10,9 @@ from collections.abc import Generator
 import pytest
 
 from snap7.error import S7ConnectionError
+from s7commplus import connection
 from s7commplus.async_client import S7CommPlusAsyncClient
+from s7commplus.connection import S7CommPlusConnection
 from s7commplus.server import S7CommPlusServer
 from s7commplus.protocol import ProtocolVersion
 
@@ -320,3 +324,99 @@ class TestSyncTLSBioPlumbing:
         server_ssl.write(payload)
         conn._iso_conn.inbox.append(server_out.read())  # queue ciphertext for the client
         assert conn._recv_s7_data() == payload
+
+
+class TestTLSGroupSelection:
+    """The ClientHello's supported_groups must offer X25519.
+
+    Hardware evidence (CPU 1511F-1 PN, FW V2.9, plaintext port 102): a TIA
+    Portal session against this CPU offers x25519 and is accepted; a
+    ClientHello offering only secp256r1 is answered with a TCP RST during the
+    TLS handshake. `set_ecdh_curve` cannot name X25519 on OpenSSL 3.0, so a
+    fallback group there silently produced the rejected ClientHello.
+    """
+
+    X25519 = 0x001D
+    SECP256R1 = 0x0017
+
+    @staticmethod
+    def _client_hello(ctx: ssl.SSLContext) -> bytes:
+        """Drive a BIO handshake far enough to emit the ClientHello."""
+        incoming, outgoing = ssl.MemoryBIO(), ssl.MemoryBIO()
+        obj = ctx.wrap_bio(incoming, outgoing, server_side=False, server_hostname=None)
+        with contextlib.suppress(ssl.SSLWantReadError):
+            obj.do_handshake()
+        return outgoing.read()
+
+    @staticmethod
+    def _supported_groups(record: bytes) -> list[int]:
+        """Parse supported_groups (extension 10) out of a ClientHello record."""
+        body = record[5:]  # past the TLS record header
+        p = 6 + 32  # handshake header + legacy_version + random
+        p += 1 + body[p]  # legacy_session_id
+        p += 2 + int.from_bytes(body[p : p + 2], "big")  # cipher_suites
+        p += 1 + body[p]  # compression_methods
+        ext_end = p + 2 + int.from_bytes(body[p : p + 2], "big")
+        p += 2
+        while p + 4 <= ext_end:
+            etype = int.from_bytes(body[p : p + 2], "big")
+            elen = int.from_bytes(body[p + 2 : p + 4], "big")
+            p += 4
+            if etype == 10:
+                n = int.from_bytes(body[p : p + 2], "big")
+                return [int.from_bytes(body[p + 2 + i : p + 4 + i], "big") for i in range(0, n, 2)]
+            p += elen
+        return []
+
+    def test_client_hello_offers_x25519(self) -> None:
+        ctx = S7CommPlusConnection("127.0.0.1", 102)._setup_ssl_context()
+        groups = self._supported_groups(self._client_hello(ctx))
+        assert groups, "ClientHello carried no supported_groups extension"
+        assert self.X25519 in groups, (
+            f"ClientHello must offer x25519 - an S7-1500 RSTs without it; offered {[hex(g) for g in groups]}"
+        )
+
+    def test_no_fallback_group_when_x25519_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """On OpenSSL builds that cannot name X25519, leave the groups alone.
+
+        Narrowing to a different group is not graceful degradation: it
+        restricts supported_groups to that group ALONE, which is exactly the
+        ClientHello the PLC rejects. It also silently overrides the documented
+        OPENSSL_CONF `Groups` workaround.
+        """
+        tried: list[str] = []
+
+        def refuse(self: ssl.SSLContext, name: str) -> None:
+            tried.append(name)
+            raise ssl.SSLError("[EC: UNKNOWN_GROUP] unknown group")
+
+        monkeypatch.setattr(ssl.SSLContext, "set_ecdh_curve", refuse)
+        connection._set_s7_groups(ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT))
+
+        assert tried == ["X25519"], f"must not narrow to a fallback group when X25519 is unavailable; tried {tried}"
+
+    def test_client_hello_offers_x25519_even_when_curve_api_cannot_name_it(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The regression, end to end: simulate OpenSSL 3.0 and read the wire.
+
+        `test_client_hello_offers_x25519` above cannot catch this on a build
+        where `set_ecdh_curve("X25519")` succeeds - the fallback never runs.
+        Forcing the failure reproduces the hardware case: the ClientHello must
+        still offer x25519, which holds only if the groups are left at the
+        OpenSSL default instead of being narrowed to secp256r1.
+        """
+        real_set = ssl.SSLContext.set_ecdh_curve
+
+        def refuse_x25519(self: ssl.SSLContext, name: str) -> None:
+            if name == "X25519":
+                raise ssl.SSLError("[EC: UNKNOWN_GROUP] unknown group")
+            real_set(self, name)
+
+        monkeypatch.setattr(ssl.SSLContext, "set_ecdh_curve", refuse_x25519)
+
+        ctx = S7CommPlusConnection("127.0.0.1", 102)._setup_ssl_context()
+        groups = self._supported_groups(self._client_hello(ctx))
+
+        assert groups != [self.SECP256R1], (
+            "supported_groups was narrowed to secp256r1 alone - this is the ClientHello an S7-1500 answers with a TCP RST"
+        )
+        assert self.X25519 in groups, f"ClientHello must still offer x25519; offered {[hex(g) for g in groups]}"


### PR DESCRIPTION
## The problem

`_set_s7_groups` tries `X25519`, then falls back to `prime256v1`. On OpenSSL 3.0 the first call always raises, so the fallback always runs — and it restricts the ClientHello's `supported_groups` to **secp256r1 alone**. An S7-1500 answers that with a TCP RST during the TLS handshake.

```python
>>> ctx.set_ecdh_curve("X25519")      # OpenSSL 3.0.20
ssl.SSLError: [EC: UNKNOWN_GROUP] unknown group
>>> ctx.set_ecdh_curve("x25519")
ValueError: unknown elliptic curve name 'x25519'
>>> ctx.set_ecdh_curve("prime256v1")  # succeeds — and this is the problem
```

There is no spelling that works, and CPython exposes no other API for setting groups (there is no `SSLContext.set_groups`, checked through 3.14). So on OpenSSL 3.0 the fallback is not graceful degradation — it is a different, wrong answer.

## Evidence

Paired captures against the same unchanged CPU (1511F-1 PN, FW V2.9), minutes apart. TIA Portal's session is accepted; ours is reset. The ClientHellos differ in one decisive field:

| | TIA (accepted) | python-snap7 (reset) |
|---|---|---|
| **supported_groups** | **x25519** | **secp256r1** |
| supported_versions | TLS 1.3 | TLS 1.3, TLS 1.2 |
| cipher suites | 3 | 10 |
| record length | 194 | 249 |

The file's own comment above `_S7_CIPHERS` already states the intent — *"offered groups to x25519 via set_ecdh_curve"* — so this is the fallback defeating it, not a disagreement about what the PLC wants.

## The fix

Drop the fallback group. Where `set_ecdh_curve` can name X25519, behaviour is unchanged and the ClientHello carries x25519 alone, matching TIA. Where it cannot, leave the context untouched.

On OpenSSL 3.0.20, before and after:

```
current:  secp256r1                                              -> RST
fixed:    x25519, secp256r1, x448, secp521r1, secp384r1, ffdhe*  -> accepted
```

Two consequences worth noting:

- **No regression for PLCs that want P-256.** The untouched default list still offers `secp256r1`; the current code offers *only* that.
- **It makes the documented `OPENSSL_CONF` workaround work.** `doc/connecting.rst` recommends restricting groups that way, but the `set_ecdh_curve` call silently overwrote it. I confirmed this: with `Groups = x25519` set, the ClientHello still went out with secp256r1 until this call was removed.

One observation against the comment's assumption: the accepted ClientHello above still contains `x448` and `ffdhe*`, which the comment predicts will cause an RST. This CPU tolerated them. I would not generalise from one CPU — the point is only that offering x25519 was sufficient here.

## Hardware verification

CPU 1511F-1 PN, order 6ES7 511-1FK02-0AB0, FW V2.9, plaintext port 102, Python 3.11.2 / OpenSSL 3.0.20:

```
attempt 1: CONNECTED  session_setup_ok=True  protocol_version=V2  protection_level=0
attempt 2: CONNECTED  session_setup_ok=True  protocol_version=V2  protection_level=0
```

Reproducible; fails on `master` and succeeds with this change, on the same CPU in the same state.

## Tests

Three tests in `TestTLSGroupSelection`, all parsing the real ClientHello emitted through a MemoryBIO handshake rather than asserting on the call:

1. `test_client_hello_offers_x25519` — the invariant.
2. `test_no_fallback_group_when_x25519_unavailable` — pins the specific regression.
3. `test_client_hello_offers_x25519_even_when_curve_api_cannot_name_it` — simulates OpenSSL 3.0 and reads the wire. This is the one that catches the bug on a modern build, where test 1 passes either way because `set_ecdh_curve("X25519")` succeeds.

Reverted the fix and re-ran: tests 2 and 3 fail, test 1 passes. Restored: all three pass. Full suite `1861 passed, 82 skipped`; ruff and mypy show no new findings against the `master` baseline (53 ruff, 164 mypy, unchanged).

## On my earlier reports in #861

Worth recontextualising the plaintext evidence I posted there. This CPU is a V2/TLS target, so a plaintext V1 `SetupSession` was never going to be accepted — the RST I reported is expected behaviour for that path, not a defect. My earlier conclusion that "port 102 is not TLS-wrapped on this box" came from `openssl s_client` being reset, which was the wrong instrument: TLS starts *inside* the established COTP connection after the InitSSL exchange, so a bare ClientHello as the first bytes on the socket proves nothing.

The cleanup and non-regression findings in #861 stand; the plaintext reset is a separate matter from the atomic-setup work.

I have the paired capture (CreateObject through SetupSession, both clients, same CPU) and can share it on request — happy to send it with addresses rewritten.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
