### PR TITLE
fix(s7commplus): probe family-only session keys

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -100,6 +100,12 @@ S7-1200/1500 PLCs. The ``s7`` package (recommended) and its ``snap7`` alias
 continue to work unchanged for legacy S7-300/400 PLCs and S7-1200/1500 with
 PUT/GET enabled.
 
+Some older PLCs advertise only their SessionKey family instead of a complete
+public-key fingerprint. The synchronous ``Client`` tries the bounded set of
+bundled keys from that family on fresh sessions and caches the confirmed key
+for the PLC. Set ``allow_legacy_key_fallback=False`` on ``connect()`` when key
+probing must be disabled.
+
 **Other new features in 4.0:**
 
 * **Command-line interface** (``s7 read``, ``s7 write``, ``s7 info``)

--- a/s7commplus/client.py
+++ b/s7commplus/client.py
@@ -29,7 +29,7 @@ from .codec import (
     encode_pvalue_typed,
     parse_create_object_session_id,
 )
-from .connection import S7CommPlusConnection
+from .connection import FamilyOnlyFingerprintError, S7CommPlusConnection, SessionKeyCandidateRejectedError
 from .protocol import DataType, ElementID, FunctionCode, Ids, ObjectId, ProtocolVersion
 from .subscription import (
     SubscriptionItem,
@@ -41,6 +41,8 @@ from .subscription import (
 from .vlq import decode_uint32_vlq, decode_uint64_vlq, encode_uint32_vlq
 
 logger = logging.getLogger(__name__)
+
+_LEGACY_KEY_CACHE: dict[tuple[str, int], str] = {}
 
 _T = TypeVar("_T")
 DBWriteItem: TypeAlias = tuple[int, int, bytes, DataType]
@@ -126,6 +128,7 @@ class S7CommPlusClient:
         tls_key: Optional[str] = None,
         tls_ca: Optional[str] = None,
         password: Optional[str] = None,
+        allow_legacy_key_fallback: bool = True,
     ) -> None:
         """Connect to an S7-1200/1500 PLC using S7CommPlus.
 
@@ -139,6 +142,8 @@ class S7CommPlusClient:
             tls_key: Path to client private key (PEM)
             tls_ca: Path to CA certificate for PLC verification (PEM)
             password: PLC password for legitimation (V2+ with TLS)
+            allow_legacy_key_fallback: Try known same-family public keys on
+                fresh sessions when a legacy PLC omits its key id.
         """
         self._connect_params = {
             "host": host,
@@ -148,6 +153,7 @@ class S7CommPlusClient:
             "tls_key": tls_key,
             "tls_ca": tls_ca,
             "password": password,
+            "allow_legacy_key_fallback": allow_legacy_key_fallback,
         }
         self._open_connection()
 
@@ -156,6 +162,34 @@ class S7CommPlusClient:
         if self._connect_params is None:
             raise RuntimeError("Not connected")
         p = self._connect_params
+        cache_key = (p["host"], p["port"])
+        cached = _LEGACY_KEY_CACHE.get(cache_key) if p["allow_legacy_key_fallback"] else None
+        if cached is not None:
+            try:
+                self._open_connection_once(cached)
+                return
+            except SessionKeyCandidateRejectedError:
+                logger.info("Cached SessionKey candidate %s was rejected; trying remaining family keys", cached)
+                _LEGACY_KEY_CACHE.pop(cache_key, None)
+                from .session_auth.keys import parse_fingerprint
+
+                family, _ = parse_fingerprint(cached)
+                self._probe_family_keys(family, excluded={cached})
+                return
+
+        try:
+            self._open_connection_once()
+        except FamilyOnlyFingerprintError as exc:
+            if not p["allow_legacy_key_fallback"]:
+                raise S7ConnectionError(
+                    f"PLC advertised family-only key id {exc.family:02X}, but legacy key fallback is disabled"
+                ) from exc
+            self._probe_family_keys(exc.family)
+
+    def _open_connection_once(self, fingerprint: Optional[str] = None) -> None:
+        """Open exactly one transport/session, optionally with one key candidate."""
+        assert self._connect_params is not None
+        p = self._connect_params
         self._connection = S7CommPlusConnection(host=p["host"], port=p["port"])
         self._connection.connect(
             use_tls=p["use_tls"],
@@ -163,10 +197,34 @@ class S7CommPlusClient:
             tls_key=p["tls_key"],
             tls_ca=p["tls_ca"],
             password=p["password"] or "",
+            _session_key_fingerprint=fingerprint,
         )
         if p["password"] is not None and self._connection.tls_active and not self._connection.requires_substreamed:
             logger.info("Performing PLC legitimation (password authentication)")
             self._connection.authenticate(p["password"])
+
+    def _probe_family_keys(self, family: int, excluded: set[str] | None = None) -> None:
+        """Try each same-family key on a new connection and cache the winner."""
+        assert self._connect_params is not None
+        from .session_auth.keys import fingerprints_for_family
+
+        excluded = excluded or set()
+        candidates = [fingerprint for fingerprint in fingerprints_for_family(family) if fingerprint not in excluded]
+        if not candidates:
+            raise S7ConnectionError(f"No bundled SessionKey candidates for public-key family {family:02X}")
+
+        for attempt, fingerprint in enumerate(candidates, 1):
+            logger.info("Trying SessionKey candidate %s (%d/%d) on a fresh session", fingerprint, attempt, len(candidates))
+            try:
+                self._open_connection_once(fingerprint)
+            except SessionKeyCandidateRejectedError:
+                continue
+            _LEGACY_KEY_CACHE[(self._connect_params["host"], self._connect_params["port"])] = fingerprint
+            logger.info("Confirmed and cached SessionKey candidate %s", fingerprint)
+            return
+        raise S7ConnectionError(
+            f"PLC rejected all {len(candidates)} bundled SessionKey candidates for public-key family {family:02X}"
+        )
 
     def _reconnect(self) -> None:
         """Tear down and re-establish the connection with the same parameters.

--- a/s7commplus/connection.py
+++ b/s7commplus/connection.py
@@ -50,6 +50,7 @@ from types import TracebackType
 from typing import Any, Optional, Type
 
 from snap7.connection import ISOTCPConnection
+from snap7.error import S7ConnectionError
 
 from .codec import decode_header, encode_header, encode_object_qualifier, parse_create_object_attributes
 from .legitimation import (
@@ -78,6 +79,25 @@ from .protocol import (
 from .vlq import decode_uint32_vlq, decode_uint64_vlq, encode_uint32_vlq, encode_uint64_vlq
 
 logger = logging.getLogger(__name__)
+
+
+class FamilyOnlyFingerprintError(S7ConnectionError):
+    """A legacy PLC advertised only a public-key family identifier."""
+
+    def __init__(self, family: int) -> None:
+        self.family = family
+        super().__init__(
+            f"PLC advertised public-key family {family:02X} without a key id; "
+            "connect through Client with allow_legacy_key_fallback enabled to probe known same-family keys"
+        )
+
+
+class SessionKeyCandidateRejectedError(S7ConnectionError):
+    """The PLC rejected setup with one explicitly selected family key."""
+
+
+class SessionKeyAuthenticationDependencyError(S7ConnectionError):
+    """Optional dependencies required for SessionKey authentication are absent."""
 
 
 def _log_create_object_return_value(return_value: int, tls_active: bool) -> None:
@@ -466,6 +486,7 @@ class S7CommPlusConnection:
         self._session_key: Optional[bytes] = None
         self._session_auth_public_key: bytes = b""
         self._session_auth_family: int = 0
+        self._session_key_fingerprint_override: Optional[str] = None
 
         # V2+ IntegrityId tracking
         self._integrity_id_read: int = 0
@@ -550,6 +571,8 @@ class S7CommPlusConnection:
         tls_key: Optional[str] = None,
         tls_ca: Optional[str] = None,
         password: str = "",
+        *,
+        _session_key_fingerprint: Optional[str] = None,
     ) -> None:
         """Establish S7CommPlus connection.
 
@@ -569,6 +592,7 @@ class S7CommPlusConnection:
             tls_ca: Path to CA certificate for PLC verification (PEM)
         """
         self._connect_password = password
+        self._session_key_fingerprint_override = _session_key_fingerprint
         try:
             # Step 1: COTP connection (same TSAP for all S7CommPlus versions)
             self._iso_conn.connect(timeout)
@@ -584,6 +608,26 @@ class S7CommPlusConnection:
             # CreateObject always uses V1 framing
             self._create_session()
 
+            if self._public_key_fingerprint is not None and ":" not in self._public_key_fingerprint:
+                from .session_auth.keys import parse_family_identifier, parse_fingerprint
+
+                try:
+                    family = parse_family_identifier(self._public_key_fingerprint)
+                except ValueError as exc:
+                    raise S7ConnectionError(str(exc)) from exc
+                if self._session_key_fingerprint_override is None:
+                    raise FamilyOnlyFingerprintError(family)
+                override_family, _ = parse_fingerprint(self._session_key_fingerprint_override)
+                if override_family != family:
+                    raise S7ConnectionError(
+                        f"SessionKey candidate {self._session_key_fingerprint_override} does not belong to "
+                        f"PLC family {family.value:02X}"
+                    )
+            elif self._public_key_fingerprint is not None:
+                # A complete PLC fingerprint always wins over a cached/provided
+                # family-only fallback candidate.
+                self._session_key_fingerprint_override = None
+
             # After CreateObject (V1), data PDUs over TLS use ProtocolVersion V2 (matches C# driver)
             if self._tls_active:
                 self._protocol_version = ProtocolVersion.V2
@@ -592,15 +636,24 @@ class S7CommPlusConnection:
             # Transport establishment and CreateObject alone do not make the
             # public client usable.
             if self._server_session_version is None:
-                from snap7.error import S7ConnectionError
-
                 raise S7ConnectionError(
                     "PLC did not provide a usable ServerSessionVersion attribute; S7CommPlus session setup cannot continue"
                 )
-            self._session_setup_ok = self._setup_session()
+            try:
+                self._session_setup_ok = self._setup_session()
+            except SessionKeyAuthenticationDependencyError:
+                raise
+            except Exception as exc:
+                if self._session_key_fingerprint_override is not None:
+                    raise SessionKeyCandidateRejectedError(
+                        f"Session failed while trying SessionKey candidate {self._session_key_fingerprint_override}"
+                    ) from exc
+                raise
             if not self._session_setup_ok:
-                from snap7.error import S7ConnectionError
-
+                if self._session_key_fingerprint_override is not None:
+                    raise SessionKeyCandidateRejectedError(
+                        f"PLC rejected SessionKey candidate {self._session_key_fingerprint_override}"
+                    )
                 raise S7ConnectionError("S7CommPlus session setup was rejected by the PLC")
             self._session_ready = True
 
@@ -612,8 +665,6 @@ class S7CommPlusConnection:
                     )
             elif self._protocol_version == ProtocolVersion.V2:
                 if not self._tls_active:
-                    from snap7.error import S7ConnectionError
-
                     raise S7ConnectionError("PLC reports V2 protocol but TLS is not active. V2 requires TLS. Use use_tls=True.")
                 # Enable IntegrityId tracking for V2+
                 self._with_integrity_id = True
@@ -1399,11 +1450,12 @@ class S7CommPlusConnection:
         try:
             from .session_auth.keys import get_public_key, parse_fingerprint
 
-            family, _key_id = parse_fingerprint(self._public_key_fingerprint)
+            fingerprint = self._session_key_fingerprint_override or self._public_key_fingerprint
+            family, _key_id = parse_fingerprint(fingerprint)
 
-            public_key = get_public_key(self._public_key_fingerprint)
+            public_key = get_public_key(fingerprint)
             if public_key is None:
-                logger.info(f"SessionKey auth: no matching public key for {self._public_key_fingerprint}")
+                logger.info(f"SessionKey auth: no matching public key for {fingerprint}")
                 return None
 
             from .session_auth.legacy_auth import authenticate_real_plc
@@ -1411,13 +1463,11 @@ class S7CommPlusConnection:
             blob, session_key = authenticate_real_plc(self._session_challenge, public_key, family)
             self._session_auth_public_key = public_key
             self._session_auth_family = family
-            logger.info(f"SessionKey auth blob generated ({len(blob)} bytes)")
+            logger.info(f"SessionKey auth blob generated with key {fingerprint} ({len(blob)} bytes)")
             return blob, session_key
 
         except ImportError as e:
-            from snap7.error import S7ConnectionError
-
-            raise S7ConnectionError(
+            raise SessionKeyAuthenticationDependencyError(
                 "Cannot load S7CommPlus SessionKey authentication dependencies. "
                 "Install them with python -m pip install 'python-snap7[s7commplus]' "
                 "(or python -m pip install -e '.[s7commplus]' for a source checkout). "

--- a/s7commplus/session_auth/__init__.py
+++ b/s7commplus/session_auth/__init__.py
@@ -43,7 +43,9 @@ from .keys import (
     PUBLIC_KEY_LENGTH_REAL_PLC,
     PUBLIC_KEY_LENGTH_PLCSIM,
     UnknownPublicKeyError,
+    fingerprints_for_family,
     get_public_key,
+    parse_family_identifier,
     parse_fingerprint,
 )
 from .utils import KEY_ID_LENGTH, derive_key_id
@@ -65,12 +67,14 @@ __all__ = [
     "derive_legitimation_challenge_key",
     "derive_seed_encryption_key_and_iv",
     "generate_lookup_table",
+    "fingerprints_for_family",
     "get_blob_length",
     "get_public_key",
     "get_public_key_flags",
     "get_symmetric_key_flags",
     "hash_block",
     "lut1",
+    "parse_family_identifier",
     "parse_fingerprint",
     "write_metadata",
 ]

--- a/s7commplus/session_auth/keys.py
+++ b/s7commplus/session_auth/keys.py
@@ -163,6 +163,26 @@ def parse_fingerprint(fingerprint: str) -> tuple[KeyFamily, str]:
     return family, key_id
 
 
+def parse_family_identifier(identifier: str) -> KeyFamily:
+    """Parse a two-hex-digit family-only identifier advertised by older PLCs."""
+    if len(identifier) != 2:
+        raise ValueError(f"Invalid public-key family identifier: {identifier!r}")
+    try:
+        family_value = int(identifier, 16)
+    except ValueError as exc:
+        raise ValueError(f"Invalid public-key family identifier: {identifier!r}") from exc
+    try:
+        return KeyFamily(family_value)
+    except ValueError as exc:
+        raise ValueError(f"Unsupported public-key family 0x{family_value:02X}") from exc
+
+
+def fingerprints_for_family(family: KeyFamily | int) -> tuple[str, ...]:
+    """Return the bounded, deterministic fingerprint candidates for one family."""
+    resolved = KeyFamily(family)
+    return tuple(f"{resolved.value:02X}:{key_id}" for candidate_family, key_id in _PUBLIC_KEYS if candidate_family == resolved)
+
+
 def get_public_key(fingerprint: str) -> bytes:
     """Look up the public-key bytes for a given fingerprint.
 

--- a/tests/test_s7_family_key_fallback.py
+++ b/tests/test_s7_family_key_fallback.py
@@ -1,0 +1,212 @@
+"""Fresh-session orchestration for legacy family-only key identifiers."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from snap7.error import S7ConnectionError
+from s7commplus.client import S7CommPlusClient, _LEGACY_KEY_CACHE
+from s7commplus.connection import FamilyOnlyFingerprintError, S7CommPlusConnection, SessionKeyCandidateRejectedError
+from s7commplus.protocol import DataType, ProtocolVersion
+from s7commplus.session_auth import KeyFamily, get_public_key
+
+
+@pytest.fixture(autouse=True)
+def clear_key_cache() -> None:
+    _LEGACY_KEY_CACHE.clear()
+
+
+def _connection_factory(connect_effects):  # type: ignore[no-untyped-def]
+    instances: list[MagicMock] = []
+
+    def factory(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        connection = MagicMock(tls_active=False, requires_substreamed=False)
+        connection.connect.side_effect = connect_effects
+        instances.append(connection)
+        return connection
+
+    return factory, instances
+
+
+def test_complete_fingerprint_path_does_not_probe() -> None:
+    factory, instances = _connection_factory(None)
+    with patch("s7commplus.client.S7CommPlusConnection", side_effect=factory):
+        S7CommPlusClient().connect("plc")
+
+    assert len(instances) == 1
+    assert instances[0].connect.call_args.kwargs["_session_key_fingerprint"] is None
+
+
+def test_family_only_identifier_tries_same_family_candidates_on_fresh_sessions() -> None:
+    attempts: list[str | None] = []
+
+    def connect_effect(**kwargs):  # type: ignore[no-untyped-def]
+        fingerprint = kwargs["_session_key_fingerprint"]
+        attempts.append(fingerprint)
+        if fingerprint is None:
+            raise FamilyOnlyFingerprintError(KeyFamily.S7_1200)
+        if fingerprint != "01:GOOD":
+            raise SessionKeyCandidateRejectedError("rejected")
+
+    factory, instances = _connection_factory(connect_effect)
+    with (
+        patch("s7commplus.client.S7CommPlusConnection", side_effect=factory),
+        patch("s7commplus.session_auth.keys.fingerprints_for_family", return_value=("01:BAD", "01:GOOD")),
+    ):
+        S7CommPlusClient().connect("plc")
+
+    assert attempts == [None, "01:BAD", "01:GOOD"]
+    assert len(instances) == 3
+    assert _LEGACY_KEY_CACHE[("plc", 102)] == "01:GOOD"
+
+
+def test_cached_success_is_used_on_the_first_session() -> None:
+    _LEGACY_KEY_CACHE[("plc", 102)] = "01:CACHED"
+    attempts: list[str | None] = []
+
+    def connect_effect(**kwargs):  # type: ignore[no-untyped-def]
+        attempts.append(kwargs["_session_key_fingerprint"])
+
+    factory, instances = _connection_factory(connect_effect)
+    with patch("s7commplus.client.S7CommPlusConnection", side_effect=factory):
+        S7CommPlusClient().connect("plc")
+
+    assert attempts == ["01:CACHED"]
+    assert len(instances) == 1
+
+
+def test_disabled_fallback_fails_without_probing() -> None:
+    def connect_effect(**_kwargs):  # type: ignore[no-untyped-def]
+        raise FamilyOnlyFingerprintError(KeyFamily.S7_1500)
+
+    factory, instances = _connection_factory(connect_effect)
+    with (
+        patch("s7commplus.client.S7CommPlusConnection", side_effect=factory),
+        patch("s7commplus.session_auth.keys.fingerprints_for_family") as candidates,
+        pytest.raises(S7ConnectionError, match="fallback is disabled"),
+    ):
+        S7CommPlusClient().connect("plc", allow_legacy_key_fallback=False)
+
+    assert len(instances) == 1
+    candidates.assert_not_called()
+
+
+def test_exhausted_candidates_fail_clearly_and_each_uses_a_fresh_session() -> None:
+    def connect_effect(**kwargs):  # type: ignore[no-untyped-def]
+        if kwargs["_session_key_fingerprint"] is None:
+            raise FamilyOnlyFingerprintError(KeyFamily.S7_1200)
+        raise SessionKeyCandidateRejectedError("rejected")
+
+    factory, instances = _connection_factory(connect_effect)
+    with (
+        patch("s7commplus.client.S7CommPlusConnection", side_effect=factory),
+        patch("s7commplus.session_auth.keys.fingerprints_for_family", return_value=("01:A", "01:B")),
+        pytest.raises(S7ConnectionError, match="rejected all 2"),
+    ):
+        S7CommPlusClient().connect("plc")
+
+    assert len(instances) == 3
+    assert all(connection.connect.call_count == 1 for connection in instances)
+
+
+def test_low_level_connection_reports_family_before_setup() -> None:
+    connection = S7CommPlusConnection("plc")
+    connection._iso_conn.connect = MagicMock()
+    connection._iso_conn.disconnect = MagicMock()
+    connection._init_ssl = MagicMock()
+
+    def create_session() -> None:
+        connection._protocol_version = ProtocolVersion.V1
+        connection._session_id = 7
+        connection._server_session_version = bytes([0, DataType.UDINT, 1])
+        connection._public_key_fingerprint = "01"
+
+    connection._create_session = MagicMock(side_effect=create_session)
+    connection._setup_session = MagicMock(return_value=True)
+
+    with pytest.raises(FamilyOnlyFingerprintError) as error:
+        connection.connect()
+
+    assert error.value.family is KeyFamily.S7_1200
+    connection._setup_session.assert_not_called()
+
+
+def test_low_level_connection_rejects_unknown_family_clearly() -> None:
+    connection = S7CommPlusConnection("plc")
+    connection._iso_conn.connect = MagicMock()
+    connection._iso_conn.disconnect = MagicMock()
+    connection._init_ssl = MagicMock()
+
+    def create_session() -> None:
+        connection._protocol_version = ProtocolVersion.V1
+        connection._session_id = 7
+        connection._server_session_version = bytes([0, DataType.UDINT, 1])
+        connection._public_key_fingerprint = "02"
+
+    connection._create_session = MagicMock(side_effect=create_session)
+    connection._setup_session = MagicMock(return_value=True)
+
+    with pytest.raises(S7ConnectionError, match="Unsupported public-key family 0x02"):
+        connection.connect()
+
+    connection._setup_session.assert_not_called()
+
+
+def test_explicit_candidate_selects_its_public_key() -> None:
+    connection = S7CommPlusConnection("plc")
+    connection._protocol_version = ProtocolVersion.V1
+    connection._public_key_fingerprint = "01"
+    connection._session_key_fingerprint_override = "01:BD426B091F08731A"
+    connection._session_challenge = bytes(range(20))
+    generated = (bytes(180), bytes(24))
+
+    with patch("s7commplus.session_auth.legacy_auth.authenticate_real_plc", return_value=generated) as authenticate:
+        assert connection._try_session_key_auth() == generated
+
+    assert authenticate.call_args.args[1] == get_public_key("01:BD426B091F08731A")
+    assert authenticate.call_args.args[2] is KeyFamily.S7_1200
+
+
+def test_setup_disconnect_rejects_candidate_and_cleans_session() -> None:
+    connection = S7CommPlusConnection("plc")
+    connection._iso_conn.connect = MagicMock()
+    connection._iso_conn.disconnect = MagicMock()
+    connection._init_ssl = MagicMock()
+
+    def create_session() -> None:
+        connection._protocol_version = ProtocolVersion.V1
+        connection._session_id = 7
+        connection._server_session_version = bytes([0, DataType.UDINT, 1])
+        connection._public_key_fingerprint = "01"
+
+    connection._create_session = MagicMock(side_effect=create_session)
+    connection._setup_session = MagicMock(side_effect=OSError("reset by PLC"))
+
+    with pytest.raises(SessionKeyCandidateRejectedError, match="BD426B091F08731A") as error:
+        connection.connect(_session_key_fingerprint="01:BD426B091F08731A")
+
+    assert isinstance(error.value.__cause__, OSError)
+    assert not connection.connected
+    assert connection.session_id == 0
+
+
+def test_complete_fingerprint_ignores_fallback_override() -> None:
+    connection = S7CommPlusConnection("plc")
+    connection._iso_conn.connect = MagicMock()
+    connection._iso_conn.disconnect = MagicMock()
+    connection._init_ssl = MagicMock()
+
+    def create_session() -> None:
+        connection._protocol_version = ProtocolVersion.V1
+        connection._session_id = 7
+        connection._server_session_version = bytes([0, DataType.UDINT, 1])
+        connection._public_key_fingerprint = "01:BD426B091F08731A"
+
+    connection._create_session = MagicMock(side_effect=create_session)
+    connection._setup_session = MagicMock(return_value=True)
+    connection._get_effective_protection_level = MagicMock(return_value=None)
+
+    connection.connect(_session_key_fingerprint="01:A95850575DF7B3DE")
+
+    assert connection.connected
+    assert connection._session_key_fingerprint_override is None

--- a/tests/test_session_auth.py
+++ b/tests/test_session_auth.py
@@ -9,7 +9,9 @@ from s7commplus.session_auth import (
     PUBLIC_KEY_LENGTH_REAL_PLC,
     KeyFamily,
     UnknownPublicKeyError,
+    fingerprints_for_family,
     get_public_key,
+    parse_family_identifier,
     parse_fingerprint,
 )
 from s7commplus.session_auth.keys import _PUBLIC_KEYS
@@ -52,6 +54,29 @@ class TestParseFingerprint:
         assert len(bad) == 19
         with pytest.raises(ValueError, match="Invalid key id"):
             parse_fingerprint(bad)
+
+
+class TestFamilyOnlyIdentifiers:
+    @pytest.mark.parametrize(
+        ("identifier", "family"),
+        [("00", KeyFamily.S7_1500), ("01", KeyFamily.S7_1200), ("03", KeyFamily.PLCSIM)],
+    )
+    def test_supported_family(self, identifier: str, family: KeyFamily) -> None:
+        assert parse_family_identifier(identifier) is family
+
+    @pytest.mark.parametrize("identifier", ["", "0", "000", "zz", "02"])
+    def test_invalid_or_unknown_family(self, identifier: str) -> None:
+        with pytest.raises(ValueError, match="family"):
+            parse_family_identifier(identifier)
+
+    def test_candidates_are_bounded_to_reported_family(self) -> None:
+        candidates = fingerprints_for_family(KeyFamily.S7_1200)
+        assert candidates == (
+            "01:A95850575DF7B3DE",
+            "01:AC9BE476CB324E65",
+            "01:BD426B091F08731A",
+        )
+        assert all(parse_fingerprint(candidate)[0] is KeyFamily.S7_1200 for candidate in candidates)
 
 
 class TestGetPublicKey:


### PR DESCRIPTION
Closes gijzelaerr/s7commplus#3

Some legacy PLCs advertise only a SessionKey family such as 00, 01, or 03. This adds a bounded fallback that:

- keeps complete-fingerprint selection unchanged
- enumerates only bundled keys from the reported family
- tries every candidate on a fresh transport/session
- treats setup rejection or setup-time disconnect as a rejected candidate
- caches a confirmed key by PLC host and port
- supports allow_legacy_key_fallback=False for deterministic no-probing operation
- keeps missing authentication dependencies as an immediate hard failure
- logs key identifiers, never key material

Validation:
- uv run pre-commit run --all-files
- uv run pytest -q --tb=short (2092 passed, 82 skipped)
- uv build --quiet