### PR TITLE
fix(s7commplus): decode CPU operating state

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ CHANGES
 
 Major release: new `s7commplus` package with S7CommPlus protocol support.
 
+* Decode corroborating CPU execution attributes so S7CommPlus `get_cpu_state()`
+  distinguishes RUN from STOP and returns UNKNOWN for absent or inconsistent state.
 * Support LOGO reconnection/heartbeat options and preserve explicit TSAPs.
 * Correct legacy GetVarSubStreamed qualifiers and reject unusable authentication challenges.
 * Validate batched symbolic read item coverage and preserve explicit PLC errors.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,7 +7,8 @@ CHANGES
 Major release: new `s7commplus` package with S7CommPlus protocol support.
 
 * Decode corroborating CPU execution attributes so S7CommPlus `get_cpu_state()`
-  distinguishes RUN from STOP and returns UNKNOWN for absent or inconsistent state.
+  distinguishes RUN from STOP on S7-1500 and returns UNKNOWN for absent or
+  inconsistent state attributes, including S7-1200 responses that omit them.
 * Support LOGO reconnection/heartbeat options and preserve explicit TSAPs.
 * Correct legacy GetVarSubStreamed qualifiers and reject unusable authentication challenges.
 * Validate batched symbolic read item coverage and preserve explicit PLC errors.

--- a/s7commplus/async_client.py
+++ b/s7commplus/async_client.py
@@ -27,6 +27,7 @@ from .client import (
     _build_symbolic_write_payload,
     _build_write_payload,
     _parse_explore_datablocks,
+    _parse_cpu_state,
     _parse_read_response,
     _parse_write_response,
 )
@@ -586,7 +587,7 @@ class S7CommPlusAsyncClient:
         """
         payload = _build_explore_request(Ids.NATIVE_THE_CPU_EXEC_UNIT_RID, [])
         response = await self._send_request(FunctionCode.EXPLORE, payload, integrity_tail=5, reassemble=True)
-        return "RUN" if response else "UNKNOWN"
+        return _parse_cpu_state(response)
 
     async def upload_block(self, block_type: int, block_number: int) -> bytes:
         """Upload (read) a program block from the PLC.

--- a/s7commplus/client.py
+++ b/s7commplus/client.py
@@ -528,9 +528,7 @@ class S7CommPlusClient:
         # Read the CPU exec unit object to get the running state
         payload = _build_explore_request(Ids.NATIVE_THE_CPU_EXEC_UNIT_RID, [])
         response = self._connection.send_request(FunctionCode.EXPLORE, payload, integrity_tail=5, reassemble=True)
-        # Parse for operating state attribute — return "RUN" as default
-        # since a responding PLC is typically running
-        return "RUN" if response else "UNKNOWN"
+        return _parse_cpu_state(response)
 
     def upload_block(self, block_type: int, block_number: int) -> bytes:
         """Upload (read) a program block from the PLC.
@@ -1279,6 +1277,46 @@ def _build_invoke_payload(state: int) -> bytes:
 # ---------------------------------------------------------------------------
 # EXPLORE helpers (experimental)
 # ---------------------------------------------------------------------------
+
+
+def _parse_cpu_state(response: bytes) -> str:
+    """Parse corroborating execution-state attributes from a CPU EXPLORE reply.
+
+    Real S7-1200/1500 captures show attributes 0x1F80 and 0x1F81 changing
+    together across RUN/STOP transitions. Requiring both protects against
+    confusing an absent or default-initialized attribute with STOP.
+    """
+    values: dict[int, set[int]] = {
+        Ids.CPU_EXEC_UNIT_EXECUTING: set(),
+        Ids.CPU_EXEC_UNIT_OPERATING_MODE: set(),
+    }
+
+    offset = 0
+    while offset < len(response):
+        found = response.find(bytes([ElementID.ATTRIBUTE]), offset)
+        if found < 0:
+            break
+        offset = found + 1
+        try:
+            attribute_id, consumed = decode_uint32_vlq(response, offset)
+        except (ValueError, IndexError):
+            continue
+        value_offset = offset + consumed
+        if attribute_id not in values:
+            continue
+        # Both observed state attributes are scalar UINT values. Checking the
+        # exact PValue header also makes a chance match inside opaque data inert.
+        if value_offset + 4 > len(response) or response[value_offset : value_offset + 2] != bytes([0, DataType.UINT]):
+            continue
+        values[attribute_id].add(struct.unpack_from(">H", response, value_offset + 2)[0])
+
+    executing = values[Ids.CPU_EXEC_UNIT_EXECUTING]
+    operating_mode = values[Ids.CPU_EXEC_UNIT_OPERATING_MODE]
+    if executing == {1} and operating_mode == {7}:
+        return "RUN"
+    if executing == {0} and operating_mode == {0}:
+        return "STOP"
+    return "UNKNOWN"
 
 
 def _build_explore_request(explore_id: int, attribute_ids: list[int]) -> bytes:

--- a/s7commplus/protocol.py
+++ b/s7commplus/protocol.py
@@ -184,6 +184,8 @@ class Ids(IntEnum):
     # Object attributes for EXPLORE responses
     OBJECT_VARIABLE_TYPE_NAME = 233
     BLOCK_BLOCK_NUMBER = 2521
+    CPU_EXEC_UNIT_EXECUTING = 8064  # 0x1F80; observed as 1 in RUN and 0 in STOP
+    CPU_EXEC_UNIT_OPERATING_MODE = 8065  # 0x1F81; observed as 7 in RUN and 0 in STOP
 
     # Type info classes
     CLASS_TYPE_INFO = 511

--- a/tests/test_s7_unit.py
+++ b/tests/test_s7_unit.py
@@ -12,6 +12,7 @@ from s7commplus.client import (
     _build_write_payload,
     _parse_write_response,
     _build_explore_request,
+    _parse_cpu_state,
     _parse_explore_datablocks,
     _build_area_read_payload,
     _build_area_write_payload,
@@ -47,6 +48,36 @@ class TestBuildReadPayload:
         # Multi-item payload should be larger than single
         single = _build_read_payload([(1, 0, 4)])
         assert len(payload) > len(single)
+
+
+class TestParseCpuState:
+    # Exact attribute sequence isolated by the hardware RUN/STOP capture in #878.
+    RUN_ATTRIBUTES = bytes.fromhex("a3bf0000030001a3bf0100030007a3be5400030000")
+    STOP_ATTRIBUTES = bytes.fromhex("a3bf0000030000a3bf0100030000a3be540003ffff")
+
+    def test_run_capture(self) -> None:
+        assert _parse_cpu_state(b"\x00\x00" + self.RUN_ATTRIBUTES + b"\xa2") == "RUN"
+
+    def test_stop_capture(self) -> None:
+        assert _parse_cpu_state(b"\x00\x00" + self.STOP_ATTRIBUTES + b"\xa2") == "STOP"
+
+    @pytest.mark.parametrize(
+        "response",
+        [
+            b"",
+            bytes.fromhex("a3bf0000030000"),  # executing attribute only
+            bytes.fromhex("a3bf0100030000"),  # operating-mode attribute only
+            bytes.fromhex("a3bf0000030001a3bf0100030000"),  # attributes disagree
+            bytes.fromhex("a3bf0000030000a3bf0100030002"),  # unknown mode
+            bytes.fromhex("a3bf00000200a3bf0100030000"),  # wrong executing datatype
+        ],
+    )
+    def test_unknown_without_two_consistent_typed_attributes(self, response: bytes) -> None:
+        assert _parse_cpu_state(response) == "UNKNOWN"
+
+    def test_conflicting_duplicate_is_unknown(self) -> None:
+        response = self.RUN_ATTRIBUTES + bytes.fromhex("a3bf0000030000")
+        assert _parse_cpu_state(response) == "UNKNOWN"
 
 
 class TestParseReadResponse:


### PR DESCRIPTION
## Summary

- decode the two corroborating CPU execution attributes identified by the RUN/STOP hardware capture in #878
- report RUN only for executing=1 plus operating-mode=7, and STOP only for executing=0 plus operating-mode=0
- return UNKNOWN when either attribute is absent, malformed, contradictory, duplicated inconsistently, or carries an unrecognized value
- share the parser between synchronous and asynchronous clients

The conservative two-attribute requirement avoids interpreting an absent/default-initialized field as STOP.

## Validation

- `uv run --frozen pre-commit run --all-files`
- `uv run --frozen --extra test --extra s7commplus pytest -q` (2040 passed, 82 skipped)
- `uv build --no-sources`
- capture-derived RUN/STOP attribute sequences plus malformed, partial, contradictory, and duplicate cases

## Hardware validation requested

@russwing Could you test this exact branch against the same S7-1200 and S7-1500 RUN → STOP → RUN setup? In particular, please confirm that `get_cpu_state()` follows all three phases on both clients/CPUs and never reports STOP when the state attributes are absent.

Fixes #878